### PR TITLE
Fixes last migration - removes :force=>true and MyISAM

### DIFF
--- a/db/migrate/20140416153948_remove_unused_tables_and_add_used_ones.rb
+++ b/db/migrate/20140416153948_remove_unused_tables_and_add_used_ones.rb
@@ -14,52 +14,72 @@ class RemoveUnusedTablesAndAddUsedOnes < ActiveRecord::Migration
     drop_table :context
     drop_table :node_images
 
-    create_table "node_access", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
-      t.integer "nid",                       :default => 0,  :null => false
-      t.integer "gid",                       :default => 0,  :null => false
-      t.string  "realm",                     :default => "", :null => false
-      t.integer "grant_view",   :limit => 1, :default => 0,  :null => false
-      t.integer "grant_update", :limit => 1, :default => 0,  :null => false
-      t.integer "grant_delete", :limit => 1, :default => 0,  :null => false
+    unless table_exists? "node_access"
+      create_table "node_access", :id => false do |t|
+        t.integer "nid",                       :default => 0,  :null => false
+        t.integer "gid",                       :default => 0,  :null => false
+        t.string  "realm",                     :default => "", :null => false
+        t.integer "grant_view",   :limit => 1, :default => 0,  :null => false
+        t.integer "grant_update", :limit => 1, :default => 0,  :null => false
+        t.integer "grant_delete", :limit => 1, :default => 0,  :null => false
+      end
     end
 
-    create_table "profile_fields", :primary_key => "fid", :options=>'ENGINE=MyISAM', :force => true do |t|
-      t.string  "title"
-      t.string  "name",         :limit => 128, :default => "", :null => false
-      t.text    "explanation"
-      t.string  "category"
-      t.string  "page"
-      t.string  "type",         :limit => 128
-      t.integer "weight",       :limit => 1,   :default => 0,  :null => false
-      t.integer "required",     :limit => 1,   :default => 0,  :null => false
-      t.integer "register",     :limit => 1,   :default => 0,  :null => false
-      t.integer "visibility",   :limit => 1,   :default => 0,  :null => false
-      t.integer "autocomplete", :limit => 1,   :default => 0,  :null => false
-      t.text    "options"
+    unless table_exists? "profile_fields"
+      create_table "profile_fields", :primary_key => "fid" do |t|
+        t.string  "title"
+        t.string  "name",         :limit => 128, :default => "", :null => false
+        t.text    "explanation"
+        t.string  "category"
+        t.string  "page"
+        t.string  "type",         :limit => 128
+        t.integer "weight",       :limit => 1,   :default => 0,  :null => false
+        t.integer "required",     :limit => 1,   :default => 0,  :null => false
+        t.integer "register",     :limit => 1,   :default => 0,  :null => false
+        t.integer "visibility",   :limit => 1,   :default => 0,  :null => false
+        t.integer "autocomplete", :limit => 1,   :default => 0,  :null => false
+        t.text    "options"
+      end
     end
 
-    add_index "profile_fields", ["category"], :name => "category"
-    add_index "profile_fields", ["name"], :name => "name"
-
-    create_table "profile_values", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
-      t.integer "fid",   :default => 0, :null => false
-      t.integer "uid",   :default => 0, :null => false
-      t.text    "value"
+    unless index_exists? "profile_fields", :category, name: "category"
+      add_index "profile_fields", ["category"], :name => "category"
     end
 
-    add_index "profile_values", ["fid"], :name => "fid"
-
-    create_table "upload", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
-      t.integer "fid",                      :default => 0,  :null => false
-      t.integer "nid",                      :default => 0,  :null => false
-      t.integer "vid",                      :default => 0,  :null => false
-      t.string  "description",              :default => "", :null => false
-      t.integer "list",        :limit => 1, :default => 0,  :null => false
-      t.integer "weight",      :limit => 1, :default => 0,  :null => false
+    unless index_exists? "profile_fields", :name, name: "name"
+      add_index "profile_fields", ["name"], :name => "name"
     end
 
-    add_index "upload", ["fid"], :name => "fid"
-    add_index "upload", ["nid"], :name => "nid"
+    unless table_exists? "profile_values"
+      create_table "profile_values", :id => false do |t|
+        t.integer "fid",   :default => 0, :null => false
+        t.integer "uid",   :default => 0, :null => false
+        t.text    "value"
+      end
+    end
+
+    unless index_exists? "profile_values", :fid, name: "fid"
+      add_index "profile_values", ["fid"], :name => "fid"
+    end
+
+    unless table_exists? "upload"
+      create_table "upload", :id => false do |t|
+        t.integer "fid",                      :default => 0,  :null => false
+        t.integer "nid",                      :default => 0,  :null => false
+        t.integer "vid",                      :default => 0,  :null => false
+        t.string  "description",              :default => "", :null => false
+        t.integer "list",        :limit => 1, :default => 0,  :null => false
+        t.integer "weight",      :limit => 1, :default => 0,  :null => false
+      end
+    end
+
+    unless index_exists? "upload", :fid, name: "fid"
+      add_index "upload", ["fid"], :name => "fid"
+    end
+
+    unless index_exists? "upload", :nid, name: "nid"
+      add_index "upload", ["nid"], :name => "nid"
+    end
     #
     # drop old tables
     drop_table :access if table_exists? :access
@@ -225,13 +245,13 @@ class RemoveUnusedTablesAndAddUsedOnes < ActiveRecord::Migration
     drop_table :profile_fields
     drop_table :profile_values
     drop_table :uploads
-    create_table "content_field_map", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_field_map", :id => false, :options=>'ENGINE=MyISAM' do |t|
       t.integer "vid",                                            :default => 0, :null => false
       t.integer "nid",                                            :default => 0, :null => false
       t.text    "field_map_openlayers_wkt", :limit => 2147483647
       t.integer "delta",                                          :default => 0, :null => false
     end
-    create_table "content_group", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_group", :id => false, :options=>'ENGINE=MyISAM' do |t|
       t.string  "group_type", :limit => 32,       :default => "standard", :null => false
       t.string  "type_name",  :limit => 32,       :default => "",         :null => false
       t.string  "group_name", :limit => 32,       :default => "",         :null => false
@@ -239,13 +259,13 @@ class RemoveUnusedTablesAndAddUsedOnes < ActiveRecord::Migration
       t.text    "settings",   :limit => 16777215,                         :null => false
       t.integer "weight",                         :default => 0,          :null => false
     end
-    create_table "content_group_fields", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_group_fields", :id => false, :options=>'ENGINE=MyISAM' do |t|
       t.string "type_name",  :limit => 32, :default => "", :null => false
       t.string "group_name", :limit => 32, :default => "", :null => false
       t.string "field_name", :limit => 32, :default => "", :null => false
     end
 
-    create_table "content_node_field", :primary_key => "field_name", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_node_field", :primary_key => "field_name", :options=>'ENGINE=MyISAM' do |t|
       t.string  "type",            :limit => 127,      :default => "", :null => false
       t.text    "global_settings", :limit => 16777215,                 :null => false
       t.integer "required",        :limit => 1,        :default => 0,  :null => false
@@ -257,7 +277,7 @@ class RemoveUnusedTablesAndAddUsedOnes < ActiveRecord::Migration
       t.integer "locked",          :limit => 1,        :default => 0,  :null => false
     end
 
-    create_table "content_node_field_instance", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_node_field_instance", :id => false, :options=>'ENGINE=MyISAM' do |t|
       t.string  "field_name",       :limit => 32,       :default => "", :null => false
       t.string  "type_name",        :limit => 32,       :default => "", :null => false
       t.integer "weight",                               :default => 0,  :null => false
@@ -269,20 +289,20 @@ class RemoveUnusedTablesAndAddUsedOnes < ActiveRecord::Migration
       t.string  "widget_module",    :limit => 127,      :default => "", :null => false
       t.integer "widget_active",    :limit => 1,        :default => 0,  :null => false
     end
-    create_table "content_type_note", :primary_key => "vid", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_type_note", :primary_key => "vid", :options=>'ENGINE=MyISAM' do |t|
       t.integer "nid", :default => 0, :null => false
     end
 
     add_index "content_type_note", ["nid"], :name => "nid"
 
-    create_table "content_type_page", :primary_key => "vid", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_type_page", :primary_key => "vid", :options=>'ENGINE=MyISAM' do |t|
       t.integer "nid",             :default => 0, :null => false
       t.integer "field_toc_value"
     end
 
     add_index "content_type_page", ["nid"], :name => "nid"
 
-    create_table "content_type_place", :primary_key => "vid", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_type_place", :primary_key => "vid", :options=>'ENGINE=MyISAM' do |t|
       t.integer "nid",                                          :default => 0, :null => false
       t.integer "field_host_logo_fid"
       t.integer "field_host_logo_list",   :limit => 1
@@ -293,26 +313,26 @@ class RemoveUnusedTablesAndAddUsedOnes < ActiveRecord::Migration
 
     add_index "content_type_place", ["nid"], :name => "nid"
 
-    create_table "content_type_report", :primary_key => "vid", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_type_report", :primary_key => "vid", :options=>'ENGINE=MyISAM' do |t|
       t.integer "nid", :default => 0, :null => false
     end
 
     add_index "content_type_report", ["nid"], :name => "nid"
 
-    create_table "content_type_tool", :primary_key => "vid", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "content_type_tool", :primary_key => "vid", :options=>'ENGINE=MyISAM' do |t|
       t.integer "nid", :default => 0, :null => false
     end
 
     add_index "content_type_tool", ["nid"], :name => "nid"
 
-    create_table "context", :primary_key => "name", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "context", :primary_key => "name", :options=>'ENGINE=MyISAM' do |t|
       t.string  "description",    :default => "", :null => false
       t.string  "tag",            :default => "", :null => false
       t.text    "conditions"
       t.text    "reactions"
       t.integer "condition_mode", :default => 0
     end
-    create_table "node_images", :options=>'ENGINE=MyISAM', :force => true do |t|
+    create_table "node_images", :options=>'ENGINE=MyISAM' do |t|
       t.integer "nid",                      :default => 0,  :null => false
       t.integer "uid",                      :default => 0,  :null => false
       t.string  "filename",                 :default => "", :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,7 +32,6 @@ ActiveRecord::Schema.define(:version => 20140416153948) do
   add_index "comments", ["nid"], :name => "nid"
   add_index "comments", ["pid"], :name => "pid"
   add_index "comments", ["status"], :name => "status"
-  add_index "comments", ["timestamp"], :name => "timestamp"
 
   create_table "community_tags", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
     t.integer "tid",  :default => 0, :null => false
@@ -178,7 +177,7 @@ ActiveRecord::Schema.define(:version => 20140416153948) do
   add_index "node", ["uid"], :name => "uid"
   add_index "node", ["vid"], :name => "vid"
 
-  create_table "node_access", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+  create_table "node_access", :id => false, :force => true do |t|
     t.integer "nid",                       :default => 0,  :null => false
     t.integer "gid",                       :default => 0,  :null => false
     t.string  "realm",                     :default => "", :null => false
@@ -205,7 +204,6 @@ ActiveRecord::Schema.define(:version => 20140416153948) do
   end
 
   add_index "node_revisions", ["nid"], :name => "nid"
-  add_index "node_revisions", ["timestamp"], :name => "timestamp"
   add_index "node_revisions", ["uid"], :name => "uid"
 
   create_table "node_selections", :id => false, :force => true do |t|
@@ -217,7 +215,7 @@ ActiveRecord::Schema.define(:version => 20140416153948) do
 
   add_index "node_selections", ["user_id", "nid"], :name => "index_node_selections_on_user_id_and_nid"
 
-  create_table "profile_fields", :primary_key => "fid", :options=>'ENGINE=MyISAM', :force => true do |t|
+  create_table "profile_fields", :primary_key => "fid", :force => true do |t|
     t.string  "title"
     t.string  "name",         :limit => 128, :default => "", :null => false
     t.text    "explanation"
@@ -235,7 +233,7 @@ ActiveRecord::Schema.define(:version => 20140416153948) do
   add_index "profile_fields", ["category"], :name => "category"
   add_index "profile_fields", ["name"], :name => "name"
 
-  create_table "profile_values", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+  create_table "profile_values", :id => false, :force => true do |t|
     t.integer "fid",   :default => 0, :null => false
     t.integer "uid",   :default => 0, :null => false
     t.text    "value"
@@ -310,7 +308,7 @@ ActiveRecord::Schema.define(:version => 20140416153948) do
   add_index "term_node", ["nid"], :name => "nid"
   add_index "term_node", ["vid"], :name => "vid"
 
-  create_table "upload", :id => false, :options=>'ENGINE=MyISAM', :force => true do |t|
+  create_table "upload", :id => false, :force => true do |t|
     t.integer "fid",                      :default => 0,  :null => false
     t.integer "nid",                      :default => 0,  :null => false
     t.integer "vid",                      :default => 0,  :null => false


### PR DESCRIPTION
As per the further discussion under issue #34 this PR removes the `:force=>true` and wraps table creation statements into `unless table_exists?` statements. Further, the table it creates no longer use the MyISAM engine.
