### PR TITLE
Patches consolidate_tags migration to work without DrupalNodeTag model

### DIFF
--- a/app/models/drupal_node_tag.rb
+++ b/app/models/drupal_node_tag.rb
@@ -1,3 +1,0 @@
-class DrupalNode < ActiveRecord::Base
-  # stub, to make migrations run. Boo.
-end

--- a/app/models/drupal_tag.rb
+++ b/app/models/drupal_tag.rb
@@ -2,7 +2,6 @@ class DrupalTag < ActiveRecord::Base
   attr_accessible :vid, :name, :description, :weight
   self.table_name = 'term_data'
   self.primary_key = 'tid'
-  has_many :drupal_node_tag, :foreign_key => 'tid'
   #has_many :drupal_users, :through => :drupal_node_tag, :foreign_key => 'uid'
 
   has_many :tag_selection, :foreign_key => 'tid'


### PR DESCRIPTION
I extracted this from working on the url_alias table - it makes the migrations work without the DrupalNodeTag model present which should make things a bit easier. 

Tested it out on the test server and it whooshes through the migrations without errors :).
