### PR TITLE
Notification email fixes & callout tests, test overhaul

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -26,4 +26,5 @@ class CommentMailer < ActionMailer::Base
     @comment = comment
     mail(:to => user.email, :subject => "You were mentioned in a comment.").deliver
   end
+
 end

--- a/app/models/drupal_comment.rb
+++ b/app/models/drupal_comment.rb
@@ -61,7 +61,7 @@ class DrupalComment < ActiveRecord::Base
 
   def mentioned_users
     usernames = self.comment.scan(Callouts.const_get(:FINDER))
-    User.find_all_by_username(usernames.map {|m| m[0] }).uniq
+    User.find_all_by_username(usernames.map {|m| m[1] }).uniq
   end
 
   # email all users in this thread 

--- a/app/models/drupal_node.rb
+++ b/app/models/drupal_node.rb
@@ -562,10 +562,9 @@ class DrupalNode < ActiveRecord::Base
     self.power_tag_objects('barnstar')
   end
 
-  def add_barnstar(tagname,user)
-    self.add_tag(tagname,user.drupal_user)
-    # don't bother checking if it worked
-    CommentMailer.notify_barnstar(self.author.user,self)
+  def add_barnstar(tagname,giver)
+    self.add_tag(tagname,giver.drupal_user)
+    CommentMailer.notify_barnstar(giver,self)
   end
 
   def add_tag(tagname,user)

--- a/app/models/drupal_node.rb
+++ b/app/models/drupal_node.rb
@@ -598,4 +598,9 @@ class DrupalNode < ActiveRecord::Base
     end
   end
 
+  def mentioned_users
+    usernames = self.body.scan(Callouts.const_get(:FINDER))
+    User.find_all_by_username(usernames.map {|m| m[1] }).uniq
+  end
+
 end

--- a/app/views/comment_mailer/notify.html.erb
+++ b/app/views/comment_mailer/notify.html.erb
@@ -2,7 +2,7 @@ Hi! There's been a response to a discussion you're involved in. Do NOT reply to 
 
 <p>http://publiclab.org<%= @comment.node.path %>#c<%= @comment.cid %></p>
 
-<p><b><a href="http://publiclab.org/profile/<%= @comment.author.name %>"><%= @comment.author.name %> wrote:</b></p>
+<p><b><a href="http://publiclab.org/profile/<%= @comment.author.name %>"><%= @comment.author.name %></a> wrote:</b></p>
 
 <hr /> 
 

--- a/app/views/comment_mailer/notify_callout.html.erb
+++ b/app/views/comment_mailer/notify_callout.html.erb
@@ -2,7 +2,7 @@ Hi! You were mentioned by <%= @comment.author.name %> in a comment on the resear
 
 <p>http://publiclab.org<%= @comment.node.path %>#c<%= @comment.cid %></p>
 
-<p><b><a href="http://publiclab.org/profile/<%= @comment.author.name %>"><%= @comment.author.name %> wrote:</b></p>
+<p><b><a href="http://publiclab.org/profile/<%= @comment.author.name %>"><%= @comment.author.name %></a> wrote:</b></p>
 
 <hr /> 
 

--- a/app/views/comment_mailer/notify_note_author.html.erb
+++ b/app/views/comment_mailer/notify_note_author.html.erb
@@ -1,4 +1,4 @@
-Hi! There's been a response to your research note "<a href="<%= @comment.parent.path %>"><%= @comment.parent.title %></a>". Do NOT reply to this email; click this link to respond:
+Hi! There's been a response to your research note "<a href="http://publiclab.org/<%= @comment.parent.path %>"><%= @comment.parent.title %></a>". Do NOT reply to this email; click this link to respond:
 
 <p>http://publiclab.org<%= @comment.node.path %>#c<%= @comment.cid %></p>
 

--- a/test/fixtures/node.yml
+++ b/test/fixtures/node.yml
@@ -1,17 +1,16 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
-
 one:
   title: "Canon A1200 IR conversion at PLOTS Barnraising at LUMCON"
+  path: "canon-a1200-ir-conversion-at-plots-barnraising-at-lumcon"
   created: 1362353067
   changed: 1362354920
   status: 1
   type: "note"
   uid: 2
   nid: 1
- # this needs a drupal_node_revision and other crap
 
 two: 
   title: "about"
+  path: "about"
   created: 1362353067
   changed: 1362354920
   status: 1

--- a/test/fixtures/node_counter.yml
+++ b/test/fixtures/node_counter.yml
@@ -1,0 +1,5 @@
+one:
+  nid: 1
+
+two: 
+  nid: 2

--- a/test/fixtures/node_revisions.yml
+++ b/test/fixtures/node_revisions.yml
@@ -1,0 +1,9 @@
+one: 
+  nid: 1
+  uid: 1
+  title: "Canon A1200 IR conversion at PLOTS Barnraising at LUMCON"
+
+two: 
+  nid: 2
+  uid: 2
+  title: About

--- a/test/fixtures/rusers.yml
+++ b/test/fixtures/rusers.yml
@@ -2,11 +2,15 @@ bob:
   username: bob
   email: bob@publiclab.org
   id: 1
-  #password: lalala
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
 
 jeff:
   username: jeff
   email: jeff@pxlshp.com
   id: 2
-  role: 'admin'
-  #password: lalala
+  role: admin
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,7 @@
+bob:
+  uid: 1
+  name: Bob
+
+jeff:
+  uid: 2
+  name: jeff

--- a/test/functional/features_controller_test.rb
+++ b/test/functional/features_controller_test.rb
@@ -2,9 +2,6 @@ require 'test_helper'
 
 class FeaturesControllerTest < ActionController::TestCase
 
-  fixtures :rusers
-  set_fixture_class :rusers => User
-
   test "should not get features if not admin" do
     session[:user_id] = rusers(:bob).id # log in; this is not actually working
     get :index

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -39,7 +39,7 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   def test_post_note
-    UserSession.new(@user)
+    UserSession.create(@user)
     title = "My new post about balloon mapping"
     post :create, :title => title, :body => "This is a fascinating post about a balloon mapping event.", :tags => "balloon-mapping,event"#, :main_image => "/images/testimage.jpg"
     assert_redirected_to "/notes/"+@user.username+"/"+Time.now.strftime("%m-%d-%Y")+"/"+title.parameterize
@@ -56,7 +56,7 @@ class NotesControllerTest < ActionController::TestCase
   #end
 
   def test_edit_note
-    UserSession.new(@user)
+    UserSession.create(@user)
     title = "My second post about balloon mapping"
     post :create, :title => title, :body => "This is a fascinating post about a balloon mapping event.", :tags => "balloon-mapping,event"#, :main_image => "/images/testimage.jpg"
     assert_redirected_to "/notes/"+@user.username+"/"+Time.now.strftime("%m-%d-%Y")+"/"+title.parameterize

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -5,31 +5,30 @@ class TagControllerTest < ActionController::TestCase
   def setup
     activate_authlogic
     @user =  FactoryGirl.create(:user)
-    @node =  FactoryGirl.create(:drupal_node,uid: @user.id)
   end
 
   # create accepts comma-delimited list of tags
   def test_add_tag
     UserSession.new(@user)
-    post :create, :name => 'mytag', :nid => @node.id, :uid => @user.id
-    assert_redirected_to(@node.path)
+    post :create, :name => 'mytag', :nid => node(:one).nid, :uid => @user.id
+    assert_redirected_to(node(:one).path)
   end
 
   # create returns JSON list of errors in response[:errors]
   def test_add_duplicate_tag
     UserSession.new(@user)
-    post :create, :name => 'mytag', :nid => @node.id, :uid => @user.id
-    assert_redirected_to(@node.path)
+    post :create, :name => 'mytag', :nid => node(:one).nid, :uid => @user.id
+    assert_redirected_to(node(:one).path)
 
     # 2nd identical tag:
-    post :create, :name => 'mytag', :nid => @node.id, :uid => @user.id
-    assert_redirected_to(@node.path)
+    post :create, :name => 'mytag', :nid => node(:one).nid, :uid => @user.id
+    assert_redirected_to(node(:one).path)
     assert_equal "Error: that tag already exists.", assigns['output']['errors'][0]
   end
 
   def test_add_tag_not_logged_in
     @user.destroy
-    post :create, :name => 'mytag', :nid => @node.id, :uid => 1
+    post :create, :name => 'mytag', :nid => node(:one).nid, :uid => 1
     assert_redirected_to('/login?return_to='+URI.encode(request.env['PATH_INFO']))
   end
 

--- a/test/integration/public_pages_test.rb
+++ b/test/integration/public_pages_test.rb
@@ -5,6 +5,7 @@ class PublicPagesTest < ActionDispatch::IntegrationTest
   def setup
     activate_authlogic
     @user =  FactoryGirl.create(:user)
+    # needed?:
     @user.save({})
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,14 @@ class ActiveSupport::TestCase
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting
-  # fixtures :all
+
+  # yay thanks: http://journal.missiondata.com/post/63405042042/rails-fixtures-with-models-using-settablename
+  set_fixture_class :node => DrupalNode
+  set_fixture_class :rusers => User
+  set_fixture_class :users => DrupalUsers
+  set_fixture_class :node_counter => DrupalNodeCounter
+  
+  fixtures :all
 
   # Add more helper methods to be used by all tests here...
 end

--- a/test/unit/drupal_comment_test.rb
+++ b/test/unit/drupal_comment_test.rb
@@ -2,13 +2,18 @@ require 'test_helper'
 
 class DrupalCommentTest < ActiveSupport::TestCase
 
-  #test 'new_comment_should_be_valid' do
-  #  assert DrupalComment.new.valid?
-  #end
+  test "should not save comment without body" do
+    comment = DrupalComment.new
+    assert !comment.save, "Saved the comment without body text"
+  end
 
-  #test "should not save comment without body" do
-  #  note = DrupalNode.new
-  #  assert !note.save, "Saved the comment without body text"
-  #end
+  test "should scan callouts out of body" do
+    comment = DrupalComment.new({
+      nid: node(:one).nid,
+      uid: rusers(:bob).id
+    })
+    comment.comment = 'Hey, @bob, what do you think?'
+    assert_equal comment.mentioned_users.first.id, rusers(:bob).id
+  end
 
 end

--- a/test/unit/drupal_node_test.rb
+++ b/test/unit/drupal_node_test.rb
@@ -2,19 +2,22 @@ require 'test_helper'
 
 class DrupalNodeTest < ActiveSupport::TestCase
 
-  def setup
-    activate_authlogic
-    @user =  FactoryGirl.create(:user)
-  end
-
-  def teardown
-    @user.destroy
-  end
-
   test "create a node" do
-    node =  FactoryGirl.create(:drupal_node, :uid => @user.uid)
-    node_revision = FactoryGirl.create(:drupal_node_revision, :nid => node.id)
+    # in testing, uid and id should be matched, although this is not yet true in production db
+    node =  DrupalNode.new({:uid => rusers(:bob).id})
+    node.title = "My new node"
     assert node.save!
+  end
+
+  test "create a node_revision" do
+    # in testing, uid and id should be matched, although this is not yet true in production db
+    node_revision =  DrupalNodeRevision.new({
+      :uid => rusers(:bob).id,
+      :nid => node(:one).nid
+    })
+    node_revision.title = "My new node"
+    node_revision.body = "My new node"
+    assert node_revision.save!
   end
 
   #test "should not save node without title, or anything else" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -2,17 +2,10 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
 
-  def setup
-    activate_authlogic
-    @user =  FactoryGirl.create(:user)
-  end
+  #test "user creation" do
 
-  def teardown
-    @user.destroy
-  end
+    # create a user
 
-  test "user creation" do
-    UserSession.new(@user)
-  end
+  #end
 
 end


### PR DESCRIPTION
I broke a bunch of tests getting this new test for comment callouts working, but all is passing now. We're using a hybrid of FactoryGirl and Fixtures, because FactoryGirl is a little illegible (reparable, i guess) but fixtures isn't working for UserSession.create "login faking" so FG is needed for login-dependent tests. 

* Should close https://github.com/publiclab/plots2/issues/203
* related FactoryGirl issue: https://github.com/publiclab/plots2/issues/229