### PR TITLE
fixes #257 and creates matching tests

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,5 +1,5 @@
 module Callouts
-  FINDER = /(^|\W)\@([\w-]+)(\W|$)/
-  PRETTYLINKMD = '\1[@\2](/profile/\2)\3'
-  PRETTYLINKHTML = '\1<a href="/profile/\2">@\2</a>\3'
+  FINDER = /(^|\W)\@([\w-]+)/
+  PRETTYLINKMD = '\1[@\2](/profile/\2)'
+  PRETTYLINKHTML = '\1<a href="/profile/\2">@\2</a>'
 end

--- a/test/unit/drupal_comment_test.rb
+++ b/test/unit/drupal_comment_test.rb
@@ -16,4 +16,26 @@ class DrupalCommentTest < ActiveSupport::TestCase
     assert_equal comment.mentioned_users.first.id, rusers(:bob).id
   end
 
+  test "should scan multiple callouts out of body" do
+    comment = DrupalComment.new({
+      nid: node(:one).nid,
+      uid: rusers(:bob).id
+    })
+    comment.comment = 'Hey, @bob, @jeff, @bob, what do you think?'
+    assert_equal comment.mentioned_users.length, 2 # one duplicate, removed
+    assert_equal comment.mentioned_users.first.id, rusers(:bob).id
+    assert_equal comment.mentioned_users[1].id, rusers(:jeff).id
+  end
+
+  test "should scan multiple space-separated callouts out of body" do
+    comment = DrupalComment.new({
+      nid: node(:one).nid,
+      uid: rusers(:bob).id
+    })
+    comment.comment = 'Hey, @bob @jeff @bob, what do you think?'
+    assert_equal comment.mentioned_users.length, 2 # one duplicate, removed
+    assert_equal comment.mentioned_users[0].id, rusers(:bob).id
+    assert_equal comment.mentioned_users[1].id, rusers(:jeff).id
+  end
+
 end


### PR DESCRIPTION
New, passing unit tests for callouts with spaces between, comments between. 