### PR TITLE
remove duplicate Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ config/amazon_s3.yml
 config/initializers/recaptcha.rb
 config/config.yml
 config/initializers/site_keys.rb
-Gemfile.lock
 public/system
 public/lib
 db/openid-store/


### PR DESCRIPTION
This PR removes an additional Gemfile.lock in gitignore.