### PR TITLE
update gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rails', '3.2.20'
 #  gem 'sqlite3'
 #end
 group :mysql do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.10'
 end
 # TODO support postgresql
 #group :postgresql do
@@ -41,7 +41,7 @@ gem 'execjs'
 gem 'therubyracer'
 #gem 'secondbase', '0.5.0'
 gem 'rdiscount', '1.6.8'
-gem 'will_paginate'
+gem 'will_paginate', '3.0.6'
 gem 'will_paginate-bootstrap', '0.2.5'
 gem 'georuby', '2.0'
 gem 'geokit-rails'


### PR DESCRIPTION
This PR updates the mysql2 gem version which resolves issues with OS X El Capitan mysql installation path.
Also tests fail due to unsupported parameter value from :order which caused due to latest version of will_paginate. Changing version to previous version fixes this issue.
@jywarren tests are passing now :+1: 

**Note:**
If you clone the repository, you can directly `bundle install` all the gems from the Gemfile. However if you are updating code from master, Gemfile.lock locks to previous version of will_paginate during bundle install because it locks latest version. In that case enter `bundle update will_paginate` which will update the version in Gemfile.lock