### PR TITLE
Projects dropdown Safari fix

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,7 +29,7 @@
         <% if current_user %><li><a rel="tooltip" title="Your dashboard" data-placement="bottom" href="/dashboard"><i class="icon-home icon-white"></i></a></li><% end %>
         <li class="dropdown">
 
-          <a class="dropdown-toggle" data-toggle="dropdown">
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             Projects <b class="caret"></b>
           </a>
           <ul class="dropdown-menu">


### PR DESCRIPTION
"Projects" dropdown is working on iOS devices now.

Tested on  Safari 9.0.3.

@jywarren 