### PR TITLE
Fix error handling issues

### DIFF
--- a/app/controllers/subscription_controller.rb
+++ b/app/controllers/subscription_controller.rb
@@ -52,11 +52,15 @@ class SubscriptionController < ApplicationController
             :name => params[:name],
             :description => "",
             :weight => 0})
-          unless tag.save! 
-            flash[:error] = "There was an error and your subscription failed. Please contact web@publiclab.org."
+          begin
+            tag.save!
+          rescue ActiveRecord::RecordInvalid
+            flash[:error] = tag.errors.full_messages
             redirect_to "/subscriptions"
+            return false
           end
         end
+
         # test for uniqueness, handle it as a validation error if you like
         if TagSelection.where(following: true, user_id: current_user.uid, tid: tag.tid).length > 0
           flash[:error] = "You are already subscribed to '#{params[:name]}'"

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -2,7 +2,20 @@
 
 <% if flash[:notice] %><div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">×</button><%= raw flash[:notice] %></div><% end %>
 
-<% if flash[:error] %><div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert">×</button><%= raw flash[:error] %></div><% end %>
+<% if flash[:error] %>
+  <div class="alert alert-danger">
+    <button type="button" class="close" data-dismiss="alert">×</button>
+    <% if flash[:error].is_a? String %>
+      <%= raw flash[:error] %>
+    <% elsif flash[:error].is_a? Array %>
+      <ul>
+        <% flash[:error].each do |error| %>
+          <li><%= raw error %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+<% end %>
 
 <% if flash[:warning] %><div class="alert alert-warning"><button type="button" class="close" data-dismiss="alert">×</button><i class="fa fa-exclamation-mark"></i> <%= raw flash[:warning] %></div><% end %>
 

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -27,6 +27,13 @@ class TagControllerTest < ActionController::TestCase
     assert_redirected_to(node(:one).path)
   end
 
+  def test_add_invalid_tag
+    UserSession.new(@user)
+    post :create, :name => 'my invalid tag $_', :nid => node(:one).nid, :uid => @user.id
+    assert_redirected_to(node(:one).path)
+    assert_equal "Error: tags can only include letters, numbers, and dashes", assigns['output']['errors'][0]
+  end
+
   # create returns JSON list of errors in response[:errors]
   def test_add_duplicate_tag
     UserSession.new(@user)


### PR DESCRIPTION
When ever an invalid tag is added rails error page will be displayed in dev mode. This PR displays error message to user through flash messages.

Alert view has been changed to support error datatypes compatibility.

@jywarren review please :smiley: 