### PR TITLE
Display generic message for unused contributor tags

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -202,12 +202,12 @@ class TagController < ApplicationController
     @tags = []
 
     @tagnames.each do |tagname|
-      @tags << DrupalTag.find_by_name(tagname)
-
+      tag = DrupalTag.find_by_name(tagname)
+      @tags << tag if tag
       @tagdata[tagname] = {}
       t = DrupalTag.find :all, :conditions => {:name => tagname}
       nct = DrupalNodeCommunityTag.find :all, :conditions => ['tid in (?)',t.collect(&:tid)]
-      @tagdata[tagname][:users] = DrupalNode.find(:all, :conditions => ['nid IN (?)',(nct).collect(&:nid)]).collect(&:author).uniq!.length
+      @tagdata[tagname][:users] = DrupalNode.find(:all, :conditions => ['nid IN (?)',(nct).collect(&:nid)]).collect(&:author).uniq.length
       @tagdata[tagname][:wikis] = DrupalNode.count :all, :conditions => ["nid IN (?) AND (type = 'page' OR type = 'tool' OR type = 'place')", (nct).collect(&:nid)]
       @tagdata[:notes] = DrupalNode.count :all, :conditions => ["nid IN (?) AND type = 'note'", (nct).collect(&:nid)]
     end

--- a/app/views/tag/contributors-index.html.erb
+++ b/app/views/tag/contributors-index.html.erb
@@ -1,59 +1,64 @@
 <%= render :partial => "sidebar/featured" %>
 <div class="col-md-9">
-  <% @tags.each do |tag| %>
+  <% if !@tags.empty? %>
+    <% @tags.each do |tag| %>
 
-    <div id="note-graph-<%= tag.name %>" style="height:100px;"></div>
+      <div id="note-graph-<%= tag.name %>" style="height:100px;"></div>
 
-    <script type="text/javascript">
-    (function () {
+      <script type="text/javascript">
+      (function () {
 
-      flotoptions_minimal = {
-        yaxis: { show: true },
-        xaxis: { show: true },
-        grid: {
-          borderWidth: 0,
-          //color: "#444",
-          markers: []
-        },
-        colors: [ "#08f", "#80f" ]
-      }
+        flotoptions_minimal = {
+          yaxis: { show: true },
+          xaxis: { show: true },
+          grid: {
+            borderWidth: 0,
+            //color: "#444",
+            markers: []
+          },
+          colors: [ "#08f", "#80f" ]
+        }
 
-      var notes = <%= tag.weekly_tallies.to_a.sort.to_json %>
+        var notes = <%= tag.weekly_tallies.to_a.sort.to_json %>
 
-      $.plot($("#note-graph-<%= tag.name %>"), [
-        {
+        $.plot($("#note-graph-<%= tag.name %>"), [
+          {
             data: notes,
             hoverable: true,
  //         label: "Research Notes",
-            bars: { show: true, 
-                    lineWidth: 0,
-                    fillColor: "#08f",
-                    barWidth: 0.5
-                  }
-        }
-      ],flotoptions_minimal)
+            bars: {
+              show: true,
+              lineWidth: 0,
+              fillColor: "#08f",
+              barWidth: 0.5
+            }
+          }
+        ],flotoptions_minimal)
 
-    })()
-    </script>
+      })()
+      </script>
 
-    <h3 style="margin-top:0;">Contributors for <i style="color:#aaa;"><%= tag.name %></i> over the past 52 weeks <small><a href="/tag/<%= tag.name %>">Read more &raquo;</a></small></h3>
-    <p><%= @tagdata[tag.name][:users] || 0 %> people have contributed <%= @tagdata[tag.name][:notes] %> research notes and <%= @tagdata[tag.name][:wikis] %> wiki pages tagged with "<%= tag.name %>"</i></p>
+      <h3 style="margin-top:0;">Contributors for <i style="color:#aaa;"><%= tag.name %></i> over the past 52 weeks <small><a href="/tag/<%= tag.name %>">Read more &raquo;</a></small></h3>
+      <p><%= @tagdata[tag.name][:users] || 0 %> people have contributed <%= @tagdata[tag.name][:notes] %> research notes and <%= @tagdata[tag.name][:wikis] %> wiki pages tagged with "<%= tag.name %>"</i></p>
 
-    <% if current_user %>
-    <!-- AJAXify -->
-    <div class="btn-group">
-      <a class="btn btn-sm" href="/feed/tag/<%= tag.name %>.rss"><i class="fa fa-rss"></i> RSS</a>
-      <% if current_user.following(tag.name) %>
-      <a rel="tooltip" title="Click to unfollow" class="btn btn-sm active" href="/unsubscribe/tag/<%= tag.name %>"><i class="fa fa-eye-open"></i> Following <b><%= tag.name %></b></a>
-      <% else %>
-      <a class="btn btn-sm" href="/subscribe/tag/<%= tag.name %>"><i class="fa fa-eye-open"></i> Follow <b><%= tag.name %></b></a>
+      <% if current_user %>
+      <!-- AJAXify -->
+      <div class="btn-group">
+        <a class="btn btn-sm" href="/feed/tag/<%= tag.name %>.rss"><i class="fa fa-rss"></i> RSS</a>
+        <% if current_user.following(tag.name) %>
+        <a rel="tooltip" title="Click to unfollow" class="btn btn-sm active" href="/unsubscribe/tag/<%= tag.name %>"><i class="fa fa-eye-open"></i> Following <b><%= tag.name %></b></a>
+        <% else %>
+        <a class="btn btn-sm" href="/subscribe/tag/<%= tag.name %>"><i class="fa fa-eye-open"></i> Follow <b><%= tag.name %></b></a>
+        <% end %>
+      </div>
+      <!-- AJAXify -->
+      &nbsp; <%= DrupalTag.follower_count(tag.name) %> people are watching this tag
       <% end %>
-    </div>
-    <!-- AJAXify -->
-    &nbsp; <%= DrupalTag.follower_count(tag.name) %> people are watching this tag
-    <% end %>
 
-    <hr />
+      <hr />
+    <% end %>
+  <% else %>
+    <p>No contributors are listed. <a href="/post">Write a research note</a></p>
   <% end %>
 
 </div>

--- a/app/views/tag/contributors.html.erb
+++ b/app/views/tag/contributors.html.erb
@@ -1,57 +1,60 @@
 <%= render :partial => "sidebar/related" %>
 <div class="col-md-9">
-  <div id="note-graph" style="height:100px;"></div>
+  <% if @tag %>
+    <div id="note-graph" style="height:100px;"></div>
 
-  <script type="text/javascript">
-  (function () {
+    <script type="text/javascript">
+    (function () {
 
-    flotoptions_minimal = {
-      yaxis: { show: false },
-      xaxis: { show: true },
-      grid: {
-        borderWidth: 0,
-        //color: "#444",
-        markers: []
-      },
-      colors: [ "#08f", "#80f" ]
-    }
+      flotoptions_minimal = {
+        yaxis: { show: false },
+        xaxis: { show: true },
+        grid: {
+          borderWidth: 0,
+          //color: "#444",
+          markers: []
+        },
+        colors: [ "#08f", "#80f" ]
+      }
 
-    var notes = <%= @tag.weekly_tallies.to_a.sort.to_json %>
+      var notes = <%= @tag.weekly_tallies.to_a.sort.to_json %>
 
-    $.plot($("#note-graph"), [
-      {
+      $.plot($("#note-graph"), [
+        {
           data: notes,
           hoverable: true,
- //         label: "Research Notes",
-          bars: { show: true, 
-                  lineWidth: 0,
-                  fillColor: "#08f",
-                  barWidth: 0.5
-                }
-      }
-    ],flotoptions_minimal)
+ //       label: "Research Notes",
+          bars: {
+            show: true,
+            lineWidth: 0,
+            fillColor: "#08f",
+            barWidth: 0.5
+          }
+        }
+      ],flotoptions_minimal)
 
-  })()
-  </script>
+    })()
+    </script>
 
-  <h3 style="margin-top:0;">Contributors for <i style="color:#aaa;"><%= params[:id] %></i></h3>
-  <p><i>Above: contributions over the past year.</p>
-  <% if @users %><p><%= @users.length || 0 %> people have contributed <%= @notes.length %> research notes and <%= @wikis.length %> wiki pages tagged with "<%= params[:id] %>"</i></p><% end %>
+    <h3 style="margin-top:0;">Contributors for <i style="color:#aaa;"><%= params[:id] %></i></h3>
+    <p><i>Above: contributions over the past year.</p>
+    <% if @users %><p><%= @users.length || 0 %> people have contributed <%= @notes.length %> research notes and <%= @wikis.length %> wiki pages tagged with "<%= params[:id] %>"</i></p><% end %>
 
-  <% if current_user %>
-  <!-- AJAXify -->
-  <div class="btn-group">
-    <a class="btn btn-sm" href="/feed/tag/<%= params[:id] %>.rss"><i class="fa fa-rss"></i> RSS</a>
-    <% if current_user.following(params[:id]) %>
-    <a rel="tooltip" title="Click to unfollow" class="btn btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>"><i class="fa fa-eye-open"></i> Following <b><%= params[:id] %></b></a>
-    <% else %>
-    <a class="btn btn-sm" href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-eye-open"></i> Follow <b><%= params[:id] %></b></a>
+    <% if current_user %>
+    <!-- AJAXify -->
+    <div class="btn-group">
+      <a class="btn btn-sm" href="/feed/tag/<%= params[:id] %>.rss"><i class="fa fa-rss"></i> RSS</a>
+      <% if current_user.following(params[:id]) %>
+      <a rel="tooltip" title="Click to unfollow" class="btn btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>"><i class="fa fa-eye-open"></i> Following <b><%= params[:id] %></b></a>
+      <% else %>
+      <a class="btn btn-sm" href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-eye-open"></i> Follow <b><%= params[:id] %></b></a>
+      <% end %>
+    </div>
+    <!-- AJAXify -->
+    &nbsp; <%= DrupalTag.follower_count(params[:id]) %> people are watching this tag
+
     <% end %>
-  </div>
-  <!-- AJAXify -->
-  &nbsp; <%= DrupalTag.follower_count(params[:id]) %> people are watching this tag
   <% end %>
-
   <hr />
 
   <% if @notes.nil? || @notes.length == 0 %>

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -27,6 +27,13 @@ class TagControllerTest < ActionController::TestCase
     assert_redirected_to(node(:one).path)
   end
 
+  def test_validate_unused_tag
+    UserSession.new(@user)
+    get :contributors, :id => 'question:*'
+    assert_template :contributors
+    assert_tag :tag => 'p', :child => /No contributors for that tag/
+  end
+
   def test_add_invalid_tag
     UserSession.new(@user)
     post :create, :name => 'my invalid tag $_', :nid => node(:one).nid, :uid => @user.id


### PR DESCRIPTION
This fixes #275 issue when unused tags are passed as parameter. Also fixes `#contributors_index` method validations for tag. Displays a generic message in `/contributions` route when there is no tag data.

Tests are pending, not ready for merge