### PR TITLE
commented-out tests for image and revision deletion features in #470

### DIFF
--- a/test/functional/images_controller_test.rb
+++ b/test/functional/images_controller_test.rb
@@ -1,13 +1,26 @@
 require 'test_helper'
 
 class ImagesControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
 
 # def create
 # def new
 # def update
-# def delete
+
+#  test "normal user should not delete image" do
+#    UserSession.new(users(:bob))
+#    post :delete, id: Image.last.id
+#    assert_equal flash[:error], "Only admins can delete wiki pages."
+#    assert_redirected_to "/wiki/" + title.parameterize # use node_path?
+#  end
+
+#  test "admin user should delete image" do
+#    UserSession.new(users(:admin))
+#    post :delete, id: Image.last.id
+#    assert_equal flash[:notice], "Wiki revision deleted."
+#    assert_redirected_to "/wiki/" + title.parameterize # use node_path?
+
+## also ensure any revisions/wiki pages/notes using this image have been re-assigned a most-recent, or no image
+
+#  end
 
 end

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -133,6 +133,25 @@ class WikiControllerTest < ActionController::TestCase
     assert_redirected_to "/dashboard"
   end
 
+#  test "normal user should not delete wiki revision" do
+#    UserSession.new(users(:bob))
+#    post :delete_revision, id: DrupalNodeRevision.last.vid
+#    assert_equal flash[:error], "Only admins can delete wiki revisions."
+#    assert_redirected_to "/wiki/" + title.parameterize # use node_path?
+#  end
+
+#  test "admin user should delete wiki revision" do
+#    UserSession.new(users(:admin))
+#    post :delete_revision, id: DrupalNodeRevision.last.vid
+#    assert_equal flash[:notice], "Wiki revision deleted."
+#    assert_redirected_to "/wiki/" + title.parameterize # use node_path?
+#  end
+
+#  test "admin user should not delete wiki revision if its the only revision" do
+## this will require creating a wiki page with only one revision, to be sure
+## this could also be done in a unit test if we add a before_destroy filter on the DrupalNodeRevision model
+#  end
+
   test "should display wiki pages with slug in root" do
     @user.role = "admin"
     @user.save!


### PR DESCRIPTION
This includes tests for #470 which are commented out until someone starts to solve that issue. Borrowing [this idea from Hoodie](http://hood.ie/blog/starter-issues.html), under "Beyond the extra mile".

* [x] tests pass -- `rake test`
* [x] code has been rebased on top of latest master (check if another pull request was added recently, and please rebase)
* [x] pull request is descriptively named and, if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer

Thanks!