### PR TITLE
tests running in sqlite now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ ruby '2.1.2'
 gem 'rails', '~> 3.2.20'
 gem 'passenger'
 
-# Bundle edge Rails instead:
-# gem 'rails', :git => 'git://github.com/rails/rails.git'
-
 # run with `bundle install --without production` or `bundle install --without mysql` to exclude this
 group :mysql, :production do
   gem 'mysql2', '~> 0.3.20'

--- a/db/migrate/20160403220245_remove_constraints_for_sqlite.rb
+++ b/db/migrate/20160403220245_remove_constraints_for_sqlite.rb
@@ -1,0 +1,8 @@
+class RemoveConstraintsForSqlite < ActiveRecord::Migration
+  def up
+    change_column :comments, :thread, :string, null: true
+  end
+
+  def down
+  end
+end

--- a/test/fixtures/rusers.yml
+++ b/test/fixtures/rusers.yml
@@ -5,7 +5,7 @@ bob:
   password_salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
   persistence_token: <%= Authlogic::Random.hex_token %>
-  last_request_at: <%= Time.now.to_i %>
+  last_request_at: <%= Time.now %>
 
 jeff:
   username: jeff
@@ -15,23 +15,32 @@ jeff:
   password_salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
   persistence_token: <%= Authlogic::Random.hex_token %>
-  last_request_at: <%= Time.now.to_i %>
+  last_request_at: <%= Time.now %>
 
 spammer:
   username: spammer
   email: spam@spam.com
   id: 3
-  last_request_at: <%= Time.now.to_i %>
+  last_request_at: <%= Time.now %>
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
 
 unbanned_spammer:
   username: unbanned_spammer
   email: uspam@spam.com
   id: 4
-  last_request_at: <%= Time.now.to_i %>
+  last_request_at: <%= Time.now %>
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
 
 admin:
   username: palpatine
   email: admin@publiclab.org
   id: 5
-  last_request_at: <%= Time.now.to_i %>
+  last_request_at: <%= Time.now %>
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secret" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
   role: admin

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -39,13 +39,19 @@ class NotesControllerTest < ActionController::TestCase
 
   test "show note" do
     note = DrupalNode.where(type: 'note', status: 1).last
-    get :show, author: note.author.name, date: Time.at(note.created).strftime("%m-%d-%Y"), id: note.title.parameterize
+    get :show, 
+        author: note.author.name, 
+        date: Time.at(note.created).strftime("%m-%d-%Y"), 
+        id: note.title.parameterize
     assert_response :success
   end
 
   test "don't show note by spam author" do
     note = DrupalNode.find_by_nid(3) # spam fixture
-    get :show, author: note.author.name, date: Time.at(note.created).strftime("%m-%d-%Y"), id: note.title.parameterize
+    get :show, 
+        author: note.author.name, 
+        date: Time.at(note.created).strftime("%m-%d-%Y"), 
+        id: note.title.parameterize
     assert_redirected_to '/'
   end
 

--- a/test/unit/drupal_comment_test.rb
+++ b/test/unit/drupal_comment_test.rb
@@ -12,7 +12,9 @@ class DrupalCommentTest < ActiveSupport::TestCase
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
-    comment.comment = 'Hey, @bob, what do you think?'
+    comment.comment = 'Hey, @Bob, what do you think?'
+    assert_not_nil comment
+    assert_equal 1, comment.mentioned_users.length
     assert_equal comment.mentioned_users.first.id, rusers(:bob).id
   end
 
@@ -21,7 +23,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
-    comment.comment = 'Hey, @bob, @jeff, @bob, what do you think?'
+    comment.comment = 'Hey, @Bob, @jeff, @Bob, what do you think?'
     assert_equal comment.mentioned_users.length, 2 # one duplicate, removed
     assert_equal comment.mentioned_users.first.id, rusers(:bob).id
     assert_equal comment.mentioned_users[1].id, rusers(:jeff).id
@@ -32,7 +34,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
-    comment.comment = 'Hey, @bob @jeff @bob, what do you think?'
+    comment.comment = 'Hey, @Bob @jeff @Bob, what do you think?'
     assert_equal comment.mentioned_users.length, 2 # one duplicate, removed
     assert_equal comment.mentioned_users[0].id, rusers(:bob).id
     assert_equal comment.mentioned_users[1].id, rusers(:jeff).id

--- a/test/unit/drupal_node_test.rb
+++ b/test/unit/drupal_node_test.rb
@@ -27,6 +27,20 @@ class DrupalNodeTest < ActiveSupport::TestCase
     assert node.save!
   end
 
+  test "create a wiki page with DrupalNode.new_wiki" do
+    node = DrupalNode.new_wiki({
+      uid: rusers(:bob).id,
+      type: 'page',
+      title: 'My wiki page',
+      body: 'Wiki page content/body'
+    })[1] # returns an array, oddly. refactor this API!
+    assert node.save!
+    assert_equal rusers(:bob).id, node.uid
+    assert_equal 'page', node.type
+    assert_equal 'My wiki page', node.title
+    assert_equal 'Wiki page content/body', node.body
+  end
+
   test "create a node_revision" do
     # in testing, uid and id should be matched, although this is not yet true in production db
     node_revision =  DrupalNodeRevision.new({


### PR DESCRIPTION
fixes #478 -- requires `rake db:migrate`

* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer