### PR TITLE
fix and test for dashboard2

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -66,10 +66,10 @@ class HomeController < ApplicationController
                             .where('term_data.name = (?)', 'hidden:response')
                             .collect(&:nid)
     @notes = DrupalNode.where(type: 'note', status: 1)
-                       .where('nid != (?)', @blog.nid)
                        .where('node.nid NOT IN (?)', hidden_nids)
                        .order('nid DESC')
                        .page(params[:page])
+    @notes = @notes.where('nid != (?)', @blog.nid) if @blog
     # include revisions, then mix with new pages:
     @wikis = DrupalNode.where(type: 'page', status: 1)
                        .order('nid DESC')
@@ -77,17 +77,21 @@ class HomeController < ApplicationController
     @wikis += DrupalNodeRevision.joins(:drupal_node)
                                 .order('timestamp DESC')
                                 .where('type = (?)', 'page')
-                                .where('status = (?)', 1)
+                                .where('node.status = 1')
                                 .where('timestamp - node.created > ?', 300) # don't report edits within 5 mins of page creation
                                 .limit(10)
-                                .group(:title, 'DATE(FROM_UNIXTIME(timestamp))') # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
+                                .group('node.title')
+    # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
+    @wikis = @wikis.group('DATE(FROM_UNIXTIME(timestamp))') if Rails.env == "production"
     @wikis = @wikis.sort_by { |a| a.created_at }.reverse
     @comments = DrupalComment.joins(:drupal_node, :drupal_users)
                              .order('timestamp DESC')
                              .where('timestamp - node.created > ?', 86400) # don't report edits within 1 day of page creation
                              .limit(20)
-                             .group('title', 'DATE(FROM_UNIXTIME(timestamp))') # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
+                             .group('title') # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
 #                            .where('comments.status = (?)', 1)
+    # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
+    @comments = @comments.group('DATE(FROM_UNIXTIME(timestamp))') if Rails.env == "production"
     @activity = (@notes + @wikis + @comments).sort_by { |a| a.created_at }.reverse
     @user_note_count = DrupalNode.where(type: 'note', status: 1, uid: current_user.uid).count if current_user
     render template: 'dashboard/dashboard'

--- a/app/views/admin/_revisions.html.erb
+++ b/app/views/admin/_revisions.html.erb
@@ -13,7 +13,7 @@
         <span style="color:grey;"><%= time_ago_in_words(revision.timestamp) %> ago</span>
       </td>
       <td style="width:200px;">
-        <%= revision.body %>
+        <%= revision.body.truncate(40) %>
       </td>
       <td style="width:200px;">
         <a href="/profile/<%= revision.author.name %>"><%= revision.author.name %></a> 

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -7,21 +7,23 @@
     <div class="col-md-8">
  
       <div class="dashboard-blog">
-  
-        <div class="img"<% if @blog.main_image %> style="background-image: url('<%= @blog.main_image.path(:large) %>')"<% end %>>
-  
-          <div class="blog-caption">
-
-            <h4>
-              <small class="pull-right hidden-xs hidden-sm">From the <a href="/blog">Public Lab Blog</a></small>
-              <a class="title" href="/blog"><%= @blog.title %></a> 
-              <small>by <a href="/profile/<%= @blog.author.username %>"><%= @blog.author.username %></a></small>
-            </h4>
-
+ 
+        <% if @blog %> 
+          <div class="img"<% if @blog.main_image %> style="background-image: url('<%= @blog.main_image.path(:large) %>')"<% end %>>
+       
+            <div class="blog-caption">
+       
+              <h4>
+                <small class="pull-right hidden-xs hidden-sm">From the <a href="/blog">Public Lab Blog</a></small>
+                <a class="title" href="/blog"><%= @blog.title %></a> 
+                <small>by <a href="/profile/<%= @blog.author.username %>"><%= @blog.author.username %></a></small>
+              </h4>
+       
+            </div>
           </div>
+       
         </div>
-  
-      </div>
+      <% end %>
   
       <%= render partial: "dashboard/activity", locals: { activity: @activity, notes: @notes } %>
  

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -32,4 +32,12 @@ class HomeControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get dashboard2" do
+    UserSession.create(rusers(:bob))
+
+    get :dashboard2
+
+    assert_response :success
+  end
+
 end


### PR DESCRIPTION
`/dashboard2` is not a highly visible page (not publicized yet) but I still consider it an urgent fix. I should have written a test earlier. The test can be removed once the dashboard goes live at `/dashboard`.

* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added