### PR TITLE
fixed and tested all moderation notifications

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -90,6 +90,7 @@ class AdminController < ApplicationController
       if @node.status == 1 || @node.status == 4
         @node.spam
         @node.author.ban
+        AdminMailer.notify_moderators_of_spam(@node, current_user)
         flash[:notice] = "Item marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>."
         redirect_to "/dashboard"
       else
@@ -109,6 +110,9 @@ class AdminController < ApplicationController
       @node.publish
       @node.author.unban
       if first_timer_post
+        AdminMailer.notify_author_of_approval(@node, current_user)
+        AdminMailer.notify_moderators_of_approval(@node, current_user)
+        SubscriptionMailer.notify_node_creation(@node)
         flash[:notice] = "Post approved and published after #{time_ago_in_words(@node.created_at)} in moderation. Now reach out to the new community member; thank them, just say hello, or help them revise/format their post in the comments."
       else
         flash[:notice] = "Item published."

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -55,7 +55,7 @@ class NotesController < ApplicationController
       redirect_to "/"
     elsif @node.status == 4 && (current_user && (current_user.role == "admin" || current_user.role == "moderator"))
       flash[:warning] = "First-time poster <a href='#{@node.author.name}'>#{@node.author.name}</a> submitted this #{time_ago_in_words(@node.created_at)} ago and it has not yet been approved by a moderator. <a class='btn btn-default btn-sm' href='/moderate/publish/#{@node.id}'>Approve</a> <a class='btn btn-default btn-sm' href='/moderate/spam/#{@node.id}'>Spam</a>"
-    elsif @node.status == 4 && (current_user && current_user.id == @node.author.id)
+    elsif @node.status == 4 && (current_user && current_user.id == @node.author.id) && !flash[:first_time_post]
       flash[:warning] = "Thank you for contributing open research, and thanks for your patience while your post is approved by <a href='/wiki/moderation'>community moderators</a> and we'll email you when it is published. In the meantime, if you have more to contribute, feel free to do so."
     elsif @node.status != 1 && !(current_user && (current_user.role == "admin" || current_user.role == "moderator"))
       # if it's spam or a draft
@@ -97,6 +97,8 @@ class NotesController < ApplicationController
           @node.add_tag("date:"+params[:date],current_user) if params[:date]
         end
         if current_user.first_time_poster
+          AdminMailer.notify_node_moderators(@node)
+          flash[:first_time_post] = true
           flash[:notice] = "Success! Thank you for contributing open research, and thanks for your patience while your post is approved by <a href='/wiki/moderation'>community moderators</a> and we'll email you when it is published. In the meantime, if you have more to contribute, feel free to do so."
         else
           flash[:notice] = "Research note published. Get the word out on <a href='/lists'>the discussion lists</a>!"

--- a/app/models/drupal_node.rb
+++ b/app/models/drupal_node.rb
@@ -101,10 +101,6 @@ class DrupalNode < ActiveRecord::Base
   end
 
   def publish
-    if self.status = 4 # first timer
-      self.status = 1
-      self.notify
-    end
     self.status = 1
     self.save
     self

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -141,6 +141,7 @@ class NotesControllerTest < ActionController::TestCase
          #, :main_image => "/images/testimage.jpg"
 
     assert_equal "Success! Thank you for contributing open research, and thanks for your patience while your post is approved by <a href='/wiki/moderation'>community moderators</a> and we'll email you when it is published. In the meantime, if you have more to contribute, feel free to do so.", flash[:notice]
+    assert_nil flash[:warning] # no double notice
     assert_equal 4, DrupalNode.last.status
     assert_equal title, DrupalNode.last.title
     assert_redirected_to "/notes/"+rusers(:lurker).username+"/"+Time.now.strftime("%m-%d-%Y")+"/"+title.parameterize


### PR DESCRIPTION
Fixes #504 and completes email notifications

* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added