### PR TITLE
Embed etherpad in iframe

### DIFF
--- a/app/controllers/talk_controller.rb
+++ b/app/controllers/talk_controller.rb
@@ -1,0 +1,5 @@
+class TalkController < ApplicationController
+  def show
+    @slug = params[:id]
+  end
+end

--- a/app/views/talk/show.html.erb
+++ b/app/views/talk/show.html.erb
@@ -1,0 +1,2 @@
+<div><h3 style="margin-top: 10px;font-family: 'Junction Light';clear:left;">Hello Everyone! Welcome to Publiclab Talk Pad</h3></div>
+<div><iframe src="https://pad.publiclab.org/p/<%= @slug %>" style="width: 100%; height:800px;"><p>Placeholder text</p></iframe></div>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -43,7 +43,7 @@
         <li class="active"><a href="#"><span class="hidden-xs">View</span><span class="visible-xs"><i class="fa fa-file-o"></i></span></a></li>
         <li><a href="<%= @node.edit_path %>?t=<%= Time.now.to_i %>"><i class="fa fa-pencil"></i><span class="hidden-xs hidden-sm"> Edit</span></a></li>
         <% if current_user && current_user.role == "admin" %><li><%= link_to "/wiki/delete/"+@node.id.to_s, :confirm => "Are you absolutely sure you want to delete '"+@node.path+"'? All revisions will be lost, and you cannot undo this action. If this is a spam page, be sure that it did not overwrite valid content before deleting the entire page." do %><i class="fa fa-trash"></i><span class="hidden-xs hidden-sm"> Delete</span><% end %></li><% end %>
-        <li><a href="//pad.publiclab.org/p/<%= @node.slug[0,50] %>"><i class="fa fa-comments-o"></i><span class="hidden-xs hidden-sm"> Talk</span></a></li>
+        <li><a href="/talk/<%= @node.slug[0,50] %>"><i class="fa fa-comments-o"></i><span class="hidden-xs hidden-sm"> Talk</span></a></li>
         <li><a href="/wiki/revisions/<%= @node.slug %>"><span class="hidden-xs"><%= @node.revisions.length %> </span><i class="fa fa-list"></i></a></li>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,8 @@ Plots2::Application.routes.draw do
   match 'note/add' => 'legacy#note_add'
   match 'page/add' => 'legacy#page_add'
 
+  match 'talk/:id' => 'talk#show'
+
   # Sample resource route (maps HTTP verbs to controller actions automatically):
   #   resources :products
 

--- a/test/functional/talk_controller_test.rb
+++ b/test/functional/talk_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class TalkControllerTest < ActionController::TestCase
+  test "should get show" do
+  	node = node(:about)
+    get :show, id: node.slug[0,50]
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added

Issue #175. iframe on https://pad.publiclab.com is causing the following error 
`Multiple 'X-Frame-Options' headers with conflicting values ('DENY, SAMEORIGIN') encountered when loading 'https://pad.publiclab.org/p/donate'. Falling back to 'DENY'.`