### PR TITLE
editing vs. posting switch in rich editor template

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -146,9 +146,13 @@
     editor = new PL.Editor({
       textarea:    $('.ple-textarea')[0],
       <% if @main_image %>
-      mainImageUrl:   '<%= @main_image %>',
+        mainImageUrl:   '<%= @main_image %>',
       <% end %>
-      destination: '/notes/update/<%= @node.id %>',
+      <% if params[:action] == 'edit' %>
+        destination: '/notes/update/<%= @node.id %>',
+      <% else %>
+        destination: '/notes/create',
+      <% end %>
       format:      'publiclab',
     });
 


### PR DESCRIPTION
* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added