### PR TITLE
updated tests for cache flush on saving edits in rich editor

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -221,9 +221,9 @@ class NotesController < ApplicationController
         format = false
         format = :question if params[:redirect] && params[:redirect] == 'question'
         if request.xhr?
-          render text: @node.path(format)
+          render text: @node.path(format) + "?_=" + Time.now.to_i.to_s
         else
-          redirect_to @node.path(format)
+          redirect_to @node.path(format) + "?_=" + Time.now.to_i.to_s
         end
       else
         flash[:error] = "Your edit could not be saved."

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -258,7 +258,7 @@ class NotesControllerTest < ActionController::TestCase
          body: "This is a fascinating post about a balloon mapping event. <span id='teststring'>added content</span>", 
          tags: "balloon-mapping,event,meetup"
 
-    assert_redirected_to "/notes/"+rusers(:bob).username+"/"+Time.now.strftime("%m-%d-%Y")+"/"+title.parameterize
+    assert_redirected_to "/notes/" + rusers(:bob).username + "/" + Time.now.strftime("%m-%d-%Y") + "/" + title.parameterize + "?_=" + Time.now.to_i.to_s
 
     # approve the first-timer's note:
     node.publish
@@ -320,7 +320,7 @@ class NotesControllerTest < ActionController::TestCase
          tags: "question:spectrometer",
          redirect: "question"
 
-    assert_redirected_to "/questions/"+rusers(:bob).username+"/"+Time.now.strftime("%m-%d-%Y")+"/"+title.parameterize
+    assert_redirected_to "/questions/" + rusers(:bob).username + "/" + Time.now.strftime("%m-%d-%Y") + "/" + title.parameterize
   end
 
   test "should redirect to questions show page when editing an existing question" do
@@ -333,7 +333,7 @@ class NotesControllerTest < ActionController::TestCase
          tags: "question:spectrometer",
          redirect: "question"
 
-    assert_redirected_to note.path(:question)
+    assert_redirected_to note.path(:question) + "?_=" + Time.now.to_i.to_s
   end
 
 end


### PR DESCRIPTION
* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added
