### PR TITLE
start to tagging APIs for rich editor (incomplete)

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -158,9 +158,10 @@ class TagController < ApplicationController
                .limit(10).each do |tag|
         suggestions << tag.name.downcase
       end
-      render :json => suggestions.uniq
-    else
-      render :json => []
+      @tags = suggestions.uniq
+      render json: @tags
+    else           
+      render json: []
     end
   end
 
@@ -216,6 +217,10 @@ class TagController < ApplicationController
       @tagdata[:notes] = DrupalNode.count :all, :conditions => ["nid IN (?) AND type = 'note'", (nct).collect(&:nid)]
     end
     render :template => "tag/contributors-index"
+  end
+
+  def recent
+    #@user = User.where(username: current
   end
 
 end

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -154,6 +154,27 @@
         destination: '/notes/create',
       <% end %>
       format:      'publiclab',
+      richTextEditor: {
+        tags: function(value, done) {
+
+          if (value.length > 2) {
+
+            $.ajax('/tags/recent')
+             .done(function(response) {
+               done(response);
+             });
+
+          } else {
+
+            $.ajax('/tags/suggested/' + value)
+             .done(function(response) {
+               done(response);
+             });
+
+          }
+
+        }
+      }
     });
 
   })();

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -1,7 +1,6 @@
 # def barnstar
 # def create
 # def delete
-# def suggested
 # def contributors_index
 
 require 'test_helper'
@@ -95,6 +94,28 @@ class TagControllerTest < ActionController::TestCase
     assert_not_nil :notes
     assert_not_nil :users
     assert_not_nil :tag
+  end
+
+  test "suggested tags" do
+    get :suggested, id: 'tes'
+    assert :success
+    assert_not_nil :tags
+    assert assigns(:tags).length > 0
+  end
+
+  test "suggested tags for too-short entry" do
+    get :suggested, id: 'te'
+    assert :success
+    assert_not_nil :tags
+    assert_equal "[]", @response.body 
+  end
+
+  test "recent tags for this author" do
+    UserSession.create(rusers(:bob))
+    get :recent
+    assert :success
+    assert_not_nil :tags
+    assert_equal rusers(:bob).recent_tags.collect(&:name), assigns(:tags)
   end
 
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -35,4 +35,8 @@ class UserTest < ActiveSupport::TestCase
     assert        users(:lurker).first_time_poster
   end
 
+  test "user recent tags" do  
+    assert_equal rusers(:bob).recent_tags.collect(&:name), []
+  end
+
 end


### PR DESCRIPTION
- [ ] tests pass -- `rake test`
- [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
- [x] pull request are descriptively named
- [ ] if possible, multiple commits squashed if they're smaller changes
- [ ] reviewed/confirmed/tested by another contributor or maintainer

So, we need (similar to https://github.com/publiclab/plots2/blob/master/test/functional/typeahead_api_test.rb):

* [x] tests for `/api/srch/profiles?srchString=warr`
* [x] tests for `/api/srch/tags?srchString=warr`
* [x] tests for `/api/srch/notes?srchString=warr`

Ok, now we should split this in multiple parts - we need APIs for (sourcing from https://github.com/publiclab/plots2/wiki/API):

1. [x] Profiles related to a search string: https://publiclab.org/api/srch/profiles?srchString=warr
2. [x] Tags related to a search string: Should be but no results: https://publiclab.org/tags/suggested/balloon or an **only full-word match**: https://publiclab.org/api/srch/tags?srchString=balloon-mapping
    * [x] for a **partial tag matching API** we'd have to make a new method similar to this, but for partial tags: https://github.com/publiclab/plots2/blob/master/app/services/search_service.rb#L170
    * [x] and then, after the above, expose it in the API by making a method similar to this one: https://github.com/publiclab/plots2/blob/master/app/api/srch/search.rb#L96-L119
3. [x] Nodes related to a search string: https://publiclab.org/api/srch/notes?srchString=ball (for [the "Related posts" feature in the Rich editor](https://github.com/publiclab/PublicLab.Editor/issues/77))

