### PR TITLE
fix ordering of comment index

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -5,6 +5,7 @@ class CommentController < ApplicationController
 
   def index
     @comments = DrupalComment.paginate(page: params[:page], per_page: 30)
+                             .order('timestamp DESC')
     render template: 'comments/index'
   end
 

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -9,6 +9,7 @@ class CommentControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_not_nil :comments
+    assert assigns(:comments).first.timestamp > assigns(:comments).last.timestamp
   end
 
   test "should create note comments" do


### PR DESCRIPTION
* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added
