### PR TITLE
Fix bug in header login

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -36,6 +36,8 @@ class UserSessionsController < ApplicationController
                 return_to = session[:return_to]
                 session[:return_to] = nil
                 redirect_to return_to
+              elsif params[:return_to]
+                redirect_to params[:return_to]
               else
                 redirect_to "/dashboard"
               end

--- a/test/integration/login_flow_test.rb
+++ b/test/integration/login_flow_test.rb
@@ -33,4 +33,18 @@ class LoginFlowTest < ActionDispatch::IntegrationTest
       assert_select "[value=?]", "What"
     end
   end
+
+  test "should redirect to current page when logging in through the header login" do
+    get '/questions'
+    assert_response :success
+
+    post '/user_sessions',
+         return_to: request.path,
+         user_session: {
+           username: rusers(:jeff).username,
+           password: 'secret'
+         }
+    follow_redirect!
+    assert_equal '/questions', path
+  end
 end


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] tests pass -- `rake test`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `development.sqlite.example` has been updated if any database migrations were added

When logging in through the header login dropdown the request should redirect to the current page which wasn't happening. Fixed it in this PR.

Thanks!

