### PR TITLE
Corrections to restful_typeahead.js and typeahead functionality

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,7 +43,6 @@
 //= require searchform.js
 //= require location_tags.js
 //= require users.js
-//= require restful_typeahead.js
 //= require searchform.js
 //= require location_tags.js
 //= require users.js

--- a/app/assets/javascripts/restful_typeahead.js
+++ b/app/assets/javascripts/restful_typeahead.js
@@ -36,12 +36,12 @@
 	var inid = elemRef.attr('id');
 	//Check to see if the element is looking for a defined qry type; otherwise default to 'all'
 	var ttype = 'all';
-	var intype = elemRef.attr('qryType');
+	var intype = elemRef.attr('qrytype');
 	if (intype) {
 		ttype = intype;
 	} else {
-		//set the qryType attribute to 'all'
-		elemRef.attr('qryType',ttype);
+		//set the qrytype attribute to 'all'
+		elemRef.attr('qrytype',ttype);
 	}
 	if (!inid) {
 		//create a dynamic id if there is none
@@ -114,14 +114,14 @@
     Process the element's typed values and perform the query; display the results in the associated datalist
   **/
   function typeaheadSearch(srchElem) {
-	var qtype = $(srchElem).attr('qryType');
+	var qtype = $(srchElem).attr('qrytype');
 	keycount += 1;
 	var qparams = new Object();
 	qparams.srchString = $(srchElem).val();
 	qparams.seq = keycount;
 	//checks to reduce server load and minimize long return values
         if (!qparams.srchString) return;
-        if (qparams.srchString = '' || qparams.srchString = ' ') return;
+        if (qparams.srchString == '' || qparams.srchString == ' ') return;
         if (qparams.srchString.length < minQry) return;
         $.getJSON(typeaheadBase+qtype,qparams,function(qdata) {
 		if (qdata.srchParams) {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -78,7 +78,7 @@
 
       <form id="searchform" class="navbar-form navbar-left" role="search" autocomplete="off">
         <div class="form-group">
-          <input tabindex="1" id="searchform_input" type="text" class="form-control search-query typeahead" placeholder="<%= t('layout._header.search') %>"/>
+          <input tabindex="1" id="searchform_input" type="text" class="form-control search-query typeahead" qryType="all" placeholder="<%= t('layout._header.search') %>"/>
         </div>
         <button type="submit" class="btn btn-primary" style="background:#444;border-color:#222;"><i class="fa fa-search"></i></button>
       </form>

--- a/app/views/searches/dynamic.html.erb
+++ b/app/views/searches/dynamic.html.erb
@@ -12,7 +12,7 @@
       <div class="col-md-6">
         <form class="form-horizontal" id="dynamic_srch_form">
           <div class="form-group">
-            <input class="form-control" name="qryField" id="qryField" placeholder="Enter search terms"/>
+            <input class="form-control" name="qryField" id="qryField" class="form-control search-query typeahead" qryType="all" placeholder="Enter search terms"/>
           </div>
         </div>
         <button class="btn btn-primary" id="srchButton"><span class="fa fa-search"></span></button>


### PR DESCRIPTION
* [x] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [ ] `schema.rb.example` has been updated if any database migrations were added

Typo in restful_typeahead.js caused javascript to fail on setup.  Also, Rails seems to push html attributes to all-lowercase, so I changed the "qryType" attribute in the javascript to "qrytype", as well as manually set to all lowercase in the affected .html.erb files