### PR TITLE
categories and status for activities - closes #750

### DIFF
--- a/app/views/tag/_replication.html.erb
+++ b/app/views/tag/_replication.html.erb
@@ -26,6 +26,24 @@
   </p>
   <% end %>
 
+  <% unless @node.has_power_tag('category') %>
+  <p class="category">
+    What <a href="/wiki/activity-categories">kind of <%= response_type %></a> is it?
+    <% ['build','verify','observe','test-limits','field-test','experiment','monitor'].each do |tag| %>
+      <a class="btn btn-sm btn-default" href="javascript:void()" onClick="addTag('category:<%= tag %>');$('.quiz .category').hide()"><%= tag %></a>
+    <% end %>
+  </p>
+  <% end %>
+
+  <% unless @node.has_power_tag('status') %>
+  <p class="status">
+    What is it's current <a href="/wiki/activity-categories#Status">status</a>?
+    <% ['build','verify','observe','test-limits','field-test','experiment','monitor'].each do |tag| %>
+      <a class="btn btn-sm btn-default" href="javascript:void()" onClick="addTag('status:<%= tag %>');$('.quiz .status').hide()"><%= tag %></a>
+    <% end %>
+  </p>
+  <% end %>
+
 </div>
 
 <hr />


### PR DESCRIPTION

* [ ] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added
