### PR TITLE
Manually download phantomjs for reliability of tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ LABEL "This image deploys Plots2."
 # Set correct environment variables.
 RUN mkdir -p /app
 ENV HOME /root
+ENV PHANTOMJS_VERSION 2.1.1 
 
 # Install dependencies
-RUN apt-get update -qq && apt-get install -y bundler libmysqlclient-dev ruby-rmagick libfreeimage3 nodejs-legacy npm
+RUN apt-get update -qq && apt-get install -y bundler libmysqlclient-dev ruby-rmagick libfreeimage3 nodejs-legacy npm wget
+RUN wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; tar -xvf /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C /opt ; cp /opt/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin/* /usr/local/bin/
 RUN npm install -g bower
 
 # Install bundle of gems


### PR DESCRIPTION
This should make tests more reliable, by installing phantomjs manually from github binary release instead of automatically. Ideally we should use a phantomjs Debian package for jessie (Debian 8).

* [x] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Thanks!

