### PR TITLE
Remove banners from sidebar of /questions page

### DIFF
--- a/app/views/sidebar/_user.html.erb
+++ b/app/views/sidebar/_user.html.erb
@@ -1,9 +1,11 @@
 <div class="col-md-3">
 
   <%= render :partial => "sidebar/post_button" %>
-
-  <%= feature('sidebar-feature') %>
-
+  
+  <% if params[:controller] != 'questions' %>
+    <%= feature('sidebar-feature') %>
+  <% end %>
+  
   <div class="hidden-xs hidden-sm">
     <p><i class="fa fa-envelope"></i> <a href="/lists"><%= t('sidebar._user.discussion_list') %> &raquo;</a></p>
     <p><%= t('sidebar._user.work_happens_on_discussion_lists') %> <a href="/lists"><%= t('sidebar._user.join_one_today') %></a></p>


### PR DESCRIPTION
Added conditional logic to _user.html.erb template to prevent banner from showing on questions page.

* [x] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added
