### PR TITLE
Replaced pipes in the typeahead method with 2 spaces (&nbsp;) - "in progress"

### DIFF
--- a/app/controllers/questions_search_controller.rb
+++ b/app/controllers/questions_search_controller.rb
@@ -40,8 +40,8 @@ class QuestionsSearchController < ApplicationController
       link = "<i data-url='" + match.path(:question) + 
              "' class='fa fa-question-circle'></i> " + match.title
       author = "<span class='pull-right'><i class='fa fa-user'></i> " + match.author.name
-      likes = " | <i class='fa fa-star'></i> " + match.cached_likes.to_s
-      answers = " | <i class='fa fa-comments'></i> " + match.answers.length.to_s + "</span>"
+      likes = " &nbsp; &nbsp; <i class='fa fa-star'></i> " + match.cached_likes.to_s
+      answers = " &nbsp; &nbsp; <i class='fa fa-comments'></i> " + match.answers.length.to_s + "</span>"
       matches << link + author + likes + answers
     end
     render :json => matches


### PR DESCRIPTION
Hi!
I have attempted to resolve this issue by replacing the pipes in the typeahead method with a 'few' spaces...I replaced each pipe with 2 &nbsp;. 

After responding to this issue with a request to give it a shot...I realized my local environment is apparently not setup correctly yet as I do not have rvm installed locally and tests did not seem to want to run either. So I apologize for jumping the gun and wanting to contribute without realizing whether or not my system was set up correctly!
Sandy


Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!

