### PR TITLE
failing integration test for executing advanced search

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,8 +134,6 @@ Plots2::Application.routes.draw do
   match 'questions_search/typeahead/:id' => 'questions_search#typeahead'
 
   #Search Pages
-  # match 'search' => 'searches#new'
-  # match 'search/advanced' => 'searches#new'
   match 'search/advanced/:id' => 'searches#new'
   match 'search/dynamic' => 'searches#dynamic'
   match 'search/dynamic/:id' => 'searches#dynamic'
@@ -143,7 +141,9 @@ Plots2::Application.routes.draw do
   match 'search/questions/:id' => 'searches#questions'
   match 'search/questions_typeahead/:id' => 'searches#questions_typeahead'
   match 'search/:id' => 'searches#normal_search'
-
+  match 'search/advanced' => 'searches#new'
+  match 'search' => 'searches#new'
+  
   # Question Search capability--temporary until combined with full Search Capabilities
   match 'questions_search/:id' => 'questions_search#index'
   match 'questions_search/typeahead/:id' => 'questions_search#typeahead'

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -3,7 +3,7 @@ production:
     hostname: localhost
     port: 8983
     log_level: WARNING
-    path: /solr/default
+    path: /solr/production
     # read_timeout: 2
     # open_timeout: 0.5
 
@@ -22,4 +22,3 @@ test:
     log_level: WARNING
     path: /solr/test
   disabled: true
-    

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class SearchFlowTest < ActionDispatch::IntegrationTest
+
+  test "advanced search basic test" do
+    # "key_words"=>"post", "main_type"=>"Notes or Wiki updates", "language"=>"", "min_date"=>"", "max_date"=>""
+
+    get '/searches/new'
+
+    assert_response :success
+
+    post '/searches', 
+         key_words: "blog",
+         main_type: "Notes or Wiki updates"
+
+    assert_response :success
+
+    get '/searches/new'
+
+    assert_response :success
+
+  end
+
+end

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -1,22 +1,28 @@
 require 'test_helper'
 
+# Test the get/post actions for the search forms
 class SearchFlowTest < ActionDispatch::IntegrationTest
 
   test "advanced search basic test" do
     # "key_words"=>"post", "main_type"=>"Notes or Wiki updates", "language"=>"", "min_date"=>"", "max_date"=>""
-
-    get '/searches/new'
-
+    
+    # Perform a URL GET search with a search term
+    get '/search/map'
     assert_response :success
 
-    post '/searches', 
+    # Perform a URL GET search without a term
+    get '/search'
+    assert_response :success
+
+    # Perform a POST search submission without a term
+    post '/search', 
          key_words: "blog",
          main_type: "Notes or Wiki updates"
 
     assert_response :success
-
-    get '/searches/new'
-
+ 
+    #  Perform a GET search call to advanced without a search term
+    get '/search/advanced'
     assert_response :success
 
   end

--- a/test/solr/searches_controller_test.rb
+++ b/test/solr/searches_controller_test.rb
@@ -27,6 +27,7 @@ class SearchesControllerTest < ActionController::TestCase
     assert_equal 'Advanced search', @advanced_search.title
   end
 
+  # initial advanced search page
   test 'should get new' do
     get :new
     assert_response :success


### PR DESCRIPTION
I've written a test demonstrating the problem in #854 -- and likely in #800:

@ujithaperera and @david-days -- any ideas on how to address this? The error is specifically:

```
Started POST "/searches" for 127.0.0.1 at 2016-09-30 13:25:29 -0400
Processing by SearchesController#create as HTML
  Parameters: {"utf8"=>"�", "authenticity_token"=>"KhB183d+stcIMHAdwE66BWPdZgDtPU5emZQ4Scpl/NA=", "search_record"=>{"key_words"=>"post", "main_type"=>"Notes or Wiki updates", "language"=>"", "min_date"=>"", "max_date"=>""}}
Geokit is using the domain: localhost
  Rendered text template (0.1ms)
Completed 400 Bad Request in 35.2ms (Views: 14.4ms | ActiveRecord: 0.0ms | Solr: 0.0ms)
```

* [ ] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
