### PR TITLE
Fix for lead images in node subscriptions

### DIFF
--- a/app/views/subscription_mailer/notify_node_creation.html.erb
+++ b/app/views/subscription_mailer/notify_node_creation.html.erb
@@ -10,7 +10,7 @@
 
 <hr /> 
 
-<% if @node.main_image %><a style="margin-bottom:10px;" href="https:<%= @node.main_image.path(:original) %>"><img src="https:<%= @node.main_image.path(:default) %>" /></a><% end %>
+<% if @node.main_image %><a style="margin-bottom:10px;" href="https:<%= @node.main_image.path(:original) %>"><img src="<%= @node.main_image.path(:default) %>" /></a><% end %>
 
 <%= raw auto_link(@node.latest.render_body_email(ActionMailer::Base.default_url_options[:host]), :sanitize => false) %>
 


### PR DESCRIPTION
- [x] All tests pass -- `rake test:all`
- [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
- [x] pull request are descriptively named
- [x] if possible, multiple commits squashed if they're smaller changes
- [x] reviewed/confirmed/tested by another contributor or maintainer
