### PR TITLE
advanced search form testing, closes #895

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -86,8 +86,13 @@ class SearchesController < ApplicationController
     end
 
     def search_params
-      params.require(:search).permit(:key_words, :main_type, :note_type,
-                                     :min_date, :max_date, :created_by, :language)
+      params.permit( :key_words,
+                     :main_type,
+                     :note_type,
+                     :min_date,
+                     :max_date,
+                     :created_by,
+                     :language )
     end
 
 end

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for @search, url: @search.persisted? ? search_path(@search) : searches_path, class: 'navbar-form' do |f|%>
 
   <div class="form-group form-inline">
-    <%= f.text_field :key_words, class: 'search-query form-control' %>
+    <%= f.text_field :search, class: 'search-query form-control' %>
     <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
   </div>
 

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for @search, url: @search.persisted? ? search_path(@search) : searches_path, class: 'navbar-form' do |f|%>
 
   <div class="form-group form-inline">
-    <%= f.text_field :search, class: 'search-query form-control' %>
+    <%= f.text_field :key_words, class: 'search-query form-control' %>
     <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
   </div>
 

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -25,6 +25,21 @@ class SearchFlowTest < ActionDispatch::IntegrationTest
     get '/search/advanced'
     assert_response :success
 
+    post '/search',
+         "search_record" => {
+           key_words: 'post', 
+           main_type: 'Notes or Wiki updates'
+         }
+
+    assert_response :success
+
+    # https://publiclab.org/searches?search=spec
+
+    post '/search',
+         search: 'spec'
+
+    assert_response :success
+
   end
 
 end

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -33,10 +33,10 @@ class SearchFlowTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    # https://publiclab.org/searches?search=spec
+    # https://publiclab.org/searches?key_words=spec
 
     post '/search',
-         search: 'spec'
+         key_words: 'spectrom'
 
     assert_response :success
 


### PR DESCRIPTION
Related to work in #895

* [ ] all tests pass -- `rake test:all`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please feel free to adopt #895 and pick up from where this PR leaves off!