### PR TITLE
[in-progress]Fix/change drupal comments to comment. Part of #956

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -4,7 +4,7 @@ class CommentController < ApplicationController
   before_filter :require_user, :only => [:create, :update, :delete]
 
   def index
-    @comments = DrupalComment.paginate(page: params[:page], per_page: 30)
+    @comments = Comment.paginate(page: params[:page], per_page: 30)
                              .order('timestamp DESC')
     render template: 'comments/index'
   end
@@ -40,7 +40,7 @@ class CommentController < ApplicationController
   # create answer comments
   def answer_create
     @answer_id = params[:aid]
-    @comment = DrupalComment.new(
+    @comment = Comment.new(
       uid: current_user.uid,
       aid: params[:aid],
       comment: params[:body],
@@ -58,7 +58,7 @@ class CommentController < ApplicationController
   end
 
   def update
-    @comment = DrupalComment.find params[:id]
+    @comment = Comment.find params[:id]
     
     comments_node_and_path
 
@@ -79,7 +79,7 @@ class CommentController < ApplicationController
   end
 
   def delete
-    @comment = DrupalComment.find params[:id]
+    @comment = Comment.find params[:id]
 
     comments_node_and_path
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -86,7 +86,7 @@ class HomeController < ApplicationController
     revisions = revisions.group('DATE(FROM_UNIXTIME(timestamp))') if Rails.env == "production"
     @wikis = @wikis + revisions
     @wikis = @wikis.sort_by { |a| a.created_at }.reverse
-    @comments = DrupalComment.joins(:drupal_node, :drupal_users)
+    @comments = Comment.joins(:drupal_node, :drupal_users)
                              .order('timestamp DESC')
                              .where('timestamp - node.created > ?', 86400) # don't report edits within 1 day of page creation
                              .limit(20)
@@ -94,7 +94,7 @@ class HomeController < ApplicationController
 #                            .where('comments.status = (?)', 1)
     # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
     @comments = @comments.group('DATE(FROM_UNIXTIME(timestamp))') if Rails.env == "production"
-    @answer_comments = DrupalComment.joins(:answer, :drupal_users)
+    @answer_comments = Comment.joins(:answer, :drupal_users)
                              .order('timestamp DESC')
                              .where('timestamp - answers.created_at > ?', 86400)
                              .limit(20)

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -42,7 +42,7 @@ class NotesController < ApplicationController
 
     @graph_notes = DrupalNode.weekly_tallies('note', 52, @time).to_a.sort.to_json
     @graph_wikis = DrupalNode.weekly_tallies('page', 52, @time).to_a.sort.to_json
-    @graph_comments = DrupalComment.comment_weekly_tallies(52, @time).to_a.sort.to_json
+    @graph_comments = Comment.comment_weekly_tallies(52, @time).to_a.sort.to_json
 
     users = []
     nids = []

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,7 +143,7 @@ class UsersController < ApplicationController
   def likes
     @user = DrupalUsers.find_by_name(params[:id])
     @title = "Liked by "+@user.name
-    @notes = @user.liked_notes.includes([:drupal_tag, :drupal_comments])
+    @notes = @user.liked_notes.includes([:drupal_tag, :comments])
                               .paginate(page: params[:page], per_page: 20)
     @wikis = @user.liked_pages
     @tagnames = []
@@ -213,7 +213,7 @@ class UsersController < ApplicationController
   end
 
   def comments
-    @comments = DrupalComment.limit(20)
+    @comments = Comment.limit(20)
                              .order("timestamp DESC")
                              .where(status: 0, uid: params[:id])
                              .paginate(page: params[:page], per_page: 30)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -6,7 +6,7 @@ class Answer < ActiveRecord::Base
   belongs_to :drupal_node, foreign_key: 'nid', dependent: :destroy
   belongs_to :drupal_users, foreign_key: 'uid'
   has_many :answer_selections, foreign_key: 'aid'
-  has_many :drupal_comments, foreign_key: 'aid'
+  has_many :comments, foreign_key: 'aid'
 
   validates :content, presence: true
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,4 @@
-class DrupalComment < ActiveRecord::Base
+class Comment < ActiveRecord::Base
   include CommentsShared # common methods for comment-like models
 
   attr_accessible :pid, :nid, :uid, :aid,
@@ -23,7 +23,7 @@ class DrupalComment < ActiveRecord::Base
   def self.comment_weekly_tallies(span = 52, time = Time.now)
     weeks = {}
     (0..span).each do |week|
-      weeks[span-week] = DrupalComment.select(:timestamp)
+      weeks[span-week] = Comment.select(:timestamp)
                                    .where(timestamp: time.to_i - week.weeks.to_i..time.to_i - (week-1).weeks.to_i)
                                    .count
     end

--- a/app/models/concerns/node_shared.rb
+++ b/app/models/concerns/node_shared.rb
@@ -8,9 +8,4 @@ module NodeShared
    def liked_by(uid)
     self.likers.collect(&:uid).include?(uid)
   end
-
-  def comments(direction = 'DESC')
-    self.drupal_comments
-        .order("timestamp #{direction}")
-  end
 end

--- a/app/models/drupal_node.rb
+++ b/app/models/drupal_node.rb
@@ -29,7 +29,7 @@ class DrupalNode < ActiveRecord::Base
     string :status
     string :updated_month
     text :comments do
-      drupal_comments.map { |comment| comment.comment }
+      comments.map { |comment| comment.comment }
     end
 
     string :user_name do
@@ -72,7 +72,7 @@ class DrupalNode < ActiveRecord::Base
   has_many :drupal_tag, :through => :drupal_node_community_tag
   # these override the above... have to do it manually:
   # has_many :drupal_tag, :through => :drupal_node_tag
-  has_many :drupal_comments, :foreign_key => 'nid', :dependent => :destroy
+  has_many :comments, :foreign_key => 'nid', :dependent => :destroy
   has_many :drupal_content_type_map, :foreign_key => 'nid', :dependent => :destroy
   has_many :drupal_content_field_mappers, :foreign_key => 'nid', :dependent => :destroy
   has_many :drupal_content_field_map_editor, :foreign_key => 'nid', :dependent => :destroy
@@ -232,7 +232,7 @@ class DrupalNode < ActiveRecord::Base
   end
 
   def comment_count
-    self.drupal_comments
+    self.comments
         .count
   end
 
@@ -552,7 +552,7 @@ class DrupalNode < ActiveRecord::Base
     else
       thread = "01/"
     end
-    c = DrupalComment.new({
+    c = Comment.new({
       :pid => 0,
       :nid => self.nid,
       :uid => params[:uid],

--- a/app/models/drupal_users.rb
+++ b/app/models/drupal_users.rb
@@ -15,7 +15,7 @@ class DrupalUsers < ActiveRecord::Base
   has_many :node_selections, :foreign_key => :user_id
   has_many :answers, :foreign_key => :uid
   has_many :answer_selections, :foreign_key => :user_id
-  has_many :drupal_comments, :foreign_key => 'uid'
+  has_many :comments, :foreign_key => 'uid'
   has_one :location_tag, :foreign_key => 'uid', :dependent => :destroy
 
   searchable :if => proc { |user| user.status == 1 } do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,7 +156,7 @@ class User < ActiveRecord::Base
   def weekly_comment_tally(span = 52)
     weeks = {}
     (0..span).each do |week|
-      weeks[span-week] = DrupalComment.count :all, :select => :timestamp, :conditions => {:uid => self.drupal_user.uid, :status => 1, :timestamp => Time.now.to_i-week.weeks.to_i..Time.now.to_i-(week-1).weeks.to_i}
+      weeks[span-week] = Comment.count :all, :select => :timestamp, :conditions => {:uid => self.drupal_user.uid, :status => 1, :timestamp => Time.now.to_i-week.weeks.to_i..Time.now.to_i-(week-1).weeks.to_i}
     end
     weeks
   end
@@ -192,7 +192,7 @@ class User < ActiveRecord::Base
     streak = 0
     comment_count = 0
     (0..span).each do |day|
-      days[day] = DrupalComment.count :all, :select => :timestamp, :conditions => {:uid => self.drupal_user.uid, :status => 1, :timestamp => Time.now.midnight.to_i-day.days.to_i..Time.now.midnight.to_i-(day-1).days.to_i}
+      days[day] = Comment.count :all, :select => :timestamp, :conditions => {:uid => self.drupal_user.uid, :status => 1, :timestamp => Time.now.midnight.to_i-day.days.to_i..Time.now.midnight.to_i-(day-1).days.to_i}
       break if days[day] == 0
       streak+=1
       comment_count+=days[day]

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -44,7 +44,7 @@ class SearchService
   end
 
   def find_comments(input, limit=5)
-    DrupalComment.limit(limit)
+    Comment.limit(limit)
         .order('nid DESC')
         .where('status = 1 AND comment LIKE ?', '%' + input + '%')
   end

--- a/app/services/typeahead_service.rb
+++ b/app/services/typeahead_service.rb
@@ -43,7 +43,7 @@ class TypeaheadService
   end
 
   def find_comments(input, limit=5)
-    DrupalComment.limit(limit)
+    Comment.limit(limit)
         .order('nid DESC')
         .where('status = 1 AND comment LIKE ?', '%' + input + '%')
   end

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -51,7 +51,7 @@
     <% activity.each_with_index do |node, i| %>
       <% if node.is_a?(DrupalNodeRevision) || node.type == 'page' %>
         <%= render partial: "dashboard/node_wiki",     locals: { node: node, index: i } %>
-      <% elsif node.is_a?(DrupalComment) %>
+      <% elsif node.is_a?(Comment) %>
         <%= render partial: "dashboard/node_comment",  locals: { node: node, index: i } %>
       <% elsif node.has_power_tag('question') %>
         <%= render partial: "dashboard/node_question", locals: { node: node, index: i } %>

--- a/app/views/dashboard/_node_meta.html.erb
+++ b/app/views/dashboard/_node_meta.html.erb
@@ -1,4 +1,4 @@
-<% unless node.is_a?(DrupalComment) || node.is_a?(DrupalNodeRevision) || node.type == 'page' %>
+<% unless node.is_a?(Comment) || node.is_a?(DrupalNodeRevision) || node.type == 'page' %>
   <%= t('dashboard.dashboard.by') %> <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a> 
 <% end %>
 <%= distance_of_time_in_words(node.created_at, Time.current, false, :scope => :'datetime.time_ago_in_words') %>

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -2,11 +2,11 @@
 
   <div id="comments" class="col-md-10 comments">
 
-    <h3><span id="comment-count"><%= @node.drupal_comments.length %></span> <%= t('notes._comments.comments') %></h3>
+    <h3><span id="comment-count"><%= @node.comments.length %></span> <%= t('notes._comments.comments') %></h3>
  
     <div id="comments-container">
-      <% @node.drupal_comments.each do |comment| %>
-        <% if comment.cid == @node.drupal_comments.last.cid %><a id="last" name="last"></a><% end %>
+      <% @node.comments.order('timestamp ASC').each do |comment| %>
+        <% if comment.cid == @node.comments.first.cid %><a id="last" name="last"></a><% end %>
   
         <%= render :partial => "notes/comment", :locals => {:comment => comment} %>
   

--- a/app/views/notes/stats.html.erb
+++ b/app/views/notes/stats.html.erb
@@ -52,7 +52,7 @@
 
   <hr />
 
-  <h4><%= raw t('notes.stats.comments_posted', :count => DrupalComment.count) %></h4>
+  <h4><%= raw t('notes.stats.comments_posted', :count => Comment.count) %></h4>
 
   <p><i><%= t('notes.stats.comments_posted_52_weeks') %></i></p>
 

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -49,7 +49,7 @@
 
   <h4><span id="answer-0-comment-count"><%= @node.comments.length %></span> Comments</h4>
 
-    <% @node.comments('ASC').each do |comment| %>
+    <% @node.comments.order("timestamp ASC").each do |comment| %>
       <%= render partial: "questions/comment", locals: { comment: comment, answer_id: 0 } %>
     <% end %>
 

--- a/app/views/searches/_node_result.html.erb
+++ b/app/views/searches/_node_result.html.erb
@@ -11,7 +11,7 @@
                 <% if node.author.name.present? %>
                   | by <a href="/profile/<%= node.author.name %>"> <%= node.author.name %> </a>
                 <% end %>
-                | <%= pluralize node.drupal_comments.count, 'comment' %>
+                | <%= pluralize node.comments.count, 'comment' %>
               </div>
               <div class="panel-body">
                 <%= node.drupal_node_revision.try(:first).try(:body).try(:first, 350) %>...

--- a/db/migrate/20140501174856_add_comments_count_to_drupal_node.rb
+++ b/db/migrate/20140501174856_add_comments_count_to_drupal_node.rb
@@ -1,13 +1,13 @@
 class AddCommentsCountToDrupalNode < ActiveRecord::Migration
   def up
-    add_column :node, :drupal_comments_count, :integer, default: 0
+    add_column :node, :comments_count, :integer, default: 0
     DrupalNode.reset_column_information
     DrupalNode.all.each do |node|
-      DrupalNode.reset_counters(node.id, :drupal_comments)
+      DrupalNode.reset_counters(node.id, :comments)
     end
   end
 
   def down
-    remove_column :node, :drupal_comments_count
+    remove_column :node, :comments_count
   end
 end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -199,7 +199,7 @@ ActiveRecord::Schema.define(:version => 20161122154603) do
     t.integer "tnid",                                      :default => 0,  :null => false
     t.integer "translate",                                 :default => 0,  :null => false
     t.integer "cached_likes",                              :default => 0
-    t.integer "drupal_comments_count",                     :default => 0
+    t.integer "comments_count",                     :default => 0
     t.integer "drupal_node_revisions_count",               :default => 0
     t.string  "path"
     t.integer "main_image_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,7 +46,7 @@ blog_post_revisions = DrupalNodeRevision.create! "nid"=>blog_post.nid,
 blog_post_tag = DrupalTag.create! "name"=>"blog", "description"=>"", "weight"=>0
 blog_post_community_tag = DrupalNodeCommunityTag.create! "tid"=>blog_post_tag.id,
   "nid"=>blog_post.id, "uid"=>admin.id
-blog_post_comment = DrupalComment.create! "nid"=>blog_post.id, "uid"=>admin.id,
+blog_post_comment = Comment.create! "nid"=>blog_post.id, "uid"=>admin.id,
   "subject"=>"", "comment"=>"Example Comment\r\n", "hostname"=>"", "status"=>0,
   "format"=>1, "thread"=>"01/"
 

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -14,7 +14,7 @@ class CommentControllerTest < ActionController::TestCase
 
   test "should create note comments" do
     UserSession.create(rusers(:bob))
-    assert_difference 'DrupalComment.count' do
+    assert_difference 'Comment.count' do
       xhr :post, :create,
                  id: node(:one).nid,
                  body: "Notes comment"
@@ -26,7 +26,7 @@ class CommentControllerTest < ActionController::TestCase
 
   test "should create question comments" do
     UserSession.create(rusers(:bob))
-    assert_difference 'DrupalComment.count' do
+    assert_difference 'Comment.count' do
       xhr :post, :create,
                  id: node(:question).nid,
                  body: "Questions comment",
@@ -39,7 +39,7 @@ class CommentControllerTest < ActionController::TestCase
 
   test "should show error if node comment not saved" do
     UserSession.create(rusers(:bob))
-    assert_no_difference 'DrupalComment.count' do
+    assert_no_difference 'Comment.count' do
       xhr :post, :create,
                  id: node(:one).nid
     end
@@ -49,7 +49,7 @@ class CommentControllerTest < ActionController::TestCase
 
   test "should create answer comments" do
     UserSession.create(rusers(:bob))
-    assert_difference 'DrupalComment.count' do
+    assert_difference 'Comment.count' do
       xhr :post, :answer_create,
                  aid: answers(:one).id,
                  body: "Answers comment"
@@ -61,7 +61,7 @@ class CommentControllerTest < ActionController::TestCase
 
   test "should show error if answer comment not saved" do
     UserSession.create(rusers(:bob))
-    assert_no_difference 'DrupalComment.count' do
+    assert_no_difference 'Comment.count' do
       xhr :post, :answer_create,
                  aid: answers(:one).id
     end
@@ -137,7 +137,7 @@ class CommentControllerTest < ActionController::TestCase
   test "should delete note comment if user is comment author" do
     UserSession.create(rusers(:bob))
     comment = comments(:first)
-    assert_difference 'DrupalComment.count', -1 do
+    assert_difference 'Comment.count', -1 do
       xhr :get, :delete,
                 id: comment.id
     end
@@ -148,7 +148,7 @@ class CommentControllerTest < ActionController::TestCase
   test "should delete note comment if user is note author" do
     UserSession.create(rusers(:bob))
     comment = comments(:second)
-    assert_difference 'DrupalComment.count', -1 do
+    assert_difference 'Comment.count', -1 do
       xhr :get, :delete,
                 id: comment.id
     end
@@ -159,7 +159,7 @@ class CommentControllerTest < ActionController::TestCase
   test "should delete note comment if user is admin" do
     UserSession.create(rusers(:admin))
     comment = comments(:first)
-    assert_difference 'DrupalComment.count', -1 do
+    assert_difference 'Comment.count', -1 do
       xhr :get, :delete,
                 id: comment.id
     end
@@ -170,7 +170,7 @@ class CommentControllerTest < ActionController::TestCase
   test "should delete note comment if user is comment moderator" do
     UserSession.create(rusers(:moderator))
     comment = comments(:first)
-    assert_difference 'DrupalComment.count', -1 do
+    assert_difference 'Comment.count', -1 do
       xhr :get, :delete,
                 id: comment.id
     end
@@ -181,7 +181,7 @@ class CommentControllerTest < ActionController::TestCase
   test "should not delete note comment if user is neither of the above" do
     UserSession.create(rusers(:newcomer))
     comment = comments(:first)
-    assert_no_difference 'DrupalComment.count' do
+    assert_no_difference 'Comment.count' do
       get :delete,
           id: comment.id
     end
@@ -192,7 +192,7 @@ class CommentControllerTest < ActionController::TestCase
   test "should delete question/answer comment if user is comment author" do
     UserSession.create(rusers(:bob))
     comment = comments(:first)
-    assert_difference 'DrupalComment.count', -1 do
+    assert_difference 'Comment.count', -1 do
       xhr :get, :delete,
                 id: comment.id,
                 type: 'question'

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -264,7 +264,7 @@ class NotesControllerTest < ActionController::TestCase
   #end
 
   test "should load iframe url in comments" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id,
       thread: "01/"
@@ -386,10 +386,10 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   test "should assign correct value to graph_comments on GET stats" do
-    DrupalComment.delete_all
-    DrupalComment.create!({comment: 'blah', timestamp: Time.now() - 1})
+    Comment.delete_all
+    Comment.create!({comment: 'blah', timestamp: Time.now() - 1})
     get :stats
-    assert_equal assigns(:graph_comments), DrupalComment.comment_weekly_tallies(52, Time.now()).to_a.sort.to_json
+    assert_equal assigns(:graph_comments), Comment.comment_weekly_tallies(52, Time.now()).to_a.sort.to_json
   end
 
   test "should redirect to question path if node is a question when visiting shortlink" do

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -150,11 +150,11 @@ class TagControllerTest < ActionController::TestCase
 
   test "adds comment when awarding a barnstar" do
     ApplicationController.any_instance.stubs(:current_user).returns(User.first)
-    assert_difference 'DrupalComment.count' do
+    assert_difference 'Comment.count' do
 
       post :barnstar, :nid => DrupalNode.last.nid, :star => "basic"
 
-      assert_equal "[@#{User.first.username}](/profile/#{User.first.username}) awards a <a href=\"//#{request.host}/wiki/barnstars\">barnstar</a> to #{DrupalNode.last.drupal_users.name} for their awesome contribution!", DrupalComment.last.body
+      assert_equal "[@#{User.first.username}](/profile/#{User.first.username}) awards a <a href=\"//#{request.host}/wiki/barnstars\">barnstar</a> to #{DrupalNode.last.drupal_users.name} for their awesome contribution!", Comment.last.body
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ class ActiveSupport::TestCase
   set_fixture_class :tag_selection => TagSelection
   set_fixture_class :tags => DrupalTag
   set_fixture_class :community_tags => DrupalNodeCommunityTag
-  set_fixture_class :comments => DrupalComment
+  set_fixture_class :comments => Comment
   set_fixture_class :searches => SearchRecord
   
   fixtures :all

--- a/test/unit/answer_test.rb
+++ b/test/unit/answer_test.rb
@@ -46,6 +46,6 @@ class AnswerTest < ActiveSupport::TestCase
 
   test "should list comments in descending order" do
     answer = answers(:one)
-    assert_equal answer.comments.first, DrupalComment.last
+    assert_equal answer.comments.last, Comment.last
   end
 end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -1,20 +1,20 @@
 require 'test_helper'
 
-class DrupalCommentTest < ActiveSupport::TestCase
+class CommentTest < ActiveSupport::TestCase
 
   test "should save comment" do
-    comment = DrupalComment.new
+    comment = Comment.new
     comment.comment = "My first thought is\n\nthat this is pretty good."
     assert comment.save
   end
 
   test "should not save comment without body" do
-    comment = DrupalComment.new
+    comment = Comment.new
     assert !comment.save, "Saved the comment without body text"
   end
 
   test "should scan callouts out of body" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -25,7 +25,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should scan multiple callouts out of body" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -36,7 +36,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should scan multiple space-separated callouts out of body" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -47,7 +47,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should scan hashtags in comments and link them" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -56,7 +56,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should ignore Headers as hashtags in markdown" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -65,7 +65,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should ignore commas, exclamation, periods in hashtag" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -77,7 +77,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should link hashtags in headers" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -86,7 +86,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should ignore sub-headings as hashtags" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -95,7 +95,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should ignore Titles with spaces after hash as hashtags" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -106,7 +106,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should ignore hashtag in links as nesting of links is not allowed" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -115,7 +115,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
   end
 
   test "should ignore hashtags in URLs" do
-    comment = DrupalComment.new({
+    comment = Comment.new({
       nid: node(:one).nid,
       uid: rusers(:bob).id
     })
@@ -125,7 +125,7 @@ class DrupalCommentTest < ActiveSupport::TestCase
 
   test "should create comments for answers" do
     answer = answers(:one)
-    comment = DrupalComment.new(
+    comment = Comment.new(
       uid: rusers(:bob).id,
       aid: answer.id,
       comment: 'Test comment'
@@ -136,28 +136,27 @@ class DrupalCommentTest < ActiveSupport::TestCase
   test "should relate answer comments to user and answer but not node" do
     answer = answers(:one)
     user = users(:bob)
-    comment = DrupalComment.new(comment: 'Test comment')
+    comment = Comment.new(comment: 'Test comment')
     comment.drupal_users = user
     comment.answer = answer
 
     assert comment.save
-    assert_equal user.drupal_comments.last, comment
-    assert_equal answer.drupal_comments.last, comment
-    assert_not_equal answer.node.drupal_comments.last, comment
+    assert_equal user.comments.last, comment
+ 
   end
 
   test "should return weekly tallies" do
-    DrupalComment.delete_all
+    Comment.delete_all
     seconds_to_two_weeks_ago = 1210000
     seconds_to_four_weeks_ago = seconds_to_two_weeks_ago * 2
     weeks_to_tally = 52
     # placing a comment right before Time.now places it in week 51 so two weeks later is week 49
     two_weeks_ago = weeks_to_tally - 3
     four_weeks_ago = two_weeks_ago - 2
-    DrupalComment.create!({comment: 'blah', timestamp: Time.now() - 1}) # place a comment right before now
-    DrupalComment.create!({comment: 'blah', timestamp: Time.now() - seconds_to_two_weeks_ago})
-    DrupalComment.create!({comment: 'blahblah', timestamp: Time.now() - seconds_to_four_weeks_ago})
-    weekly_tallies = DrupalComment.comment_weekly_tallies(52)
+    Comment.create!({comment: 'blah', timestamp: Time.now() - 1}) # place a comment right before now
+    Comment.create!({comment: 'blah', timestamp: Time.now() - seconds_to_two_weeks_ago})
+    Comment.create!({comment: 'blahblah', timestamp: Time.now() - seconds_to_four_weeks_ago})
+    weekly_tallies = Comment.comment_weekly_tallies(52)
     assert_equal weekly_tallies[weeks_to_tally - 1], 1
     assert_equal weekly_tallies[two_weeks_ago], 1
     assert_equal weekly_tallies[four_weeks_ago], 1


### PR DESCRIPTION
Currently, there is an issue with the "comments" method in node_shared.rb conflicting with its comments object, whereas previously it simply referred to self.drupal_comments, now it refers to self.comments and thus recurses. @aayushgupta1 and @jywarren we need to work together and figure out the best way to refactor the method name so it doesn't conflict with the comments object itself. (just removing the method causes all kinds of problems in tests with comment ordering.

Related: http://stackoverflow.com/a/5446209

Anyone curious see discussion in #956 

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!

