### PR TITLE
removing indices for #1003

### DIFF
--- a/db/migrate/20161122154603_remove_friendly_id_indices.rb
+++ b/db/migrate/20161122154603_remove_friendly_id_indices.rb
@@ -1,0 +1,10 @@
+class RemoveFriendlyIdIndices < ActiveRecord::Migration
+  def up
+    remove_index :friendly_id_slugs, :sluggable_id
+    remove_index :friendly_id_slugs, [:slug, :sluggable_type]
+    remove_index :friendly_id_slugs, :sluggable_type
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161009024807) do
+ActiveRecord::Schema.define(:version => 20161122154603) do
 
   create_table "answer_selections", :force => true do |t|
     t.integer "user_id"
@@ -153,10 +153,6 @@ ActiveRecord::Schema.define(:version => 20161009024807) do
     t.string   "sluggable_type", :limit => 40
     t.datetime "created_at"
   end
-
-  add_index "friendly_id_slugs", ["slug", "sluggable_type"], :name => "index_friendly_id_slugs_on_slug_and_sluggable_type", :unique => true
-  add_index "friendly_id_slugs", ["sluggable_id"], :name => "index_friendly_id_slugs_on_sluggable_id"
-  add_index "friendly_id_slugs", ["sluggable_type"], :name => "index_friendly_id_slugs_on_sluggable_type"
 
   create_table "images", :force => true do |t|
     t.string   "title"


### PR DESCRIPTION
* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added
