### PR TITLE
Added first timers badge to README as per GCI task - Fixes #1012 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ PublicLab.org
 ======
 
 [![Build Status](https://travis-ci.org/publiclab/plots2.svg)](https://travis-ci.org/publiclab/plots2)
+[![badge](http://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square)](https://github.com/publiclab/plots2/projects/2)
 
 The content management system for the Public Lab research community, the plots2 web application is a combination of a group research blog of what we call "research notes" and a wiki. 
 


### PR DESCRIPTION
As per the GCI task: https://codein.withgoogle.com/dashboard/task-instances/4907900732440576/

Added the "first timers" badge next to the "build passing" badge to the README from http://www.firsttimersonly.com/

Before: 
<img width="998" alt="screen shot 2016-12-01 at 12 25 58 pm" src="https://cloud.githubusercontent.com/assets/21118039/20784630/98f1807a-b7c1-11e6-8d6b-7799838fd98d.png">


After:
<img width="990" alt="screen shot 2016-12-01 at 12 25 25 pm" src="https://cloud.githubusercontent.com/assets/21118039/20784632/9d53f9d6-b7c1-11e6-92d3-9f10a383c578.png">


