### PR TITLE
Add ability to sort wiki index alphabetically (closes #193) 

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -261,9 +261,15 @@ class WikiController < ApplicationController
   def index
     @title = I18n.t('wiki_controller.wiki')
 
+    if params[:order] == 'alphabetic'
+      order_string = "node_revisions.title ASC"
+    else
+      order_string = "node_revisions.timestamp DESC"
+    end
+
     @wikis = DrupalNode.includes(:drupal_node_revision, :drupal_node_counter)
                        .group('node_revisions.nid')
-                       .order("node_revisions.timestamp DESC")
+                       .order(order_string)
                        .where("node_revisions.status = 1 AND node.status = 1 AND (type = 'page' OR type = 'tool' OR type = 'place')")
                        .page(params[:page])
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -34,6 +34,13 @@ class WikiControllerTest < ActionController::TestCase
     assert_not_nil :wikis
   end
 
+  test "should get wiki index in alphabetical order" do
+    get :index, order: 'alphabetic'
+
+    assert_response :success
+    assert_not_nil :wikis
+  end
+
   test "should get raw wiki markup" do
     get :raw, id: node_revisions(:one).id
 


### PR DESCRIPTION
Add ability for wiki index to be sorted alphabetically using the `order` get paramater


* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

