### PR TITLE
Remove history graph for wildcard tag display (Fixes #878)

### DIFF
--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -25,7 +25,7 @@
     <p><a class="btn btn-primary" href="/wiki/<%= params[:id] %>"><span class="fa fa-plus fa-white"></span> Add one now</a></p>
   <% end %>
 
-  <% if @tags.first %>
+  <% if @tags.first && params[:id][-1..-1] != "*" %>
   <div id="note-graph" style="height:100px;"></div>
 
   <script type="text/javascript">

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -100,6 +100,15 @@ class TagControllerTest < ActionController::TestCase
     assert_select '#wiki-content', 0
   end
 
+  test "wildcard tag show" do
+    get :show, id: 'question:*'
+    assert :success
+    assert_not_nil :tags
+    assert :wildcard
+
+    assert_select '#note-graph', 0
+  end
+
   test "should show a featured wiki page at top, if it exists" do
     tag = tags(:test)
 


### PR DESCRIPTION
Fixed the issue of the graph showing on wildcard tag display (#878)

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added



