### PR TITLE
#1034: Add node.can_tag to check if given user can powertag a given tagname

### DIFF
--- a/app/models/drupal_node.rb
+++ b/app/models/drupal_node.rb
@@ -779,4 +779,18 @@ class DrupalNode < ActiveRecord::Base
               .where('term_data.name LIKE ?', "upgrade:#{tagname}")
   end
 
+  def can_tag(tagname, user)
+    if tagname[0..4] == "with:"
+      if self.author.uid != user.uid || User.find_by_username(tagname.split(':')[1]).nil? || tagname.split(':')[1] == user.username
+        return false
+      else
+        return true
+      end
+    elsif tagname[0..4] == "rsvp:" && user.username != tagname.split(":")[1]
+      return false
+    else
+      return true
+    end
+  end
+
 end

--- a/test/unit/drupal_node_tag_test.rb
+++ b/test/unit/drupal_node_tag_test.rb
@@ -119,4 +119,73 @@ class DrupalNodeTagTest < ActiveSupport::TestCase
     assert_nil node.tagged_lon
   end
 
+  test "can't powertag with: yourself" do
+    user = rusers(:bob)
+    node =  DrupalNode.new({
+      uid: user.id,
+      type: 'note',
+      title: 'My research note'
+    })
+    tagname = "with:#{user.username}"
+    assert_false node.can_tag(tagname, user)
+  end
+
+  test "can powertag with: another user" do
+    user = rusers(:bob)
+    jeff = rusers(:jeff)
+    node = DrupalNode.new({
+      uid: user.id,
+      type: 'note',
+      title: 'My research note'
+    })
+    tagname = "with:#{jeff.username}"
+    assert node.can_tag(tagname, user)
+  end
+
+  test "can't tag with: a nonexistent user" do
+    user = rusers(:bob)
+    node = DrupalNode.new({
+      uid: user.id,
+      type: 'note',
+      title: 'My research note'
+    })
+    tagname = "with:steven"
+    assert_false node.can_tag(tagname, user)
+  end
+
+  test "can't powertag if you're not author" do
+    user = rusers(:bob)
+    jeff = rusers(:jeff)
+    node = DrupalNode.new({
+      uid: jeff.id,
+      type: 'note',
+      title: 'My research note'
+    })
+    tagname = "with:#{jeff.username}"
+    assert_false node.can_tag(tagname, user)
+  end
+
+  test "can rsvp yourself" do
+    user = rusers(:bob)
+    node = DrupalNode.new({
+      uid: user.id,
+      type: 'note',
+      title: 'My research note'
+    })
+    tagname = "rsvp:#{user.username}"
+    assert node.can_tag(tagname, user)
+  end
+
+  test "can't rsvp someone else" do
+    user = rusers(:bob)
+    jeff = rusers(:jeff)
+    node = DrupalNode.new({
+      uid: user.id,
+      type: 'note',
+      title: 'My research note'
+    })
+    tagname = "rsvp:#{jeff.username}"
+    assert_false node.can_tag(tagname, user)
+  end
+
 end


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!

Added unit tests for node.can_tag method

Fixes #1034 