### PR TITLE
better templating via GET params

### DIFF
--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -12,12 +12,20 @@ class EditorController < ApplicationController
       })
       flash[:error] = "The image could not be saved." unless @image.save!
     end
+    if params[:n] && !params[:body] # use another node body as a template
+      node = DrupalNode.find(params[:n])
+      params[:body] = node.body if node
+    end
     redirect_to "/questions/new?#{request.env['QUERY_STRING']}" if params[:tags] && params[:tags].include?("question:")
   end
 
   def rich
     if params[:main_image] && Image.find_by_id(params[:main_image])
       @main_image = Image.find_by_id(params[:main_image]).path
+    end
+    if params[:n] && !params[:body] # use another node body as a template
+      node = DrupalNode.find(params[:n])
+      params[:body] = node.body if node
     end
   end
 

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -85,6 +85,10 @@ class WikiController < ApplicationController
 
   def new
     @node = DrupalNode.new
+    if params[:n] && !params[:body] # use another node body as a template
+      node = DrupalNode.find(params[:n])
+      params[:body] = node.latest.body if node && node.latest
+    end
     @tags = []
     if params[:id]
       flash.now[:notice] = I18n.t('wiki_controller.page_does_not_exist_create')

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -98,7 +98,7 @@
       </div>
 
       <div class="ple-module-content col-md-9 container">
-        <textarea class="ple-textarea form-control"><% if @node && @node.latest && @node.latest.body %><%= @node.latest.body %><% else %><%= params[:body] %><% end %></textarea>
+        <textarea id="text-input" class="ple-textarea form-control"><% if @node && @node.latest && @node.latest.body %><%= @node.latest.body %><% else %><%= params[:body] %><% end %></textarea>
       </div>
 
     </div>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -53,6 +53,8 @@
       <input id="has_main_image" type="hidden" name="has_main_image" value="<% if @node && @node.main_image %>true<% end %>" />
       <input id="main_image" type="hidden" name="main_image" value="<% if @node && @node.main_image(:rails) %><%= @node.main_image(:rails).id %><% else %><%= params[:main_image] %><% end %>" />
       <input id="images_input" type="hidden" name="images" value="" />
+
+      <input id="taginput" type="hidden" name="tags" value="<%= params[:tags] %>" />
  
       <div class="form-group">
         <input tabindex="1" name="title" type="text" class="form-control" id="title" value="<% if @node && @node.latest %><%= @node.latest.title %><% else %><%= params[:id] %><% end %>">

--- a/test/functional/editor_controller_test.rb
+++ b/test/functional/editor_controller_test.rb
@@ -21,6 +21,22 @@ class EditorControllerTest < ActionController::TestCase
     assert_select "#taginput[value=?]", "one,two"
   end
 
+  test "should use existing node body as template in post form based on param 'n'" do
+    UserSession.create(rusers(:bob))
+    get :post,
+        n: node(:blog).id
+    assert_response :success
+    assert_select "textarea#text-input", node(:blog).body
+  end
+
+  test "should use existing node body as template in post form based on param 'n' in rich editor" do
+    UserSession.create(rusers(:bob))
+    get :rich,
+        n: node(:blog).id
+    assert_response :success
+    assert_select "textarea#text-input", node(:blog).body
+  end
+
   test "newcomer should get post form" do
     UserSession.create(rusers(:newcomer))
     get :post

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -41,6 +41,18 @@ class WikiControllerTest < ActionController::TestCase
     assert_not_nil :wikis
   end
 
+  test "should use existing node body as template in post form based on param 'n'" do
+    UserSession.create(rusers(:bob))
+
+    get :new,
+        tags: 'one,two',
+        n: node(:blog).id
+
+    assert_response :success
+    assert_select "#taginput[value=?]", "one,two"
+    assert_select "textarea#text-input", node(:blog).body
+  end
+
   test "should get raw wiki markup" do
     get :raw, id: node_revisions(:one).id
 


### PR DESCRIPTION
* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
