### PR TITLE
"Browse other activities" next to "replicate this" prompt, fixes #754

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -2,6 +2,7 @@
 
 <div class="col-md-9 note-show<% if @node.status == 4 || @node.status == 0 %> moderated<% end %>">
   <% if current_user && @node.tags.length == 0 %><div class="alert alert-warning"><%= raw t('notes.show.note_no_tags') %></div><% end %>
+  <% if @node.has_power_tag('status:candidate') %><div class="alert alert-info"><a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity" >read about how to adapt its content</a></div>
   <% if @node.has_power_tag('replication') %><div class="alert alert-info"><%= raw t('notes.show.replication') %> <a href="/n/<%= @node.power_tag('replication') %>"><%= raw t('notes.show.replication_link') %></a>.</div><% end %>
   <% if @node.has_power_tag('build') %><div class="alert alert-info"><%= raw t('notes.show.build') %> <a href="/n/<%= @node.power_tag('build') %>"><%= raw t('notes.show.build_link') %></a>.</div><% end %>
 

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="col-md-9 note-show<% if @node.status == 4 || @node.status == 0 %> moderated<% end %>">
   <% if current_user && @node.tags.length == 0 %><div class="alert alert-warning"><%= raw t('notes.show.note_no_tags') %></div><% end %>
-  <% if @node.has_power_tag('status:candidate') %><div class="alert alert-info"><a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity" >read about how to adapt its content</a></div>
+  <% if @node.has_power_tag('status:candidate') %><div class="alert alert-info">This was marked as a candidate activity -- <a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity" >read about how to adapt its content</a> into a fully-fledged, step-by-step activity that can be easily replicated.</div>
   <% if @node.has_power_tag('replication') %><div class="alert alert-info"><%= raw t('notes.show.replication') %> <a href="/n/<%= @node.power_tag('replication') %>"><%= raw t('notes.show.replication_link') %></a>.</div><% end %>
   <% if @node.has_power_tag('build') %><div class="alert alert-info"><%= raw t('notes.show.build') %> <a href="/n/<%= @node.power_tag('build') %>"><%= raw t('notes.show.build_link') %></a>.</div><% end %>
 

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -49,7 +49,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_select "table.activity-grid-test"
     assert_select "table.upgrades-grid-test"
     assert_select "table.notes-grid-shouldnt", false
-
+    assert_select "a",true
     assert_select "table.notes-grid-replication-#{node.id}"
 
   end


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] all tests pass -- `rake test:all`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [ ] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
