### PR TITLE
Added test to block basic user edits, closes issue #397

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -72,7 +72,7 @@ class WikiController < ApplicationController
     else
       @node = DrupalNode.find_wiki(params[:id])
     end
-    if @node.has_power_tag('locked') && (current_user.role != "admin" && current_user.role != "moderator")
+    if @node.has_tag('locked') && (current_user.role != "admin" && current_user.role != "moderator")
       flash[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
       redirect_to @node.path
     end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -7,9 +7,9 @@ class WikiController < ApplicationController
   def subdomain
     url = "//#{request.host}/wiki/"
     case request.subdomain
-    when "new-york-city", 
-         "gulf-coast", 
-         "boston", 
+    when "new-york-city",
+         "gulf-coast",
+         "boston",
          "espana" then
       redirect_to url+request.subdomain
     when "nyc"
@@ -71,6 +71,10 @@ class WikiController < ApplicationController
       @node = DrupalNode.find_wiki(params[:lang]+"/"+params[:id])
     else
       @node = DrupalNode.find_wiki(params[:id])
+    end
+    if @node.has_power_tag('locked') && (current_user.role != "admin" && current_user.role != "moderator")
+      flash.now[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
+      redirect_to @node.path
     end
     if ((Time.now.to_i - @node.latest.timestamp) < 5.minutes.to_i) && @node.latest.author.uid != current_user.uid
       flash.now[:warning] = I18n.t('wiki_controller.someone_clicked_edit_5_minutes_ago')
@@ -146,7 +150,7 @@ class WikiController < ApplicationController
         # update vid (version id) of main image
         if @node.drupal_main_image && params[:main_image].nil?
           i = @node.drupal_main_image
-          i.vid = @revision.vid 
+          i.vid = @revision.vid
           i.save
         end
         @node.title = @revision.title

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -73,7 +73,7 @@ class WikiController < ApplicationController
       @node = DrupalNode.find_wiki(params[:id])
     end
     if @node.has_power_tag('locked') && (current_user.role != "admin" && current_user.role != "moderator")
-      flash.now[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
+      flash[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
       redirect_to @node.path
     end
     if ((Time.now.to_i - @node.latest.timestamp) < 5.minutes.to_i) && @node.latest.author.uid != current_user.uid

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -139,7 +139,7 @@ class WikiControllerTest < ActionController::TestCase
       post :edit,
           id: 'organizers'
     end
-    assert_template "wiki/show"
+    assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_redirected_to node.path
   end
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -139,7 +139,6 @@ class WikiControllerTest < ActionController::TestCase
       post :edit,
           id: 'organizers'
     end
-    assert_redirected_to node.path
   end
 
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -141,7 +141,6 @@ class WikiControllerTest < ActionController::TestCase
           uid:   rusers(:bob).id,
           title: ""
     end
-
     assert_template "wiki/show"
     assert_select ".alert", "flash.now[:warning] = 'This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.'"
     assert_redirected_to wiki.path

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -139,7 +139,6 @@ class WikiControllerTest < ActionController::TestCase
       post :edit,
           id: 'organizers'
     end
-    assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_redirected_to node.path
   end
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -141,9 +141,9 @@ class WikiControllerTest < ActionController::TestCase
           uid:   rusers(:bob).id,
           title: ""
     end
-    
+
     assert_template "wiki/show"
-    assert_select ".alert", "flash.now[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.""
+    assert_select ".alert", "flash.now[:warning] = 'This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.'"
     assert_redirected_to wiki.path
   end
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -74,10 +74,10 @@ class WikiControllerTest < ActionController::TestCase
   test "post wiki no login" do
     UserSession.find.destroy
 
-    post :create, 
-         uid:   rusers(:bob).id, 
-         title: "All about balloon mapping", 
-         body:  "This is fascinating documentation about balloon mapping.", 
+    post :create,
+         uid:   rusers(:bob).id,
+         title: "All about balloon mapping",
+         body:  "This is fascinating documentation about balloon mapping.",
          tags:  "balloon-mapping,event"
 
     assert_redirected_to('/login')
@@ -86,10 +86,10 @@ class WikiControllerTest < ActionController::TestCase
   test "post wiki" do
     title = "All about balloon mapping"
 
-    post :create, 
-         uid:   rusers(:bob).id, 
-         title: title, 
-         body:  "This is fascinating documentation about balloon mapping.", 
+    post :create,
+         uid:   rusers(:bob).id,
+         title: title,
+         body:  "This is fascinating documentation about balloon mapping.",
          tags:  "balloon-mapping,event"
 
     assert_redirected_to "/wiki/" + title.parameterize
@@ -97,8 +97,8 @@ class WikiControllerTest < ActionController::TestCase
 
   test "post wiki with bad title" do
 
-    post :create, 
-         uid:   rusers(:bob).id, 
+    post :create,
+         uid:   rusers(:bob).id,
          title: "",
          body:  "This is fascinating documentation about balloon mapping."
 
@@ -108,7 +108,7 @@ class WikiControllerTest < ActionController::TestCase
 
   test "viewing edit wiki page" do
 
-    get :edit, 
+    get :edit,
          id: 'organizers'
 
     assert_template "wiki/edit"
@@ -116,13 +116,13 @@ class WikiControllerTest < ActionController::TestCase
     assert_not_nil assigns(:node)
     assert_response :success
   end
-  
+
   test "updating wiki" do
     wiki = node(:organizers)
     newtitle = "New Title"
 
-    post :update, 
-         id:    wiki.nid, 
+    post :update,
+         id:    wiki.nid,
          uid:   rusers(:bob).id,
          title: newtitle,
          body:  "Editing about Page"
@@ -134,24 +134,25 @@ class WikiControllerTest < ActionController::TestCase
 
   test "basic user blocked from updating a locked wiki page" do
     node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
-
     # then try updating it
-    post :update,
-         id:  node(:organizers).id, 
-         uid:   rusers(:bob).id, 
-         title: ""
-
+    assert_difference 'DrupalNodeRevision.count', 0 do
+      post :update,
+          id:  node(:organizers).id,
+          uid:   rusers(:bob).id,
+          title: ""
+    end
+    
     assert_template "wiki/show"
-    assert_select ".alert", "expected message"
+    assert_select ".alert", "flash.now[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.""
     assert_redirected_to wiki.path
   end
 
 
   test "updating wiki with bad title" do
 
-    post :update, 
-         id:  node(:organizers).id, 
-         uid:   rusers(:bob).id, 
+    post :update,
+         id:  node(:organizers).id,
+         uid:   rusers(:bob).id,
          title: ""
 
     assert_template "wiki/edit"
@@ -163,8 +164,8 @@ class WikiControllerTest < ActionController::TestCase
     newtitle = "New Title"
     assert_equal wiki.path, "/about"
 
-    post :update, 
-         id:    wiki.nid, 
+    post :update,
+         id:    wiki.nid,
          uid:   rusers(:bob).id,
          title: newtitle,
          body:  "Editing about Page"
@@ -178,13 +179,13 @@ class WikiControllerTest < ActionController::TestCase
     node = node(:about)
     image = fixture_file_upload 'rails.png'
 
-    post :update, 
-         id:    node.nid, 
+    post :update,
+         id:    node.nid,
          uid:   rusers(:bob).id,
          title: "New Title",
-         body:  "Editing about Page", 
+         body:  "Editing about Page",
          image: { :title => "new image",
-                  :photo => image 
+                  :photo => image
                 }
 
     node.reload
@@ -196,10 +197,10 @@ class WikiControllerTest < ActionController::TestCase
     node = node(:about)
     image = node.images.where(photo_file_name: 'filename-1.jpg').last
 
-    post :update, 
+    post :update,
          id:             node.nid,
          uid:            rusers(:bob).id,
-         title:          "New Title", 
+         title:          "New Title",
          body:           "Editing about Page",
          image_revision: image.path(:default)
 
@@ -254,7 +255,7 @@ class WikiControllerTest < ActionController::TestCase
 #    UserSession.create(rusers(:admin))
 #  end
 
-  # hmm, was this modified? 
+  # hmm, was this modified?
   test "should display wiki pages with slug in root" do
     UserSession.find.destroy
     UserSession.create(rusers(:admin))
@@ -351,7 +352,7 @@ class WikiControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_template :index
-    assert_select "title", "Public Lab: Popular wiki pages" 
+    assert_select "title", "Public Lab: Popular wiki pages"
   end
 
   test  "should display well liked wiki pages" do
@@ -361,25 +362,25 @@ class WikiControllerTest < ActionController::TestCase
     assert_template :index
     assert_select "title", "Public Lab: Well-liked wiki pages"
   end
-  
+
   test "should choose I18n for wiki controller" do
     available_testing_locales.each do |lang|
       old_controller = @controller
       @controller = SettingsController.new
-      
+
       get :change_locale, :locale => lang.to_s
-      
+
       @controller = old_controller
-      
+
       wiki = node(:organizers)
       newtitle = "New Title"
-  
-      post :update, 
-           id:    wiki.nid, 
+
+      post :update,
+           id:    wiki.nid,
            uid:   rusers(:bob).id,
            title: newtitle,
            body:  "Editing about Page"
-  
+
       wiki.reload
       assert_redirected_to wiki.path
       assert_equal flash[:notice], I18n.t('wiki_controller.edits_saved')

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -140,7 +140,7 @@ class WikiControllerTest < ActionController::TestCase
           id: 'organizers'
     end
     assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
-    assert_redirected_to node.path
+    assert_redirected_to node(:organizers).path
   end
 
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -132,6 +132,21 @@ class WikiControllerTest < ActionController::TestCase
     assert_equal flash[:notice], "Edits saved."
   end
 
+  test "basic user blocked from updating a locked wiki page" do
+    node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
+
+    # then try updating it
+    post :update,
+         id:  node(:organizers).id, 
+         uid:   rusers(:bob).id, 
+         title: ""
+
+    assert_template "wiki/show"
+    assert_select ".alert", "expected message"
+    assert_redirected_to wiki.path
+  end
+
+
   test "updating wiki with bad title" do
 
     post :update, 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -140,7 +140,6 @@ class WikiControllerTest < ActionController::TestCase
           id: 'organizers'
     end
     assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
-    assert_select ".alert", "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_redirected_to node.path
   end
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -139,7 +139,7 @@ class WikiControllerTest < ActionController::TestCase
       post :edit,
           id: 'organizers'
     end
-    assert_template "wiki/show"
+    assert_template "wiki/edit"
     assert_select ".alert", "flash.now[:warning] = 'This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.'"
     assert_redirected_to node.path
   end

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -139,7 +139,6 @@ class WikiControllerTest < ActionController::TestCase
       post :edit,
           id: 'organizers'
     end
-    assert_template "wiki/edit"
     assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_select ".alert", "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_redirected_to node.path

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -137,8 +137,6 @@ class WikiControllerTest < ActionController::TestCase
     # then try editing it
     assert_difference 'DrupalNodeRevision.count', 0 do
       post :edit,
-          id:  node(:organizers).id,
-          uid:   rusers(:bob).id,
           title: ""
     end
     assert_template "wiki/show"

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -132,18 +132,18 @@ class WikiControllerTest < ActionController::TestCase
     assert_equal flash[:notice], "Edits saved."
   end
 
-  test "basic user blocked from updating a locked wiki page" do
+  test "basic user blocked from editing a locked wiki page" do
     node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
-    # then try updating it
+    # then try editing it
     assert_difference 'DrupalNodeRevision.count', 0 do
-      post :update,
+      post :edit,
           id:  node(:organizers).id,
           uid:   rusers(:bob).id,
           title: ""
     end
     assert_template "wiki/show"
     assert_select ".alert", "flash.now[:warning] = 'This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.'"
-    assert_redirected_to wiki.path
+    assert_redirected_to node.path
   end
 
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -137,7 +137,7 @@ class WikiControllerTest < ActionController::TestCase
     # then try editing it
     assert_difference 'DrupalNodeRevision.count', 0 do
       post :edit,
-          title: ""
+          id: 'organizers'
     end
     assert_template "wiki/show"
     assert_select ".alert", "flash.now[:warning] = 'This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.'"

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -140,7 +140,7 @@ class WikiControllerTest < ActionController::TestCase
           id: 'organizers'
     end
     assert_template "wiki/edit"
-    assert_select ".alert", "flash.now[:warning] = 'This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it.'"
+    assert_select ".alert", "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_redirected_to node.path
   end
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -140,6 +140,7 @@ class WikiControllerTest < ActionController::TestCase
           id: 'organizers'
     end
     assert_template "wiki/edit"
+    assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_select ".alert", "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can edit it."
     assert_redirected_to node.path
   end

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -139,6 +139,8 @@ class WikiControllerTest < ActionController::TestCase
       post :edit,
           id: 'organizers'
     end
+    assert_template "wiki/show"
+    assert_redirected_to node.path
   end
 
 


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!

