### PR TITLE
Lock wiki edit tabs to non-admins/non-moderators

### DIFF
--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -42,7 +42,11 @@
  
       <ul class="nav nav-tabs">
         <li class="active"><a href="#"><span class="hidden-xs"><%= t('wiki.show.view') %></span><span class="visible-xs"><i class="fa fa-file-o"></i></span></a></li>
-        <li><a href="<%= @node.edit_path %>?t=<%= Time.now.to_i %>"><i class="fa fa-pencil"></i><span class="hidden-xs hidden-sm"> <%= t('wiki.show.edit') %></span></a></li>
+        <% if @node.has_tag('locked') %>
+          <li><a href="/wiki/locked"><i class="fa fa-lock"></i></a></li>
+        <% else %>
+          <li><a href="<%= @node.edit_path %>?t=<%= Time.now.to_i %>"><i class="fa fa-pencil"></i><span class="hidden-xs hidden-sm"> <%= t('wiki.show.edit') %></span></a></li>
+        <% end %>
         <% if current_user && current_user.role == "admin" %><li><%= link_to "/wiki/delete/"+@node.id.to_s, :confirm => I18n.t('wiki.show.are_you_sure_delete', :path => @node.path) do %><i class="fa fa-trash"></i><span class="hidden-xs hidden-sm"> <%= t('wiki.show.delete') %></span><% end %></li><% end %>
         <li><a href="/talk/<%= @node.slug_from_path %>"><i class="fa fa-comments-o"></i><span class="hidden-xs hidden-sm"> <%= t('wiki.show.talk') %></span></a></li>
         <li><a href="/wiki/revisions/<%= @node.slug_from_path %>"><span class="hidden-xs"><%= @node.revisions.length %> </span><i class="fa fa-list"></i></a></li>


### PR DESCRIPTION
Work in Progress...

Checks for locked tag on nodes and shows lock icon in edit tab to disable editing when current_user is not an admin or a moderator.

Finished issue [1099](https://github.com/publiclab/plots2/issues/1099)

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [ ] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
