### PR TITLE
Added libv8 install fix in README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.3.3'
 gem 'rails', '~> 3.2.20'
 gem 'passenger'
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Please read and abide by our [Code of Conduct](https://publiclab.org/conduct); o
 
 1. In the console, download a copy of the source with `git clone https://github.com/publiclab/plots2.git`.
 2. Enter the new **plots2** directory with `cd plots2`.
-3. Install gems with `bundle install --without production mysql` from the rails root folder, to install the gems you'll need, excluding those needed only in production. You may need to first run `bundle update` if you have older gems in your environment from previous Rails work. 
+3. Install gems with `bundle install --without production mysql` from the rails root folder, to install the gems you'll need, excluding those needed only in production. You may need to first run `bundle update` if you have older gems in your environment from previous Rails work.
+	- If you encounter error with libv8 installation as, "Make sure that `gem install libv8 -v '3.16.14.15'` succeeds before bundling.", try doing `gem install libv8 -v '3.16.14.15' -- --with-system-v8`. Explanation can be found [here](http://stackoverflow.com/questions/19577759/installing-libv8-gem-on-os-x-10-9?noredirect=1&lq=1). 
 4. Make a copy of `db/schema.rb.example` and place it at `db/schema.rb`.
 5. Make a copy of `config/database.yml.sqlite.example` and place it at `config/database.yml`
 6. Run `rake db:setup` to set up the database


### PR DESCRIPTION
**Error:** 
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
An error occurred while installing libv8 (3.16.14.15), and Bundler cannot
continue.
Make sure that `gem install libv8 -v '3.16.14.15'` succeeds before bundling.

**Fix:**
gem install libv8 -v '3.16.14.15' -- --with-system-v8

It took me quite a while to figure this one out when setting it up on my local system.
So I decided to put it in the README so nobody else gets stuck!

---
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] all tests pass -- `rake test:all`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [ ] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
