### PR TITLE
Add loading spinner for comments. Fixes #132

### DIFF
--- a/app/views/questions/_answer.html.erb
+++ b/app/views/questions/_answer.html.erb
@@ -119,8 +119,17 @@
   $("#answer-<%= answer.id %>-comment-button").click( function(){
     $("#answer-<%= answer.id %>-comment").toggle();
   });
-
+  
+  $('#answer-<%= answer.id %>-comment-form').bind('ajax:send', function(e){
+    $('#answer-<%= answer.id %>-comment-form #loading-spinner').removeClass('hidden');
+  })
+  
+  $('#answer-<%= answer.id %>-comment-form').bind('ajax:success', function(e, data, status, response){
+    $('#answer-<%= answer.id %>-comment-form #loading-spinner').addClass('hidden');
+  })
+  
   $('#answer-<%= answer.id %>-comment-form').bind('ajax:error', function(e, response){
+    $('#answer-<%= answer.id %>-comment-form #loading-spinner').removeClass('hidden');
     $('#answer-<%= answer.id %>-comment-section .help-block').remove()
     $('#answer-<%= answer.id %>-comment-section .inline').last().append('<span class="help-block" style="color: red;">Error: there was a problem.</span>')
   })

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -9,5 +9,6 @@
   </div>
   <div class="col-xs-3 col-sm-2">
     <button type="submit" class="btn btn-primary"><i class="fa fa-reply visible-xs"></i><span class="hidden-xs">Submit</span></button>
+    <i class="fa fa-spinner fa-spin hidden" id="loading-spinner"></i>
   </div>
 </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -100,8 +100,17 @@
         });
       }
     }
-
+    
+    $('#answer-0-comment-form').bind('ajax:send', function(e){
+      $('#answer-0-comment-form #loading-spinner').removeClass('hidden');
+    })
+    
+    $('#answer-0-comment-form').bind('ajax:success', function(e, data, status, response){
+      $('#answer-0-comment-form #loading-spinner').addClass('hidden');
+    })
+    
     $('#answer-0-comment-form').bind('ajax:error', function(e, response){
+      $('#answer-0-comment-form #loading-spinner').addClass('hidden');
       $('#answer-0-comment-section .help-block').remove()
       $('#answer-0-comment-section .inline').last().append('<span class="help-block" style="color: red;">Error: there was a problem.</span>')
     })


### PR DESCRIPTION
After user clicks on submit button, a spinner is shown for the ajax request to indicate the action is in process.

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Thanks!
