### PR TITLE
fixes for Browse other Activities code

### DIFF
--- a/app/views/notes/_responses.html.erb
+++ b/app/views/notes/_responses.html.erb
@@ -7,9 +7,9 @@
  
     <p id="<%= response_type %>s"><a class='btn btn-primary btn-lg' href="/post?tags=<%= response_type %>:<%= @node.id %><% if response_type == 'response' %>,hidden:response<% end %><%= ',' + (@tagnames.uniq.delete_if{|x| x.match(":") }).join(',') if @tagnames && @tagnames.length > 0 %>"><%= t('notes._responses.post_' + response_type) %></a>&nbsp;
       <% if @node.power_tag('activity') %>
-        <% if DrupalTag.where(name: @node.power_tag('activity')).first %>
-          <% if DrupalTag.where(name: @node.power_tag('activity')).first.nodes %>
-            <a id="other-activities" href="<%= DrupalTag.where(name: @node.power_tag('activity')).first.nodes.first.path %>">Browse other activities for "<%= @node.power_tag('activity') %>"</a>
+        <% if DrupalTag.where(name: 'activities:' + @node.power_tag('activity')).first %>
+          <% if DrupalTag.where(name: 'activities:' + @node.power_tag('activity')).first.nodes.length > 0 %>
+            <a id="other-activities" href="<%= DrupalTag.where(name: 'activities:' + @node.power_tag('activity')).first.nodes.first.path %>">Browse other activities for "<%= @node.power_tag('activity') %>"</a>
           <% end %> 
         <% end %>
       <% end %>

--- a/test/fixtures/community_tags.yml
+++ b/test/fixtures/community_tags.yml
@@ -111,3 +111,9 @@ activity-spectrometer:
   uid: 1
   nid: 1
   date: Time.now
+
+activities-spectrometer:
+  tid: 16
+  uid: 1
+  nid: 20
+  date: Time.now

--- a/test/fixtures/node.yml
+++ b/test/fixtures/node.yml
@@ -225,3 +225,14 @@ feature:
   status: 1
   type: "feature"
   cached_likes: 0
+
+method:
+  nid: 20
+  uid: 1
+  title: "Method page"
+  created: <%= Time.now.to_i %>
+  changed: <%= Time.now.to_i %>
+  status: 1
+  type: "page"
+  cached_likes: 0
+  path: "/wiki/spectrometer"

--- a/test/fixtures/node_counter.yml
+++ b/test/fixtures/node_counter.yml
@@ -54,3 +54,6 @@ eighteen:
 
 nineteen:
   nid: 19
+
+twenty:
+  nid: 20

--- a/test/fixtures/node_revisions.yml
+++ b/test/fixtures/node_revisions.yml
@@ -204,3 +204,9 @@ fixture:
   title: "email-footer"
   body: Test
   timestamp: <%= (Time.now - 1.week).to_i %>
+
+method:
+  nid: 20
+  uid: 1
+  title: "Method page"
+  body: "[activities:spectrometer]"

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -59,3 +59,7 @@ replications:
   tid: 15
   name: seeks:replications
   parent: activity:*
+
+activities-spectrometer:
+  tid: 16
+  name: activities:spectrometer

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -48,7 +48,9 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   test "show note" do
-    note = DrupalNode.where(type: 'note', status: 1).first
+    note = node(:blog)
+    note.add_tag('activity:nonexistent', note.author) # testing responses display
+    assert_equal 'nonexistent', note.power_tag('activity')
 
     get :show,
         author: note.author.name,
@@ -56,6 +58,22 @@ class NotesControllerTest < ActionController::TestCase
         id: note.title.parameterize
 
     assert_response :success
+    assert_select "#other-activities", false
+  end
+
+  test "show note with Browse other activities link" do
+    note = DrupalNode.where(type: 'note', status: 1).first
+    note.add_tag('activity:spectrometer', note.author) # testing responses display
+    assert DrupalTag.where(name: 'activities:' + note.power_tag('activity')).length > 0
+
+    get :show,
+        author: note.author.name,
+        date: Time.at(note.created).strftime("%m-%d-%Y"),
+        id: note.title.parameterize
+
+    assert_response :success
+    assert_select "#other-activities"
+    assert_select "a#other-activities[href = '/wiki/spectrometer']", 1
   end
 
   test "don't show note by spam author" do

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -336,8 +336,8 @@ class TagControllerTest < ActionController::TestCase
   test "shows suggested tags" do
     get :suggested, id: 'spectr'
 
-    assert_equal 3, assigns(:suggestions).length
-    assert_equal ["question:spectrometer","spectrometer","activity:spectrometer"], JSON.parse(response.body)
+    assert_equal 4, assigns(:suggestions).length
+    assert_equal ["question:spectrometer","spectrometer","activity:spectrometer","activities:spectrometer"], JSON.parse(response.body)
   end
   
   test "should choose I18n for tag controller" do

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -49,7 +49,6 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_select "table.activity-grid-test"
     assert_select "table.upgrades-grid-test"
     assert_select "table.notes-grid-shouldnt", false
-    assert_select "a#other-activities"
     assert_select "table.notes-grid-replication-#{node.id}"
 
   end


### PR DESCRIPTION
To resolve errors on, for example:

https://publiclab.org/notes/stoft/09-16-2016/stability-upgrade-mockup-for-plab-spectrometer-3-0

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
