### PR TITLE
Display RTE when editing notes by default (Fixes #1141)

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -151,7 +151,9 @@ class NotesController < ApplicationController
   def edit
     @node = DrupalNode.find(params[:id],:conditions => {:type => "note"})
     if current_user.uid == @node.uid || current_user.role == "admin"
-      if params[:rich]
+      if params[:legacy]
+        render :template => "editor/post"
+      else
         if @node.main_image
           @main_image = @node.main_image.path(:default)
         elsif params[:main_image] && Image.find_by_id(params[:main_image])
@@ -159,9 +161,8 @@ class NotesController < ApplicationController
         elsif @image
           @main_image = @image.path(:default)
         end
+        flash.now[:notice] = "This is the new rich editor. For the legacy editor, <a href='/notes/edit/#{@node.id}?#{request.env['QUERY_STRING']}&legacy=true'>click here</a>."
         render :template => "editor/rich"
-      else
-        render :template => "editor/post"
       end
     else
       if @node.has_power_tag('question')

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -404,7 +404,7 @@ class NotesControllerTest < ActionController::TestCase
     post :edit,
          id: note.nid
     assert_response :success
-    assert_select "input.form-control.input-lg[value=?]", note.tagnames.join(',') + ',spectrometer' # for now, question subject is appended to end of form
+    assert_select "input.form-control.input-lg[value=?]", note.tagnames.join(',')
   end
 
 

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -367,23 +367,23 @@ class NotesControllerTest < ActionController::TestCase
     assert_equal flash[:notice], "Question published. In the meantime, if you have more to contribute, feel free to do so."
   end
 
-  test "should display /post template when editing a note" do
+  test "should display /post template when editing a note in legacy mode" do
     user = UserSession.create(rusers(:jeff))
     note = node(:blog)
     post :edit,
-         id: note.nid
-
+         id: note.nid,
+         legacy: true
     assert_response :success
     assert_select "input#taginput[value=?]", note.tagnames.join(',')
   end
 
-  test "should display /post template when editing a question" do
+  test "should display /post template when editing a question in legacy mode" do
     user = UserSession.create(rusers(:jeff))
     note = node(:question)
     note.add_tag('nice', rusers(:jeff))
     post :edit,
-         id: note.nid
-
+         id: note.nid,
+         legacy: true
     assert_response :success
     assert_select "input#taginput[value=?]", note.tagnames.join(',') + ',spectrometer' # for now, question subject is appended to end of form
   end

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -388,6 +388,26 @@ class NotesControllerTest < ActionController::TestCase
     assert_select "input#taginput[value=?]", note.tagnames.join(',') + ',spectrometer' # for now, question subject is appended to end of form
   end
 
+  test "should display /post template when editing a note" do
+    user = UserSession.create(rusers(:jeff))
+    note = node(:blog)
+    post :edit,
+         id: note.nid
+    assert_response :success
+    assert_select "input.form-control.input-lg[value=?]", note.tagnames.join(',')
+  end
+
+  test "should display /post template when editing a question" do
+    user = UserSession.create(rusers(:jeff))
+    note = node(:question)
+    note.add_tag('nice', rusers(:jeff))
+    post :edit,
+         id: note.nid
+    assert_response :success
+    assert_select "input.form-control.input-lg[value=?]", note.tagnames.join(',') + ',spectrometer' # for now, question subject is appended to end of form
+  end
+
+
   test "should redirect to questions show page when editing an existing question" do
     user = UserSession.create(rusers(:jeff))
     note = node(:question)


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] all tests pass -- `rake test:all`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [ ] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
