### PR TITLE
Fixes #425 - Make page views unique

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem "authlogic", "3.2.0"
 gem "php-serialize", :require => "php_serialize"
 gem 'less-rails',   '~> 2.6'
 gem 'progress_bar'
+gem 'impressionist'
 
 # RESTful API Support
 gem 'grape'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     i18n-js (3.0.0.rc13)
       i18n (~> 0.6, >= 0.6.6)
     ice_nine (0.11.2)
+    impressionist (1.5.2)
+      nokogiri (~> 1.6)
     jasmine-core (2.4.1)
     jasmine-jquery-rails (2.0.3)
     jasmine-rails (0.12.6)
@@ -303,6 +305,7 @@ DEPENDENCIES
   grape-swagger-ui
   http_accept_language
   i18n-js (>= 3.0.0.rc11)
+  impressionist
   jasmine-jquery-rails
   jasmine-rails
   jbuilder
@@ -344,4 +347,4 @@ RUBY VERSION
    ruby 2.1.2p95
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -20,7 +20,7 @@ class MapController < ApplicationController
 
     # redirect_old_urls
 
-    @node.view
+    impressionist(@node.drupal_node_counter)
     @title = @node.title
     @tags = @node.tags
     @tagnames = @tags.collect(&:name)

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -69,7 +69,7 @@ class NotesController < ApplicationController
 
     alert_and_redirect_moderated
 
-    @node.view
+    impressionist(@node.drupal_node_counter)
     @title = @node.latest.title
     @tags = @node.tags
     @tagnames = @tags.collect(&:name)

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -30,7 +30,7 @@ class QuestionsController < ApplicationController
 
     alert_and_redirect_moderated
 
-    @node.view
+    impressionist(@node.drupal_node_counter)
     @title = @node.latest.title
     @tags = @node.power_tag_objects('question')
     @tagnames = @tags.collect(&:name)

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -53,7 +53,7 @@ class WikiController < ApplicationController
       set_sidebar :tags, @tagnames, {:videos => true}
       @wikis = DrupalTag.find_pages(@node.slug_from_path,30) if @node.has_tag('chapter') || @node.has_tag('tabbed:wikis')
 
-      @node.view
+      impressionist(@node.drupal_node_counter)
       @revision = @node.latest
       @title = @revision.title
     end

--- a/app/models/drupal_node.rb
+++ b/app/models/drupal_node.rb
@@ -473,13 +473,6 @@ class DrupalNode < ActiveRecord::Base
     self.tags.collect(&:name)
   end
 
-  # increment view count
-  def view
-    DrupalNodeCounter.new({:nid => self.id}).save if self.drupal_node_counter.nil?
-    self.drupal_node_counter.totalcount += 1
-    self.drupal_node_counter.save
-  end
-
   # view count
   def totalcount
     DrupalNodeCounter.new({:nid => self.id}).save if self.drupal_node_counter.nil?

--- a/app/models/drupal_node_counter.rb
+++ b/app/models/drupal_node_counter.rb
@@ -4,4 +4,5 @@ class DrupalNodeCounter < ActiveRecord::Base
 
   belongs_to :drupal_node, :foreign_key => 'nid', :dependent => :destroy
 
+  is_impressionable :counter_cache => true, :column_name => :totalcount, :unique => :ip_address
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,5 +101,7 @@ module Plots2
     config.paths.add File.join('app','api'), glob: File.join('**', '*.rb')
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
 
+    # Allow mass assignments
+    config.active_record.whitelist_attributes = false
   end
 end

--- a/config/initializers/impression.rb
+++ b/config/initializers/impression.rb
@@ -1,0 +1,4 @@
+Impressionist.setup do |config|
+  # Define ORM. Could be :active_record (default), :mongo_mapper or :mongoid
+  config.orm = :active_record
+end

--- a/db/migrate/20161230142222_create_impressions_table.rb
+++ b/db/migrate/20161230142222_create_impressions_table.rb
@@ -1,0 +1,32 @@
+class CreateImpressionsTable < ActiveRecord::Migration
+  def self.up
+    create_table :impressions, :force => true do |t|
+      t.string :impressionable_type
+      t.integer :impressionable_id
+      t.integer :user_id
+      t.string :controller_name
+      t.string :action_name
+      t.string :view_name
+      t.string :request_hash
+      t.string :ip_address
+      t.string :session_hash
+      t.text :message
+      t.text :referrer
+      t.text :params
+      t.timestamps
+    end
+    add_index :impressions, [:impressionable_type, :message, :impressionable_id], :name => "impressionable_type_message_index", :unique => false, :length => { :message => 255 }
+    add_index :impressions, [:impressionable_type, :impressionable_id, :request_hash], :name => "poly_request_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :ip_address], :name => "poly_ip_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :session_hash], :name => "poly_session_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:request_hash], :name => "controlleraction_request_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:ip_address], :name => "controlleraction_ip_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:session_hash], :name => "controlleraction_session_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :params], :name => "poly_params_request_index", :unique => false, :length => { :params => 255 }
+    add_index :impressions, :user_id
+  end
+
+  def self.down
+    drop_table :impressions
+  end
+end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161129210111) do
+ActiveRecord::Schema.define(:version => 20161230142222) do
 
   create_table "answer_selections", :force => true do |t|
     t.integer "user_id"
@@ -168,6 +168,33 @@ ActiveRecord::Schema.define(:version => 20161129210111) do
     t.string   "remote_url"
     t.integer  "vid",                :default => 0
   end
+
+  create_table "impressions", :force => true do |t|
+    t.string   "impressionable_type"
+    t.integer  "impressionable_id"
+    t.integer  "user_id"
+    t.string   "controller_name"
+    t.string   "action_name"
+    t.string   "view_name"
+    t.string   "request_hash"
+    t.string   "ip_address"
+    t.string   "session_hash"
+    t.text     "message"
+    t.text     "referrer"
+    t.text     "params"
+    t.datetime "created_at",          :null => false
+    t.datetime "updated_at",          :null => false
+  end
+
+  add_index "impressions", ["controller_name", "action_name", "ip_address"], :name => "controlleraction_ip_index"
+  add_index "impressions", ["controller_name", "action_name", "request_hash"], :name => "controlleraction_request_index"
+  add_index "impressions", ["controller_name", "action_name", "session_hash"], :name => "controlleraction_session_index"
+  add_index "impressions", ["impressionable_type", "impressionable_id", "ip_address"], :name => "poly_ip_index"
+  add_index "impressions", ["impressionable_type", "impressionable_id", "params"], :name => "poly_params_request_index", :unique => false, :length => { "params" => 255 }
+  add_index "impressions", ["impressionable_type", "impressionable_id", "request_hash"], :name => "poly_request_index"
+  add_index "impressions", ["impressionable_type", "impressionable_id", "session_hash"], :name => "poly_session_index"
+  add_index "impressions", ["impressionable_type", "message", "impressionable_id"], :name => "impressionable_type_message_index", :unique => false, :length => { "message" => 255 }
+  add_index "impressions", ["user_id"], :name => "index_impressions_on_user_id"
 
   create_table "location_tags", :force => true do |t|
     t.integer  "uid"


### PR DESCRIPTION
This commit replaces the old 'view count incrementation' with
impressionist's proper view count. View counts are now unique by their
IP Address.

`DrupalNode.show` is replaced with impressionist's count
incrementation function.

Application configuration has been modified due to impressionist's
massive assignments.

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
