### PR TITLE
Added test to block normal user from updating wiki, fixes #397

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -143,7 +143,11 @@ class WikiController < ApplicationController
       title: params[:title],
       body:  params[:body]
     })
-    if @revision.valid?
+    if @node.has_tag('locked') && (current_user.role != "admin" && current_user.role != "moderator")
+      flash[:warning] = "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can update it."
+      redirect_to @node.path
+    
+    elsif @revision.valid?
       ActiveRecord::Base.transaction do
         @revision.save
         @node.vid = @revision.vid

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -143,7 +143,7 @@ class WikiControllerTest < ActionController::TestCase
     assert_redirected_to node(:organizers).path
   end
 
-  test "basic user blocked from update a locked wiki page" do
+  test "basic user blocked from updating a locked wiki page" do
     node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
     # then try editing it
     assert_difference 'DrupalNodeRevision.count', 0 do

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -143,6 +143,16 @@ class WikiControllerTest < ActionController::TestCase
     assert_redirected_to node(:organizers).path
   end
 
+  test "basic user blocked from update a locked wiki page" do
+    node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
+    # then try editing it
+    assert_difference 'DrupalNodeRevision.count', 0 do
+      post :update,
+          id: 'organizers'
+    end
+    assert_equal flash[:warning] , "This page is <a href='/wiki/power-tags#Locking'>locked</a>, and only <a href='/wiki/moderators'>moderators</a> can update it."
+    assert_redirected_to node(:organizers).path
+  end
 
   test "updating wiki with bad title" do
 


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
