### PR TITLE
Gemfile.lock generated with no ruby version specified...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ config/amazon_s3.yml
 config/initializers/recaptcha.rb
 config/config.yml
 config/initializers/site_keys.rb
+config/initializers/secret_token.rb
 public/system
 public/lib
 db/openid-store/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,8 +343,5 @@ DEPENDENCIES
   will_paginate (>= 3.0.6)
   will_paginate-bootstrap (>= 1.0.1)
 
-RUBY VERSION
-   ruby 2.1.2p95
-
 BUNDLED WITH
    1.13.7

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Plots2::Application.config.secret_token = 'd2db59377fa49d9c8fa08fa5bb771dd326c0e84b0f1f67d324a0cc7f91ce4e99fb448097c1c9ba030d80ed331833674b5c3f85a08b109ca1684a477ee5934ddb'
+Plots2::Application.config.secret_token = 'CHANGE-THIS-TO-A-SECRET-KEY-AND-DONT-VERSION-TRACK-IT-IN-GIT'


### PR DESCRIPTION
@icarito @ananyo2012 -- take a look, my bundler generated this with no specified Ruby... not sure why. I did not change the Gemfile, and ran `bundle install` to get this. Thoughts on merging it? 

Just to cite Sebastian's input:

> As far as I understood, the purpose of Gemfile.lock is to record a particular dependency resolution constructed from the Gemfile.
> Quoting the bundler man page:
> "The Gemfile.lock
When you run bundle install, Bundler will persist the full names and versions of all gems that you used (including dependencies of the gems specified in the Gemfile(5)) into a file called Gemfile.lock.
> Bundler uses this file in all subsequent calls to bundle install, which guarantees that you always use the same exact code, even as your application moves across machines.
> Because of the way dependency resolution works, even a seemingly small change (for instance, an update to a point-release of a dependency of a gem in your Gemfile(5)) can result in radically different gems being needed to satisfy all dependencies.
> As a result, you SHOULD check your Gemfile.lock into version control. If you do not, every machine that checks out your repository (including your production server) will resolve all dependencies again, which will result in different versions of third-party code being used if any of the gems in the Gemfile(5) or any of their dependencies have been updated."
> However it will be in conflict with other developers if they only have a different version of Ruby, as apparently you can't stop Bundler from adding RUBY_VERSION to Gemfile.lock. Perhaps it's possible to widen the lock to include major version and omit patch release or minor version.
> I would suggest a note in the README under troubleshooting or faq, perhaps even explaining the purpose of Gemfile.lock - and a note that this file can be safely removed and bundle install will resolve dependencies and create it again (using any available Ruby).
> Perhaps even add it to .gitignore to avoid random commits updating it? It should really only be updated on purpose.

Just on this last point, I've seen a lot of commits recently tweaking it in one way or another, so maybe .gitignoring it is not a bad idea. I hadn't previously known that you could .gitignore something in the repo.