### PR TITLE
Fixes #775: Separate display of power tags

### DIFF
--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -1,17 +1,9 @@
 <%= render partial: 'tag/replication' %>
 
-<p>
-  <span id="tags">
-    <% @node.community_tags.each do |tag| %>
-      <span id="tag_<%= tag.tid %>" class="label label-primary" data-toggle="tooltip" data-html="true" title="created by <strong><%= tag.try(:author).try(:username) %></strong> <%= time_ago_in_words(Time.at(tag.date)) %> ago">
-        <a class="tag-name" href="<%= "/maps" if @node.type == "map" %>/tag/<%= tag.name %>"><%= tag.name %></a>
-        <% if current_user && (tag.uid == @node.uid || current_user.role == "admin" || current_user.role == "moderator") %>
-          <a data-confirm="This is a power tag (see https://publiclab.org/wiki/power-tags) -- and may drive a specific function on this page. Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>">x</a>
-        <% end %>
-      </span>
-    <% end %>
-  </span>
-</p>
+<span id="tags">
+<%= render partial: 'tag/tags', locals: { power_tag: true, label_name: 'label-default' } %>
+<%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary' } %>
+</span>
 
 <script>
 $(function () {
@@ -29,9 +21,7 @@ $(function () {
     </div>
     <script>
       jQuery(document).ready(function() {
-
         initTagForm(<%= @node.id %>, '#tagform');
-
       });
     </script>
   </div>

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,0 +1,16 @@
+<p>
+  <% @node.community_tags.each do |tag| %>
+    <% if power_tag^tag.name.include?(':') %>
+      <span id="tag_<%= tag.tid %>" class="label <%= label_name %>" data-toggle="tooltip" data-html="true" title="created by <strong><%= tag.try(:author).try(:username) %></strong> <%= time_ago_in_words(Time.at(tag.date)) %> ago">
+        <a class="tag-name" href="<%= "/maps" if @node.type == "map" %>/tag/<%= tag.name %>"><%= tag.name %></a>
+        <% if current_user && (tag.uid == @node.uid || current_user.role == "admin" || current_user.role == "moderator") %>
+          <% if tag.name.include? ':' %>
+            <a data-confirm="This is a power tag (see https://publiclab.org/wiki/power-tags) -- and may drive a specific function on this page. Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>">x</a>
+          <% else %>
+            <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>">x</a>
+          <% end %>
+        <% end %>
+      </span>
+    <% end %>
+  <% end %>  
+</p>


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!

- Separated display of power tags from normal tags
- Preview: 
<img width="477" alt="screen shot 2017-01-06 at 8 50 00 pm" src="https://cloud.githubusercontent.com/assets/13972732/21717288/693e2fbe-d453-11e6-9216-1fe92abe164d.png">
