### PR TITLE
Recaptcha signup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,8 @@ GEM
     rdiscount (1.6.8)
     rdoc (3.12.2)
       json (~> 1.4)
+    recaptcha (4.0.1)
+      json
     ref (2.0.0)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -327,6 +329,7 @@ DEPENDENCIES
   rake (~> 10.5.0)
   rb-readline
   rdiscount (= 1.6.8)
+  recaptcha
   rest-client
   rspec
   ruby-openid
@@ -342,6 +345,9 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   will_paginate (>= 3.0.6)
   will_paginate-bootstrap (>= 1.0.1)
+
+RUBY VERSION
+   ruby 2.1.2p95
 
 BUNDLED WITH
    1.13.7

--- a/Gemfile.new
+++ b/Gemfile.new
@@ -64,7 +64,7 @@ gem 'georuby', '2.0'
 gem 'geokit-rails'
 gem 'rails_autolink'
 gem 'rb-readline'
-gem "paperclip", ">= 4.1.1"
+gem "paperclip", "~> 4.1.1"
 gem "ruby-openid", :require => "openid"
 gem "rack-openid"
 gem "authlogic", "3.2.0"
@@ -72,7 +72,6 @@ gem "php-serialize", :require => "php_serialize"
 gem 'less-rails',   '~> 2.6'
 gem 'progress_bar'
 gem 'impressionist'
-gem "recaptcha", require: "recaptcha/rails"
 
 # RESTful API Support
 gem 'grape'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Please read and abide by our [Code of Conduct](https://publiclab.org/conduct); o
 4. [API](https://github.com/publiclab/plots2/wiki/API)
 5. [Bugs and Support](https://github.com/publiclab/plots2/wiki/Bugs-and-Support)
 6. [Data model](https://github.com/publiclab/plots2/blob/master/doc/DATA_MODEL.md)
+7. [Recaptcha](https://github.com/publiclab/plots2/blob/master/doc/RECAPTCHA.md)
 
 ****
 ## Installation

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
           @user.errors.add(:spam_detection, message)
         end
       elsif using_recaptcha && recaptcha == false
-        flash.now[:warning] = "If you're having trouble creating an account, try <a href='/signup?spamaway=true'>the alternative signup form</a>"
+        flash.now[:warning] = "If you're having trouble creating an account, try <a href='/signup?spamaway=true'>the alternative signup form</a>, or <a href='mailto:staff@publiclab.org'>ask staff for help</a>"
       end
       # send all errors to the page so the user can try again
       @action = "create"

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -56,56 +56,66 @@
  
  
     <% if params[:controller] == "users" && (params[:action] == "new" || params[:action] == "create") %>
-      <%= fields_for @spamaway do |spam| %>
 
-        <div class="form-group spamaway">
+      <% if !params[:spamaway] || Rails.env == "production" %>
 
-          <label for="spamaway_follow_instructions">
-            <%= t('users._form.are_you_human') %>
-          </label>
-          <p>
-            <%= t('users._form.spam_filtering') %>
-          </p>
+        <%= recaptcha_tags %>
 
-          <% vars = [:statement1, :statement2, :statement3, :statement4] %>
-          <% turingtest = Spamaway.get_pairs vars.length %>
-          <% turingtest.each_index do |i| %>
+      <% else %>
 
-              <div class="btn-group btn-group-justified" role="group">
-                <% [0,1].each_with_index do |s, j| %><% statement = turingtest[i][s] %>
-                  <div class="btn-group" role="group">
-                    <button type="button" class="col-xs-5 btn btn-default" style="text-align:left;<% if i.odd? %> background:#eef;<% end %>" id="spamaway-<%= i.to_s + j.to_s %>">
-                      <%= spam.radio_button vars[i], statement %> <%= statement %>
-                    </button>
-                  </div>
-                <% end %>
-              </div>
-              <br />
+        <%= fields_for @spamaway do |spam| %>
+ 
+          <div class="form-group spamaway">
+ 
+            <label for="spamaway_follow_instructions">
+              <%= t('users._form.are_you_human') %>
+            </label>
+            <p>
+              <%= t('users._form.spam_filtering') %>
+            </p>
+ 
+            <% vars = [:statement1, :statement2, :statement3, :statement4] %>
+            <% turingtest = Spamaway.get_pairs vars.length %>
+            <% turingtest.each_index do |i| %>
+ 
+                <div class="btn-group btn-group-justified" role="group">
+                  <% [0,1].each_with_index do |s, j| %><% statement = turingtest[i][s] %>
+                    <div class="btn-group" role="group">
+                      <button type="button" class="col-xs-5 btn btn-default" style="text-align:left;<% if i.odd? %> background:#eef;<% end %>" id="spamaway-<%= i.to_s + j.to_s %>">
+                        <%= spam.radio_button vars[i], statement %> <%= statement %>
+                      </button>
+                    </div>
+                  <% end %>
+                </div>
+                <br />
+ 
+            <% end %>
+    
+          </div>
+ 
+          <div class="form-group">
 
-          <% end %>
-  
-        </div>
-
-        <div class="form-group">
-
-          <%= spam.text_area :follow_instructions, { class: "form-control col-md-6",
+            <%= spam.text_area :follow_instructions, { class: "form-control col-md-6",
                                                      rows: 8,
                                                      tabindex: 7,
                                                      placeholder: I18n.t('users._form.dont_write_here') }
-          %>
+            %>
   
-        </div>
+          </div>
+
+        <% end %>
 
       <% end %>
-    <% end %>
 
-    <script>
-      (function() {
-        $('.spamaway button').click(function(e) { 
-          $(this).find('input').prop('checked', true);
-        })
-      })();
-    </script>
+      <script>
+        (function() {
+          $('.spamaway button').click(function(e) { 
+            $(this).find('input').prop('checked', true);
+          })
+        })();
+      </script>
+
+    <% end %>
 
     <div class="form-group form-inline" style="clear:both;padding-top:10px;">
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -57,7 +57,7 @@
  
     <% if params[:controller] == "users" && (params[:action] == "new" || params[:action] == "create") %>
 
-      <% if !params[:spamaway] || Rails.env == "production" %>
+      <% if Rails.env == "production" && !params[:spamaway] %>
 
         <%= recaptcha_tags %>
 

--- a/config/locales/views/users/_form/en.yml
+++ b/config/locales/views/users/_form/en.yml
@@ -9,7 +9,7 @@ en:
       change_password: "Change your password"
       password: "password"
       confirmation: "Confirmation"
-      confirm_password: "Confirm your password"
+      confirm_password: "Retype your password to confirm"
       bio: "Bio"
       add_bio: "Add a short bio to appear on your profile page"
       are_you_human: "Are you human?"

--- a/doc/RECAPTCHA.md
+++ b/doc/RECAPTCHA.md
@@ -1,0 +1,5 @@
+This application uses RECAPTCHA via the recaptcha gem in production only. To configure, please set your API keys in /config/initializers/recaptcha.rb:
+
+https://github.com/ambethia/recaptcha#recaptchaconfigure
+
+


### PR DESCRIPTION
closes #899, closes #1201 

Note that the Recaptcha isn't always just a "click the box" and can sometimes request the following tasks:

![screenshot 2017-01-20 at 6 42 53 pm](https://cloud.githubusercontent.com/assets/24359/22169552/eb4d3a5a-df42-11e6-890d-ca418ce8b6a6.png)
![screenshot 2017-01-20 at 3 54 36 pm](https://cloud.githubusercontent.com/assets/24359/22169553/eb609f1e-df42-11e6-9b1d-7e443452e521.png)

But I made it so that if you fail the Recaptcha, it offers to let you use the old spamaway system, which is preserved. Tested manually (since automated tests, obviously, can't do the test! They're robots.)

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [x] reviewed/confirmed/tested by another contributor or maintainer
