### PR TITLE
fixes #1198 - Tested email notifications to author on question answers

### DIFF
--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -9,10 +9,13 @@ class AnswersControllerTest < ActionController::TestCase
   test "should get create if user is logged in" do
     UserSession.create(rusers(:bob))
     node = node(:question)
-    assert_difference 'Answer.count' do
-      xhr :post, :create,
-                 nid: node.nid,
-                 body: "Sample answer"
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      assert_difference 'Answer.count' do
+        xhr :post, :create,
+                   nid: node.nid,
+                   body: "Sample answer"
+      end
+      assert_equal node(:question).author.email, ActionMailer::Base.deliveries.last.to
     end
     assert_response :success
     assert_not_nil assigns(:answer)


### PR DESCRIPTION
Added test to make sure that user who created a question is notified of
proposed answers.

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
* [ ] if possible, multiple commits squashed if they're smaller changes
* [x] `schema.rb.example` has been updated if any database migrations were added

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
