### PR TITLE
migrate legacy markdown headers in rich wikis

### DIFF
--- a/app/assets/javascripts/wikis/processSections.js
+++ b/app/assets/javascripts/wikis/processSections.js
@@ -7,9 +7,12 @@ function processSections(sections, selector, node_id) {
 
 // selector is like "#content" -- the container to append the new content to
 function processSection(markdown, selector, node_id) {
-  var html        = replaceWithMarkdown(markdown),
+  var html,
       randomNum   = parseInt(Math.random() * 10000),
       uniqueId    = "section-form-" + randomNum;
+
+  markdown = preProcessMarkdown(markdown);
+  html = replaceWithMarkdown(markdown);
 
   $(selector).append(html);
   var el = $(selector + ' > *:last');
@@ -73,4 +76,8 @@ function insertEditLink(uniqueId, el, form) {
     e.preventDefault();
     form.toggle();
   });
+}
+
+function preProcessMarkdown(markdown) {
+  return markdown.replace(/$(#+)(\w)/, function(m) { return $1 + ' ' + $2 })
 }

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -106,7 +106,7 @@
       <div <% unless @node.has_tag('style:wide') %>style="max-width:800px;"<% end %> id="content">
         <%= raw auto_link(insert_extras(@revision.render_body), :sanitize => false) %>
       </div>
-      <div style="display:none;" id="content-raw-markdown"><%= raw insert_extras(@revision.body) %></div>
+      <div style="display:none;" id="content-raw-markdown"><%= raw insert_extras(@revision.body).gsub(/^(#+)(\w)/) { |m| $1 + ' ' + $2 } %></div>
     </div>
 
   </div>


### PR DESCRIPTION
* [x] all tests pass -- `rake test:all`

To fix https://github.com/publiclab/PublicLab.Editor/issues/90