### PR TITLE
start to modularization of inline markdown editor

### DIFF
--- a/app/assets/javascripts/wikis.js
+++ b/app/assets/javascripts/wikis.js
@@ -1,32 +1,19 @@
-//= require wikis/processSections.js
-//= require wikis/replaceWithMarkdown.js
-
-/*
-* [edit]
-*/
-
+//= require wikis/inlineMarkdownEditor.js
 function setupWiki(node_id, raw, logged_in) {
   // insert inline forms
   if (raw && logged_in) {
     $('#content-raw-markdown').html(shortCodePrompt($('#content-raw-markdown')[0], { submitUrl: '/wiki/replace/' + node_id }));
     inlineMarkdownEditor({
       replaceUrl: '/wiki/replace/' + node_id,
-      selector: '#content-raw-markdown'
+      selector: '#content-raw-markdown',
+      preProcessor: preProcessMarkdown,
+      postProcessor: postProcessContent
     });
     $('#content').hide();
   } else {
     $('#content').html(shortCodePrompt($('#content')[0], { submitUrl: '/wiki/replace/' + node_id }));
-    postProcessContent($('#content'));
+    postProcessContent();
   }
-}
-
-function inlineMarkdownEditor(o) {
-  var el = $(o.selector);
-  // split by double-newline:
-  var sections = el.html().split('\n\n');
-  el.html('');
-  processSections(sections, o.selector, node_id);
-  el.show();
 }
 
 // add #hashtag and @callout links, extra CSS and deep links
@@ -36,6 +23,7 @@ function postProcessContent(element) {
   /* setup bootstrap behaviors */
   element.find("[rel=tooltip]").tooltip();
   element.find("[rel=popover]").popover({container: 'body'});
+
   element.find('table').addClass('table');
 }
 

--- a/app/assets/javascripts/wikis.js
+++ b/app/assets/javascripts/wikis.js
@@ -9,16 +9,24 @@ function setupWiki(node_id, raw, logged_in) {
   // insert inline forms
   if (raw && logged_in) {
     $('#content-raw-markdown').html(shortCodePrompt($('#content-raw-markdown')[0], { submitUrl: '/wiki/replace/' + node_id }));
-    // split by double-newline:
-    var sections = $('#content-raw-markdown').html().split('\n\n');
-    $('#content-raw-markdown').html('');
-    processSections(sections, '#content-raw-markdown', node_id);
+    inlineMarkdownEditor({
+      replaceUrl: '/wiki/replace/' + node_id,
+      selector: '#content-raw-markdown'
+    });
     $('#content').hide();
-    $('#content-raw-markdown').show();
   } else {
     $('#content').html(shortCodePrompt($('#content')[0], { submitUrl: '/wiki/replace/' + node_id }));
     postProcessContent($('#content'));
   }
+}
+
+function inlineMarkdownEditor(o) {
+  var el = $(o.selector);
+  // split by double-newline:
+  var sections = el.html().split('\n\n');
+  el.html('');
+  processSections(sections, o.selector, node_id);
+  el.show();
 }
 
 // add #hashtag and @callout links, extra CSS and deep links

--- a/app/assets/javascripts/wikis/inlineMarkdownEditor.js
+++ b/app/assets/javascripts/wikis/inlineMarkdownEditor.js
@@ -1,0 +1,15 @@
+//= require wikis/processSections.js
+
+function inlineMarkdownEditor(o) {
+  var el = $(o.selector);
+  // split by double-newline:
+  var sections = el.html().split('\n\n');
+  el.html('');
+  processSections(sections, {
+    replaceUrl: o.replaceUrl,
+    selector: o.selector,
+    preProcessor: o.preProcessor,
+    postProcessor: o.postProcessor
+  });
+  el.show();
+}


### PR DESCRIPTION

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
