### PR TITLE
Navbar render on 404 only '/' link - Fixes #1211

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,9 +361,3 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   will_paginate (>= 3.0.6)
   will_paginate-bootstrap (>= 1.0.1)
-
-RUBY VERSION
-   ruby 2.1.2p95
-
-BUNDLED WITH
-   1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,3 +361,9 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   will_paginate (>= 3.0.6)
   will_paginate-bootstrap (>= 1.0.1)
+
+RUBY VERSION
+   ruby 2.1.2p95
+
+BUNDLED WITH
+   1.13.7

--- a/public/404.html
+++ b/public/404.html
@@ -24,7 +24,6 @@
         <!-- ||| menu, displayed for mobile: -->
         <div class="navbar-header">
           <a class="navbar-brand" id="brand" href="/">Public Lab</a>
-          <a class="navbar-brand" id="brand-compact" href="/">PL</a>
         </div>
 
       </div>

--- a/public/404.html
+++ b/public/404.html
@@ -19,144 +19,15 @@
   <body>
 
     <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
-     
+
       <div class="container">
-  
-  
         <!-- ||| menu, displayed for mobile: -->
         <div class="navbar-header">
           <a class="navbar-brand" id="brand" href="/">Public Lab</a>
           <a class="navbar-brand" id="brand-compact" href="/">PL</a>
-   
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#header-navbar-collapse">
-            <span class="fa fa-white fa-bars"></span>
-          </button>
         </div>
-  
-  
-        <div class="collapse navbar-collapse" id="header-navbar-collapse">
-  
-          <ul class="nav navbar-nav navbar-left">
-   
-            
-   
-            <li class="dropdown">
-   
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Projects <b class="caret"></b>
-              </a>
-   
-              <ul class="dropdown-menu">
-   
-                <li class="dropdown-header">Research</li>
-   
-                <li><a href="/research/">Research notes</a></li>
-                <li><a href="/wiki/">Public Lab Wiki</a></li>
-                <li><a href="/tools">Tools</a></li>
-                <li><a href="/places">Places</a></li>
-   
-                <li class="divider"></li>
-   
-                <li class="dropdown-header">Initiatives</li>
-   
-                <li><a href="/wiki/nonprofit-initiatives#Open+Land">Open Land</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Water">Open Water</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Air">Open Air</a></li>
-                <li><a href="/wiki/kits">Kits</a></li>
-   
-                <li class="divider"></li>
-   
-                <li><a href="/wiki/fellows">Fellows</a></li>
-                <li><a href="/wiki/lending-library">Lending Library</a></li>
-              </ul>
-   
-            </li>
-          </ul>
-  
-          <form id="searchform" class="navbar-form navbar-left" role="search" autocomplete="off">
-            <div class="form-group">
-              <input tabindex="1" id="searchform_input" type="text" class="form-control search-query typeahead" data-provide="typeahead" placeholder="Search">
-            </div>
-            <button type="submit" class="btn btn-primary" style="background:#444;border-color:#222;"><i class="fa fa-search"></i></button>
-          </form>
-   
-          <ul class="nav navbar-nav">
-  
-            <li class="dropdown hidden-xs hidden-sm">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                About <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/wiki/stories">Stories</a></li>
-                <li><a href="/blog">Blog</a></li>
-                <li><a href="/about">About Public Lab</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/plots-staff">Non-profit team</a></li>
-                <li><a href="/wiki/organizers">Organizers</a></li>
-                <li><a href="/wiki/board">Non-profit board</a></li>
-                <li><a href="/wiki/how-public-lab-funded">How we're funded</a></li>
-                <li class="divider"></li>
-                <li><a href="/media">Press and Media</a></li>
-                <li><a href="/wiki/contact">Contact the staff</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Get Involved <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/getting-started">Getting started</a></li>
-                <li class="divider"></li>
-                <li><a href="/signup">Join the website</a></li>
-                <li><a href="/lists">Join one of our discussion lists</a></li>
-                <li><a href="/events">Attend an event</a></li>
-                <li><a href="/wiki/post-an-event">Post an event</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/start-a-chapter">Starting new chapters</a></li>
-                <li><a href="/wiki/new-projects">Starting new projects</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/organizers">Become an organizer</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                Data 
-                <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/archive">Public Lab Archive</a></li>
-                <li class="dropdown-header">Web tools</li>
-                <li><a href="//mapknitter.org">MapKnitter</a></li>
-                <li><a href="//spectralworkbench.org">Spectral Workbench</a></li>
-                <li><a href="//infragram.org">Infragram</a></li>
-                <li><a href="//openwaterproject.io">Open Water</a></li>
-              </ul>
-            </li>
-  
-            <li class="hidden-xs hidden-sm hidden-md"><a href="/donate">Donate</a></li>
-            <li class="hidden-xs hidden-sm hidden-md"><a href="//store.publiclab.org">Store</a></li>
-  
-          </ul>
-   
-          <div id="chat" class="chat-popover" data-placement="bottom" style="display:none;">
-            <a style="margin-right:4px;" class="pull-right btn btn-sm" href="https://webchat.oftc.net/?channels=publiclab" target="_blank">pop out</a>
-            <p class="popover-title">Public Lab chatroom</p>
-            <iframe width="400px" height="300px" src="https://webchat.oftc.net/?channels=publiclab"></iframe>
-          </div>
-   
-          <a rel="tooltip" title="Become part of this community" data-placement="bottom" style="margin-left:14px;" href="/signup" class="btn btn-primary navbar-btn navbar-right hidden-xs">Join</a>
-   
-            <ul class="nav navbar-nav navbar-right">
-              <li class="dropdown">
-                <a onClick="$('#chat').toggle()">
-                  <i class="fa fa-white fa fa-comments"></i>
-                </a> 
-              </li>
-            </ul>
-         </div>
-       </div>
+
+      </div>
     </nav>
 
     <div class="container">
@@ -170,45 +41,45 @@
         </div>
 
         <div class="col-md-9">
-    
+
           <h1>That page does not exist.</h1>
-      
+
           <p>Are you sure you've typed the right address?</p>
-   
+
           <hr />
-   
+
           <p>Please help us figure out what happened so we can fix it!</p>
-   
+
           <p>If possible, please describe:</p>
-   
-          <ul> 
+
+          <ul>
             <li>what you did just before the problem occurred</li>
             <li>your browser and browser version</li>
             <li>your operating system</li>
             <li>any web addresses needed to see the problem (such as the URL of this page)</li>
             <li>your PublicLab.org username (if you have one)</li>
-          </ul> 
-   
+          </ul>
+
           <p><a class="btn btn-primary" href="https://github.com/publiclab/plots2/issues/new">Report a bug on Github</a> or send an email to <a href="mailto:web@publiclab.org">web@publiclab.org</a> with the above information.</p>
-   
+
           <p>Thank you for helping to improve open source software!.</p>
-   
+
           <hr />
-      
+
           <h2>Ask for help in the Public Lab chatroom</h2>
-      
+
           <p>Community members and staff may be able to help you in real time.</p>
-      
+
           <script>
             chatroom = function() {
               $('#chat').append('<iframe width="100%" height="300px" style="border:none;" src="https://webchat.oftc.net/?channels=publiclab"></iframe>')
             }
           </script>
-      
+
           <p><a class="btn btn-primary" onClick="chatroom()">Open chatroom</a></p>
-   
+
           <div id="chat"></div>
-      
+
         </div>
 
 <!-- ################################################ -->
@@ -270,7 +141,7 @@
       _gaq.push(['_setDomainName', 'publiclab.org']);
       _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
-    
+
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
         //ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -278,8 +149,7 @@
 
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
-    
+
     </script>
   </body>
 </html>
-

--- a/public/404.html
+++ b/public/404.html
@@ -19,13 +19,10 @@
   <body>
 
     <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
-
       <div class="container">
-        <!-- ||| menu, displayed for mobile: -->
         <div class="navbar-header">
           <a class="navbar-brand" id="brand" href="/">Public Lab</a>
         </div>
-
       </div>
     </nav>
 

--- a/public/404.html
+++ b/public/404.html
@@ -20,8 +20,8 @@
 
     <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
       <div class="container">
-        <div class="navbar-header">
-          <a class="navbar-brand" id="brand" href="/">Public Lab</a>
+        <div class="navbar-header" style="float:none; text-align:center;">
+          <a class="navbar-brand" id="brand" href="/" style="text-align:center; position:absolute">Public Lab</a>
         </div>
       </div>
     </nav>

--- a/public/422.html
+++ b/public/422.html
@@ -18,146 +18,14 @@
 
   <body>
 
-    <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
-     
-      <div class="container">
-  
-  
-        <!-- ||| menu, displayed for mobile: -->
-        <div class="navbar-header">
-          <a class="navbar-brand" id="brand" href="/">Public Lab</a>
-          <a class="navbar-brand" id="brand-compact" href="/">PL</a>
-   
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#header-navbar-collapse">
-            <span class="fa fa-white fa-bars"></span>
-          </button>
-        </div>
-  
-  
-        <div class="collapse navbar-collapse" id="header-navbar-collapse">
-  
-          <ul class="nav navbar-nav navbar-left">
-   
-            
-   
-            <li class="dropdown">
-   
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Projects <b class="caret"></b>
-              </a>
-   
-              <ul class="dropdown-menu">
-   
-                <li class="dropdown-header">Research</li>
-   
-                <li><a href="/research/">Research notes</a></li>
-                <li><a href="/wiki/">Public Lab Wiki</a></li>
-                <li><a href="/tools">Tools</a></li>
-                <li><a href="/places">Places</a></li>
-   
-                <li class="divider"></li>
-   
-                <li class="dropdown-header">Initiatives</li>
-   
-                <li><a href="/wiki/nonprofit-initiatives#Open+Land">Open Land</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Water">Open Water</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Air">Open Air</a></li>
-                <li><a href="/wiki/kits">Kits</a></li>
-   
-                <li class="divider"></li>
-   
-                <li><a href="/wiki/fellows">Fellows</a></li>
-                <li><a href="/wiki/lending-library">Lending Library</a></li>
-              </ul>
-   
-            </li>
-          </ul>
-  
-          <form id="searchform" class="navbar-form navbar-left" role="search" autocomplete="off">
-            <div class="form-group">
-              <input tabindex="1" id="searchform_input" type="text" class="form-control search-query typeahead" data-provide="typeahead" placeholder="Search">
-            </div>
-            <button type="submit" class="btn btn-primary" style="background:#444;border-color:#222;"><i class="fa fa-search"></i></button>
-          </form>
-   
-          <ul class="nav navbar-nav">
-  
-            <li class="dropdown hidden-xs hidden-sm">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                About <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/wiki/stories">Stories</a></li>
-                <li><a href="/blog">Blog</a></li>
-                <li><a href="/about">About Public Lab</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/plots-staff">Non-profit team</a></li>
-                <li><a href="/wiki/organizers">Organizers</a></li>
-                <li><a href="/wiki/board">Non-profit board</a></li>
-                <li><a href="/wiki/how-public-lab-funded">How we're funded</a></li>
-                <li class="divider"></li>
-                <li><a href="/media">Press and Media</a></li>
-                <li><a href="/wiki/contact">Contact the staff</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Get Involved <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/getting-started">Getting started</a></li>
-                <li class="divider"></li>
-                <li><a href="/signup">Join the website</a></li>
-                <li><a href="/lists">Join one of our discussion lists</a></li>
-                <li><a href="/events">Attend an event</a></li>
-                <li><a href="/wiki/post-an-event">Post an event</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/start-a-chapter">Starting new chapters</a></li>
-                <li><a href="/wiki/new-projects">Starting new projects</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/organizers">Become an organizer</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                Data 
-                <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/archive">Public Lab Archive</a></li>
-                <li class="dropdown-header">Web tools</li>
-                <li><a href="//mapknitter.org">MapKnitter</a></li>
-                <li><a href="//spectralworkbench.org">Spectral Workbench</a></li>
-                <li><a href="//infragram.org">Infragram</a></li>
-                <li><a href="//openwaterproject.io">Open Water</a></li>
-              </ul>
-            </li>
-  
-            <li class="hidden-xs hidden-sm hidden-md"><a href="/donate">Donate</a></li>
-            <li class="hidden-xs hidden-sm hidden-md"><a href="//store.publiclab.org">Store</a></li>
-  
-          </ul>
-   
-          <div id="chat" class="chat-popover" data-placement="bottom" style="display:none;">
-            <a style="margin-right:4px;" class="pull-right btn btn-sm" href="https://webchat.oftc.net/?channels=publiclab" target="_blank">pop out</a>
-            <p class="popover-title">Public Lab chatroom</p>
-            <iframe width="400px" height="300px" src="https://webchat.oftc.net/?channels=publiclab"></iframe>
+
+      <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
+        <div class="container">
+          <div class="navbar-header">
+            <a class="navbar-brand" id="brand" href="/">Public Lab</a>
           </div>
-   
-          <a rel="tooltip" title="Become part of this community" data-placement="bottom" style="margin-left:14px;" href="/signup" class="btn btn-primary navbar-btn navbar-right hidden-xs">Join</a>
-   
-            <ul class="nav navbar-nav navbar-right">
-              <li class="dropdown">
-                <a onClick="$('#chat').toggle()">
-                  <i class="fa fa-white fa fa-comments"></i>
-                </a> 
-              </li>
-            </ul>
-         </div>
-       </div>
-    </nav>
+        </div>
+      </nav>
 
     <div class="container">
 
@@ -170,45 +38,45 @@
         </div>
 
         <div class="col-md-9">
-    
+
           <h2>There was a problem with your request. <small>Are you sure you have permissions to do that?</small></h2>
-      
+
           <p>Or it may be our servers!</p>
-   
+
           <hr />
-   
+
           <p>Please help us figure out what happened so we can fix it!</p>
-   
+
           <p>If possible, please describe:</p>
-   
-          <ul> 
+
+          <ul>
             <li>what you did just before the problem occurred</li>
             <li>your browser and browser version</li>
             <li>your operating system</li>
             <li>any web addresses needed to see the problem (such as the URL of this page)</li>
             <li>your PublicLab.org username (if you have one)</li>
-          </ul> 
-   
+          </ul>
+
           <p><a class="btn btn-primary" href="https://github.com/publiclab/plots2/issues/new">Report a bug on Github</a> or send an email to <a href="mailto:web@publiclab.org">web@publiclab.org</a> with the above information.</p>
-   
+
           <p>Thank you for helping to improve open source software!.</p>
-   
+
           <hr />
-      
+
           <h2>Ask for help in the Public Lab chatroom</h2>
-      
+
           <p>Community members and staff may be able to help you in real time.</p>
-      
+
           <script>
             chatroom = function() {
               $('#chat').append('<iframe width="100%" height="300px" style="border:none;" src="https://webchat.oftc.net/?channels=publiclab"></iframe>')
             }
           </script>
-      
+
           <p><a class="btn btn-primary" onClick="chatroom()">Open chatroom</a></p>
-   
+
           <div id="chat"></div>
-      
+
         </div>
 
 <!-- ################################################ -->
@@ -270,7 +138,7 @@
       _gaq.push(['_setDomainName', 'publiclab.org']);
       _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
-    
+
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
         //ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -278,7 +146,7 @@
 
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
-    
+
     </script>
   </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -18,145 +18,13 @@
 
   <body>
 
+
     <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
-     
       <div class="container">
-  
-  
-        <!-- ||| menu, displayed for mobile: -->
         <div class="navbar-header">
           <a class="navbar-brand" id="brand" href="/">Public Lab</a>
-          <a class="navbar-brand" id="brand-compact" href="/">PL</a>
-   
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#header-navbar-collapse">
-            <span class="fa fa-white fa-bars"></span>
-          </button>
         </div>
-  
-  
-        <div class="collapse navbar-collapse" id="header-navbar-collapse">
-  
-          <ul class="nav navbar-nav navbar-left">
-   
-            
-   
-            <li class="dropdown">
-   
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Projects <b class="caret"></b>
-              </a>
-   
-              <ul class="dropdown-menu">
-   
-                <li class="dropdown-header">Research</li>
-   
-                <li><a href="/research/">Research notes</a></li>
-                <li><a href="/wiki/">Public Lab Wiki</a></li>
-                <li><a href="/tools">Tools</a></li>
-                <li><a href="/places">Places</a></li>
-   
-                <li class="divider"></li>
-   
-                <li class="dropdown-header">Initiatives</li>
-   
-                <li><a href="/wiki/nonprofit-initiatives#Open+Land">Open Land</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Water">Open Water</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Air">Open Air</a></li>
-                <li><a href="/wiki/kits">Kits</a></li>
-   
-                <li class="divider"></li>
-   
-                <li><a href="/wiki/fellows">Fellows</a></li>
-                <li><a href="/wiki/lending-library">Lending Library</a></li>
-              </ul>
-   
-            </li>
-          </ul>
-  
-          <form id="searchform" class="navbar-form navbar-left" role="search" autocomplete="off">
-            <div class="form-group">
-              <input tabindex="1" id="searchform_input" type="text" class="form-control search-query typeahead" data-provide="typeahead" placeholder="Search">
-            </div>
-            <button type="submit" class="btn btn-primary" style="background:#444;border-color:#222;"><i class="fa fa-search"></i></button>
-          </form>
-   
-          <ul class="nav navbar-nav">
-  
-            <li class="dropdown hidden-xs hidden-sm">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                About <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/wiki/stories">Stories</a></li>
-                <li><a href="/blog">Blog</a></li>
-                <li><a href="/about">About Public Lab</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/plots-staff">Non-profit team</a></li>
-                <li><a href="/wiki/organizers">Organizers</a></li>
-                <li><a href="/wiki/board">Non-profit board</a></li>
-                <li><a href="/wiki/how-public-lab-funded">How we're funded</a></li>
-                <li class="divider"></li>
-                <li><a href="/media">Press and Media</a></li>
-                <li><a href="/wiki/contact">Contact the staff</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Get Involved <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/getting-started">Getting started</a></li>
-                <li class="divider"></li>
-                <li><a href="/signup">Join the website</a></li>
-                <li><a href="/lists">Join one of our discussion lists</a></li>
-                <li><a href="/events">Attend an event</a></li>
-                <li><a href="/wiki/post-an-event">Post an event</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/start-a-chapter">Starting new chapters</a></li>
-                <li><a href="/wiki/new-projects">Starting new projects</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/organizers">Become an organizer</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                Data 
-                <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/archive">Public Lab Archive</a></li>
-                <li class="dropdown-header">Web tools</li>
-                <li><a href="//mapknitter.org">MapKnitter</a></li>
-                <li><a href="//spectralworkbench.org">Spectral Workbench</a></li>
-                <li><a href="//infragram.org">Infragram</a></li>
-                <li><a href="//openwaterproject.io">Open Water</a></li>
-              </ul>
-            </li>
-  
-            <li class="hidden-xs hidden-sm hidden-md"><a href="/donate">Donate</a></li>
-            <li class="hidden-xs hidden-sm hidden-md"><a href="//store.publiclab.org">Store</a></li>
-  
-          </ul>
-   
-          <div id="chat" class="chat-popover" data-placement="bottom" style="display:none;">
-            <a style="margin-right:4px;" class="pull-right btn btn-sm" href="https://webchat.oftc.net/?channels=publiclab" target="_blank">pop out</a>
-            <p class="popover-title">Public Lab chatroom</p>
-            <iframe width="400px" height="300px" src="https://webchat.oftc.net/?channels=publiclab"></iframe>
-          </div>
-   
-          <a rel="tooltip" title="Become part of this community" data-placement="bottom" style="margin-left:14px;" href="/signup" class="btn btn-primary navbar-btn navbar-right hidden-xs">Join</a>
-   
-            <ul class="nav navbar-nav navbar-right">
-              <li class="dropdown">
-                <a onClick="$('#chat').toggle()">
-                  <i class="fa fa-white fa fa-comments"></i>
-                </a> 
-              </li>
-            </ul>
-         </div>
-       </div>
+      </div>
     </nav>
 
     <div class="container">
@@ -170,43 +38,43 @@
         </div>
 
         <div class="col-md-9">
-   
+
           <h2>There was an error. <small>Are you sure you have the right address?</small></h2>
 
           <hr />
-   
+
           <p>Please help us figure out what happened so we can fix it!</p>
-    
+
           <p>If possible, please describe:</p>
-    
-          <ul> 
+
+          <ul>
             <li>what you did just before the problem occurred</li>
             <li>your browser and browser version</li>
             <li>your operating system</li>
             <li>any web addresses needed to see the problem (such as the URL of this page)</li>
             <li>your PublicLab.org username (if you have one)</li>
-          </ul> 
-    
+          </ul>
+
           <p><a class="btn btn-primary" href="https://github.com/publiclab/plots2/issues/new">Report a bug on Github</a> or send an email to <a href="mailto:web@publiclab.org">web@publiclab.org</a> with the above information.</p>
-    
+
           <p>Thank you for helping to improve open source software!.</p>
-    
+
           <hr />
-   
+
           <h2>Ask for help in the Public Lab chatroom</h2>
-   
+
           <p>Community members and staff may be able to help you in real time.</p>
-   
+
           <script>
             chatroom = function() {
               $('#chat').append('<iframe width="100%" height="300px" style="border:none;" src="https://webchat.oftc.net/?channels=publiclab"></iframe>')
             }
           </script>
-   
+
           <p><a class="btn btn-primary" onClick="chatroom()">Open chatroom</a></p>
-    
+
           <div id="chat"></div>
-    
+
         </div>
 
 <!-- ################################################ -->
@@ -268,7 +136,7 @@
       _gaq.push(['_setDomainName', 'publiclab.org']);
       _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
-    
+
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
         //ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -276,8 +144,7 @@
 
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
-    
+
     </script>
   </body>
 </html>
-

--- a/public/502.html
+++ b/public/502.html
@@ -18,145 +18,13 @@
 
   <body>
 
+
     <nav id="header" class="navbar navbar-inverse navbar-fixed-top" style="margin-bottom:20px;">
-     
       <div class="container">
-  
-  
-        <!-- ||| menu, displayed for mobile: -->
         <div class="navbar-header">
           <a class="navbar-brand" id="brand" href="/">Public Lab</a>
-          <a class="navbar-brand" id="brand-compact" href="/">PL</a>
-   
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#header-navbar-collapse">
-            <span class="fa fa-white fa-bars"></span>
-          </button>
         </div>
-  
-  
-        <div class="collapse navbar-collapse" id="header-navbar-collapse">
-  
-          <ul class="nav navbar-nav navbar-left">
-   
-            
-   
-            <li class="dropdown">
-   
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Projects <b class="caret"></b>
-              </a>
-   
-              <ul class="dropdown-menu">
-   
-                <li class="dropdown-header">Research</li>
-   
-                <li><a href="/research/">Research notes</a></li>
-                <li><a href="/wiki/">Public Lab Wiki</a></li>
-                <li><a href="/tools">Tools</a></li>
-                <li><a href="/places">Places</a></li>
-   
-                <li class="divider"></li>
-   
-                <li class="dropdown-header">Initiatives</li>
-   
-                <li><a href="/wiki/nonprofit-initiatives#Open+Land">Open Land</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Water">Open Water</a></li>
-                <li><a href="/wiki/nonprofit-initiatives#Open+Air">Open Air</a></li>
-                <li><a href="/wiki/kits">Kits</a></li>
-   
-                <li class="divider"></li>
-   
-                <li><a href="/wiki/fellows">Fellows</a></li>
-                <li><a href="/wiki/lending-library">Lending Library</a></li>
-              </ul>
-   
-            </li>
-          </ul>
-  
-          <form id="searchform" class="navbar-form navbar-left" role="search" autocomplete="off">
-            <div class="form-group">
-              <input tabindex="1" id="searchform_input" type="text" class="form-control search-query typeahead" data-provide="typeahead" placeholder="Search">
-            </div>
-            <button type="submit" class="btn btn-primary" style="background:#444;border-color:#222;"><i class="fa fa-search"></i></button>
-          </form>
-   
-          <ul class="nav navbar-nav">
-  
-            <li class="dropdown hidden-xs hidden-sm">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                About <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/wiki/stories">Stories</a></li>
-                <li><a href="/blog">Blog</a></li>
-                <li><a href="/about">About Public Lab</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/plots-staff">Non-profit team</a></li>
-                <li><a href="/wiki/organizers">Organizers</a></li>
-                <li><a href="/wiki/board">Non-profit board</a></li>
-                <li><a href="/wiki/how-public-lab-funded">How we're funded</a></li>
-                <li class="divider"></li>
-                <li><a href="/media">Press and Media</a></li>
-                <li><a href="/wiki/contact">Contact the staff</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a class="dropdown-toggle" data-toggle="dropdown">
-                Get Involved <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/getting-started">Getting started</a></li>
-                <li class="divider"></li>
-                <li><a href="/signup">Join the website</a></li>
-                <li><a href="/lists">Join one of our discussion lists</a></li>
-                <li><a href="/events">Attend an event</a></li>
-                <li><a href="/wiki/post-an-event">Post an event</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/start-a-chapter">Starting new chapters</a></li>
-                <li><a href="/wiki/new-projects">Starting new projects</a></li>
-                <li class="divider"></li>
-                <li><a href="/wiki/organizers">Become an organizer</a></li>
-              </ul>
-            </li>
-  
-            <li class="dropdown hidden-xs hidden-sm hidden-md">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                Data 
-                <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/archive">Public Lab Archive</a></li>
-                <li class="dropdown-header">Web tools</li>
-                <li><a href="//mapknitter.org">MapKnitter</a></li>
-                <li><a href="//spectralworkbench.org">Spectral Workbench</a></li>
-                <li><a href="//infragram.org">Infragram</a></li>
-                <li><a href="//openwaterproject.io">Open Water</a></li>
-              </ul>
-            </li>
-  
-            <li class="hidden-xs hidden-sm hidden-md"><a href="/donate">Donate</a></li>
-            <li class="hidden-xs hidden-sm hidden-md"><a href="//store.publiclab.org">Store</a></li>
-  
-          </ul>
-   
-          <div id="chat" class="chat-popover" data-placement="bottom" style="display:none;">
-            <a style="margin-right:4px;" class="pull-right btn btn-sm" href="https://webchat.oftc.net/?channels=publiclab" target="_blank">pop out</a>
-            <p class="popover-title">Public Lab chatroom</p>
-            <iframe width="400px" height="300px" src="https://webchat.oftc.net/?channels=publiclab"></iframe>
-          </div>
-   
-          <a rel="tooltip" title="Become part of this community" data-placement="bottom" style="margin-left:14px;" href="/signup" class="btn btn-primary navbar-btn navbar-right hidden-xs">Join</a>
-   
-            <ul class="nav navbar-nav navbar-right">
-              <li class="dropdown">
-                <a onClick="$('#chat').toggle()">
-                  <i class="fa fa-white fa fa-comments"></i>
-                </a> 
-              </li>
-            </ul>
-         </div>
-       </div>
+      </div>
     </nav>
 
     <div class="container">
@@ -170,45 +38,45 @@
         </div>
 
         <div class="col-md-9">
-    
+
           <h2>The internet is being slow...</h2>
-      
+
           <p>Or it may be our servers!</p>
-   
+
           <hr />
-   
+
           <p>Please help us figure out what happened so we can fix it!</p>
-   
+
           <p>If possible, please describe:</p>
-   
-          <ul> 
+
+          <ul>
             <li>what you did just before the problem occurred</li>
             <li>your browser and browser version</li>
             <li>your operating system</li>
             <li>any web addresses needed to see the problem (such as the URL of this page)</li>
             <li>your PublicLab.org username (if you have one)</li>
-          </ul> 
-   
+          </ul>
+
           <p><a class="btn btn-primary" href="https://github.com/publiclab/plots2/issues/new">Report a bug on Github</a> or send an email to <a href="mailto:web@publiclab.org">web@publiclab.org</a> with the above information.</p>
-   
+
           <p>Thank you for helping to improve open source software!.</p>
-   
+
           <hr />
-      
+
           <h2>Ask for help in the Public Lab chatroom</h2>
-      
+
           <p>Community members and staff may be able to help you in real time.</p>
-      
+
           <script>
             chatroom = function() {
               $('#chat').append('<iframe width="100%" height="300px" style="border:none;" src="https://webchat.oftc.net/?channels=publiclab"></iframe>')
             }
           </script>
-      
+
           <p><a class="btn btn-primary" onClick="chatroom()">Open chatroom</a></p>
-   
+
           <div id="chat"></div>
-      
+
         </div>
 
 <!-- ################################################ -->
@@ -270,7 +138,7 @@
       _gaq.push(['_setDomainName', 'publiclab.org']);
       _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
-    
+
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
         //ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -278,9 +146,7 @@
 
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
-    
+
     </script>
   </body>
 </html>
-
-


### PR DESCRIPTION
This is an initial render of a 404 page with the limited navbar, per issue Fixes #1211 
See screenshot for below for feedback/ideas, as I know this is still an issue that still needs decision making before any merging.   Thank you for taking a look and I welcome any feedback!

<img width="1255" alt="screen shot 2017-02-24 at 9 21 44 am" src="https://cloud.githubusercontent.com/assets/19432922/23311507/92e865c8-fa73-11e6-8d86-c527c33afb53.png">


* [x ] all tests pass -- `rake test:all`
* [x ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ x] pull request is descriptively named with #number reference back to original issue
