### PR TITLE
tests for redirect function

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -26,9 +26,9 @@ class WikiController < ApplicationController
       @node = DrupalNode.find_wiki(params[:id])
     end
 
-    if @node && @node.has_power_tag('redirect')
+    if @node && @node.has_power_tag('redirect') && Node.where(nid: @node.power_tag('redirect')).exists?
       if current_user == nil || (current_user.role != 'admin' && current_user.role != 'moderator')
-        redirect_to DrupalNode.find(@node.power_tag('redirect')).path
+        redirect_to Node.find(@node.power_tag('redirect')).path
         return
       elsif (current_user.role == 'admin' || current_user.role == 'moderator')
         flash.now[:warning] = "Only moderators and admins see this page, as it is redirected to #{DrupalNode.find(@node.power_tag('redirect')).title}.

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -504,6 +504,17 @@ class WikiControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "redirect to non-existent page fails gracefully; no redirect" do
+    wiki = node(:wiki_page)
+    slug = wiki.path.gsub('/wiki/', '')
+    blog = node(:blog)
+    wiki.add_tag("redirect:nonsense", rusers(:bob))
+    assert_equal wiki.power_tag('redirect'), "nonsense"
+
+    get :show, id: slug
+    assert_response :success
+  end
+
   test "redirect normal user to tagged page" do
     wiki = node(:wiki_page)
     slug = wiki.path.gsub('/wiki/', '')

--- a/test/unit/drupal_node_tag_test.rb
+++ b/test/unit/drupal_node_tag_test.rb
@@ -181,10 +181,4 @@ class DrupalNodeTagTest < ActiveSupport::TestCase
     assert_equal I18n.t('drupal_node.only_admins_can_lock'), node(:blog).can_tag('locked', rusers(:bob), true)
   end
 
-  test "redirect tags to non-existent pages should not be accepted" do
-    assert_false node(:blog).can_tag('redirect:nonsense', rusers(:bob))
-    assert node(:blog).can_tag('locked', rusers(:admin))
-    assert_equal I18n.t('drupal_node.only_admins_can_lock'), node(:blog).can_tag('locked', rusers(:bob), true)
-  end
-
 end

--- a/test/unit/drupal_node_tag_test.rb
+++ b/test/unit/drupal_node_tag_test.rb
@@ -181,4 +181,10 @@ class DrupalNodeTagTest < ActiveSupport::TestCase
     assert_equal I18n.t('drupal_node.only_admins_can_lock'), node(:blog).can_tag('locked', rusers(:bob), true)
   end
 
+  test "redirect tags to non-existent pages should not be accepted" do
+    assert_false node(:blog).can_tag('redirect:nonsense', rusers(:bob))
+    assert node(:blog).can_tag('locked', rusers(:admin))
+    assert_equal I18n.t('drupal_node.only_admins_can_lock'), node(:blog).can_tag('locked', rusers(:bob), true)
+  end
+
 end


### PR DESCRIPTION
These tests fail, in order to demonstrate fixes we should make -- issue to be opened soon.



* [ ] all tests pass -- `rake test:all`
