### PR TITLE
fixes #1198 - Tested email notifications to author on question answers

### DIFF
--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -17,7 +17,7 @@ class AnswersControllerTest < ActionController::TestCase
                    body: "Sample answer"
       end
     end
-    assert ActionMailer::Base.deliveries.collect(&:to).includes?('author@email.com')
+    assert ActionMailer::Base.deliveries.collect(&:to).includes?(node(:question).author.email)
     assert_response :success
     assert_not_nil assigns(:answer)
   end

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -9,11 +9,15 @@ class AnswersControllerTest < ActionController::TestCase
   test "should get create if user is logged in" do
     UserSession.create(rusers(:bob))
     node = node(:question)
-    assert_difference 'Answer.count' do
-      xhr :post, :create,
-                 nid: node.nid,
-                 body: "Sample answer"
+    count = ActionMailer::Base.deliveries.length
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      assert_difference 'Answer.count' do
+        xhr :post, :create,
+                   nid: node.nid,
+                   body: "Sample answer"
+      end
     end
+    assert ActionMailer::Base.deliveries.collect(&:to).includes?('author@email.com')
     assert_response :success
     assert_not_nil assigns(:answer)
   end


### PR DESCRIPTION
Added test to make sure that user who created a question is notified of
proposed answers.

