### PR TITLE
fixes #1198 - Send mail to question's author on new answer create and test this

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -26,17 +26,17 @@ class Answer < ActiveRecord::Base
 
   def answer_notify(current_user)
     # notify question author
-    if current_user.uid != self.author.uid
-      AnswerMailer.notify_question_author(self.author, self).deliver
+    if current_user.uid != self.node.author.uid
+      AnswerMailer.notify_question_author(self.node.author, self).deliver
     end
 
     uids =  (self.node.answers.collect(&:uid) + self.node.likers.collect(&:uid)).uniq
 
     # notify other answer authors and users who liked the question
     DrupalUsers.where("uid IN (?)", uids).each do |user|
-      if user.uid != (current_user.uid && self.author.uid)
+      if (user.uid != current_user.uid) && (user.uid != self.node.author.uid)
         AnswerMailer.notify_answer_likers_author(user.user, self).deliver
       end
     end
-  end 
+  end
 end

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -9,11 +9,15 @@ class AnswersControllerTest < ActionController::TestCase
   test "should get create if user is logged in" do
     UserSession.create(rusers(:bob))
     node = node(:question)
+    initial_mail_count = ActionMailer::Base.deliveries.size
     assert_difference 'Answer.count' do
       xhr :post, :create,
                  nid: node.nid,
                  body: "Sample answer"
     end
+    assert_not_equal initial_mail_count, ActionMailer::Base.deliveries.size
+    assert ActionMailer::Base.deliveries.collect(&:to).include?([node.author.mail])
+    # Used ([node.author.mail]) here instead of just (node.author.mail) because .collect(:to) is an array of arrays
     assert_response :success
     assert_not_nil assigns(:answer)
   end


### PR DESCRIPTION
Original Issue [#1198](https://github.com/publiclab/plots2/issues/1198)

I have made changes to `answer` model's `answer_notify` method. Earlier, the mail was not being sent to the question's author. After this commit, the mail is being sent and the tests are passing.

Also see, pull #1237 (not by me) which implements the proposed solution but the tests fail.

Thank you.

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
