### PR TITLE
bower update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "moment": "~2.10.6",
     "junction": "theleagueof/junction",
     "publiclab-editor": "~0.2.0",
-    "inline-markdown-editor": "~0.0.3",
+    "inline-markdown-editor": "~0.1.0",
     "leaflet-d3": "^0.3.8",
     "woofmark": "~4.2.0",
     "horsey": "3.0.0",


### PR DESCRIPTION
updating inline-markdown-editor version with bugfixes

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
