### PR TITLE
re-enable solr-specific tests, next Solr steps

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -6,8 +6,8 @@ namespace :test do
     Coveralls::RakeTask.new
     puts "Running Rails tests"
     Rake::Task["test"].execute
-    #puts "Running Solr-dependent tests"
-    #Rake::Task["test:solr"].execute
+    puts "Running Solr-dependent tests"
+    Rake::Task["test:solr"].execute
     puts "Running jasmine tests headlessly"
     Rake::Task["spec:javascript"].execute
     Rake::Task["coveralls:push"].execute


### PR DESCRIPTION
* [ ] figure out why Coveralls isn't running on here, and get it running so we can see if coverage drops - maybe by reopening this from `publiclab/plots2`?
* [ ] re-enable test.rake "solr-specific" tests in such a way as to not confuse Coveralls and maintain 86% coverage -- this may be due to those extra tests running in a subshell...
  * possibly with http://stackoverflow.com/questions/18894060/rails-and-minitest-add-additional-folder
  * possibly using alternative shell command runner: http://stackoverflow.com/questions/2232/calling-shell-commands-from-ruby#2400 
* [ ] fix tests on `test/solr/search_record_test.rb:50` to ensure unique results are actually returned
  * was this bc it was not actually indexing? So, maybe if we get Solr indexing properly, this will pass. 
* [ ] document why 23-hour reindex is needed, or fix the toggle to make this unnecessary
* [ ] re-enable solr on production

Then, the rest of this:

* [ ] get `branch1` building from this PR
* [ ] reindexing and then looking for if a search for "balloon" works on this page: http://branch1.laboratoriopublico.org/searches/new
* [ ] Once it does, we want to try turning off Solr and ensuring the site doesn't break (as the new toggle code should allow for).
* [ ] then, we can try merging in #1366, and seeing if http://branch1.laboratoriopublico.org/search/dynamic returns results for `balloon` with Solr on AND off
* [ ] then we have to do the remainder of #1366's listed to-dos