### PR TITLE
map grids!

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,7 @@ module ApplicationHelper
     body = NodeShared.questions_grid(body)
     body = NodeShared.activities_grid(body)
     body = NodeShared.upgrades_grid(body)
+    body = NodeShared.notes_map(body)
     body
   end
 

--- a/app/models/drupal_node_revision.rb
+++ b/app/models/drupal_node_revision.rb
@@ -100,7 +100,7 @@ class DrupalNodeRevision < ActiveRecord::Base
   # filtered version of node content
   def render_body
     body = self.body || ''
-    body = RDiscount.new(body, :generate_toc)
+    body = RDiscount.new(body)
     body = body.to_html
     body = body.gsub(Callouts.const_get(:FINDER), Callouts.const_get(:PRETTYLINKHTML))
     body = body.gsub(Callouts.const_get(:HASHTAG), Callouts.const_get(:HASHLINKHTML))

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag "locationForm" %>
+<%= javascript_include_tag "location_tags.js" %>
 <style>
 
 .font-size-small {
@@ -49,3 +51,4 @@
     </div>
   </div>
 </div>
+<script src="https://maps.googleapis.com/maps/api/js?libraries=places&language=en&key=AIzaSyDWgc7p4WWFsO3y0MTe50vF4l4NUPcPuwE"></script>

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -1,16 +1,13 @@
-<% unique_id = rand(10) %>
-<%= javascript_include_tag "locationForm" %>
-<%= javascript_include_tag "location_tags.js" %>
+<% unique_id = rand(100) %>
 <style>
   #map<%= unique_id %> { width:100%; height:300px; margin: 0; position: relative;}
 </style>
 <div class="leaflet-map" id="map<%= unique_id %>"></div>
 <script>
-    var map = L.map('map<%= unique_id %>').setView([<%= lat %>,<%= lon %>], 10);
-    L.tileLayer("https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png").addTo(map);
+  var map = L.map('map<%= unique_id %>').setView([<%= lat %>,<%= lon %>], 10);
+  L.tileLayer("//a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png").addTo(map);
 
-    <% items.each do |item| %>
+  <% items.each do |item| %>
     L.marker([<%= item.lat %>, <%= item.lon %>]).addTo(map).bindPopup("<a href='/<%= item.path %>'><%= item.title %></a>");
-    <% end %>
+  <% end %>
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?libraries=places&language=en&key=AIzaSyDWgc7p4WWFsO3y0MTe50vF4l4NUPcPuwE"></script>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -68,7 +68,9 @@
       <div <% unless @node.has_tag('style:wide') %>style="max-width:800px;"<% end %> id="content" class="pl-content wiki">
         <%= raw auto_link(insert_extras(@revision.render_body), sanitize: false) %>
       </div>
-      <div style="display:none;" id="content-raw-markdown" class="pl-content wiki"><%= raw insert_extras(@revision.body_raw) %></div>
+      <% if params[:raw] == 'true' %>
+        <div style="display:none;" id="content-raw-markdown" class="pl-content wiki"><%= raw insert_extras(@revision.body_raw) %></div>
+      <% end %>
     </div>
 
   </div>

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -24,11 +24,11 @@ question:
 
 map_lat:
   tid: 7
-  name: lat:71
+  name: lat:71.0
 
 map_lon:
   tid: 8
-  name: lon:52
+  name: lon:52.0
 
 blog:
   tid: 9

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -72,7 +72,7 @@ class WikiControllerTest < ActionController::TestCase
 
       assert_response :success
     end
-    assert_select '#content-raw-markdown', insert_extras(node(:about).body)
+    #assert_select '#content-raw-markdown', insert_extras(node(:about).body)
   end
 
   test 'should get root-level (/about) wiki page' do

--- a/test/unit/node_shared_test.rb
+++ b/test/unit/node_shared_test.rb
@@ -3,50 +3,61 @@ require 'test_helper'
 class NodeSharedTest < ActiveSupport::TestCase
   test 'that NodeShared can be used to convert short codes like [notes:foo] into tables which list notes' do
     before = "Here are some notes in a table: \n\n[notes:test] \n\nThis is how you make it work:\n\n`[notes:tagname]`\n\n `[notes:tagname]`\n\nMake sense?"
-    assert NodeShared.notes_grid(before)
-    assert_equal 1, NodeShared.notes_grid(before).scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
-    assert_equal 1, NodeShared.notes_grid(before).scan('<table').length
-    assert_equal 5, NodeShared.notes_grid(before).scan('notes-grid-test').length
+    html = NodeShared.notes_grid(before)
+    assert html
+    assert_equal 1, html.scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
+    assert_equal 1, html.scan('<table').length
+    assert_equal 5, html.scan('notes-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [questions:foo] into tables which list questions' do
     before = "Here are some questions in a table: \n\n[questions:test] \n\nThis is how you make it work:\n\n`[questions:tagname]`\n\n `[questions:tagname]`\n\nMake sense?"
-    assert NodeShared.questions_grid(before)
-    assert_equal 1, NodeShared.questions_grid(before).scan('<table class="table inline-grid questions-grid questions-grid-test questions-grid-test-').length
-    assert_equal 1, NodeShared.questions_grid(before).scan('<table').length
-    assert_equal 5, NodeShared.questions_grid(before).scan('questions-grid-test').length
+    html = NodeShared.questions_grid(before)
+    assert html
+    assert_equal 1, html.scan('<table class="table inline-grid questions-grid questions-grid-test questions-grid-test-').length
+    assert_equal 1, html.scan('<table').length
+    assert_equal 5, html.scan('questions-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [activities:foo] into tables which list activity notes' do
     before = "Here are some activities in a table: \n\n[activities:spectrometer] \n\nThis is how you make it work:\n\n`[activities:tagname]`\n\nMake sense?"
-    assert NodeShared.activities_grid(before)
-    assert_equal 1, NodeShared.activities_grid(before).scan('<table class="table inline-grid activity-grid activity-grid-spectrometer activity-grid-spectrometer-').length
-    assert_equal 7, NodeShared.activities_grid(before).scan('<td').length
-    assert_equal 1, NodeShared.activities_grid(before).scan('<table').length
-    assert_equal 5, NodeShared.activities_grid(before).scan('activity-grid-spectrometer').length
+    html = NodeShared.activities_grid(before)
+    assert html
+    assert_equal 1, html.scan('<table class="table inline-grid activity-grid activity-grid-spectrometer activity-grid-spectrometer-').length
+    assert_equal 7, html.scan('<td').length
+    assert_equal 1, html.scan('<table').length
+    assert_equal 5, html.scan('activity-grid-spectrometer').length
   end
 
   test 'that NodeShared can be used to convert short codes like [upgrades:foo] into tables which list upgrade notes' do
     before = "Here are some upgrades in a table: \n\n[upgrades:test] \n\nThis is how you make it work:\n\n`[upgrades:tagname]`\n\nMake sense?"
-    assert NodeShared.upgrades_grid(before)
-    assert_equal 1, NodeShared.upgrades_grid(before).scan('<table class="table inline-grid upgrades-grid upgrades-grid-test upgrades-grid-test-').length
-    assert_equal 1, NodeShared.upgrades_grid(before).scan('<table').length
-    assert_equal 5, NodeShared.upgrades_grid(before).scan('upgrades-grid-test').length
+    html = NodeShared.upgrades_grid(before)
+    assert html
+    assert_equal 1, html.scan('<table class="table inline-grid upgrades-grid upgrades-grid-test upgrades-grid-test-').length
+    assert_equal 1, html.scan('<table').length
+    assert_equal 5, html.scan('upgrades-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [notes:foo] into tables which list notes, even after text has been markdown-ified' do
     before = "This shouldn't actually produce a table:\n\n`[notes:tagname]`\n\nOr this:\n\n `[notes:tagname]`"
-    html = RDiscount.new(before).to_html
-    assert_equal 0, NodeShared.notes_grid(before).scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
-    assert_equal 0, NodeShared.notes_grid(before).scan('<table').length
-    assert_equal 0, NodeShared.notes_grid(before).scan('notes-grid-test').length
+    html = NodeShared.notes_grid(before)
+    assert_equal 0, html.scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
+    assert_equal 0, html.scan('<table').length
+    assert_equal 0, html.scan('notes-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [notes:foo] into tables which list notes, even in code tags' do
     before = "This shouldn't actually produce a table:\n\n<code>[notes:tagname]</code>"
-    html = RDiscount.new(before).to_html
-    assert_equal 0, NodeShared.notes_grid(before).scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
-    assert_equal 0, NodeShared.notes_grid(before).scan('<table').length
-    assert_equal 0, NodeShared.notes_grid(before).scan('notes-grid-test').length
+    html = NodeShared.notes_grid(before)
+    assert_equal 0, html.scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
+    assert_equal 0, html.scan('<table').length
+    assert_equal 0, html.scan('notes-grid-test').length
+  end
+
+  test 'that NodeShared can be used to convert short codes like [map:content:lat:lon] into maps which display notes' do
+    before = "Here are some notes in a map: \n\n[map:content:71.00:52.00] \n\nThis is how you make it work:\n\n`[map:content:71.00:52.00]`\n\n `[map:content:71.00:52.00]`\n\nMake sense?"
+    html = NodeShared.notes_map(before)
+    assert_equal 1, html.scan('<div class="leaflet-map"').length
+    assert_equal 1, html.scan('L.marker').length
   end
 end


### PR DESCRIPTION
* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

This is an attempt to implement map grids with the inline powertag `[map:content:<latitude>:<longitude>]`

If merged to stable, it should work at: http://staging.laboratoriopublico.org/wiki/sandbox#Inline+map+test

If published, it should work at https://publiclab.org/wiki/sandbox#inline+maps+test: