### PR TITLE
header fix for languages

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -180,17 +180,6 @@
     <li><a href="/people">Contributors</a></li>
 	           <li class="divider"></li>
 	       <% end %>
-              <li class="dropdown">
-                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                  <i class="fa fa-language" aria-hidden="true"></i>
-                  <%= t('layout._footer.language.language_title') %> <b class="caret"></b>
-                </a>
-                <ul class="dropdown-menu">
-                  <% locale_name_pairs.each do |locale_name, locale| %>
-                    <li><%= link_to locale_name, change_locale_path(locale) %></li>
-                  <% end %>
-                </ul>
-              </li>
               <li><%= link_to t('layout._header.logout'), logout_path %></li>
             </ul>
             <% else %>


### PR DESCRIPTION
* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
