### PR TITLE
initial tag-filtered maps display

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,7 @@ module ApplicationHelper
     body = NodeShared.activities_grid(body)
     body = NodeShared.upgrades_grid(body)
     body = NodeShared.notes_map(body)
+    body = NodeShared.notes_map_by_tag(body)
     body
   end
 

--- a/test/fixtures/community_tags.yml
+++ b/test/fixtures/community_tags.yml
@@ -117,3 +117,15 @@ activities-spectrometer:
   uid: 1
   nid: 20
   date: Time.now
+
+map_lat:
+  tid: 7
+  uid: 1
+  nid: 13
+  date: Time.now
+
+map_lon:
+  tid: 8
+  uid: 1
+  nid: 13
+  date: Time.now

--- a/test/unit/node_shared_test.rb
+++ b/test/unit/node_shared_test.rb
@@ -61,9 +61,9 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert_equal 1, html.scan('L.marker').length
   end
 
-  test 'that NodeShared can be used to convert short codes like [map:content:lat:lon] into maps which display notes, but only those tagged with "blog"' do
+  test 'that NodeShared can be used to convert short codes like [map:tag:blog:lat:lon] into maps which display notes, but only those tagged with "blog"' do
     before = "Here are some notes in a map: \n\n[map:tag:blog:71.00:52.00] \n\nThis is how you make it work:\n\n`[map:tag:blog:71.00:52.00]`\n\n `[map:tag:blog:71.00:52.00]`\n\nMake sense?"
-    html = NodeShared.notes_map(before)
+    html = NodeShared.notes_map_by_tag(before)
     assert_equal 1, html.scan('<div class="leaflet-map"').length
     assert_equal 1, html.scan('L.marker').length
   end

--- a/test/unit/node_shared_test.rb
+++ b/test/unit/node_shared_test.rb
@@ -60,4 +60,11 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert_equal 1, html.scan('<div class="leaflet-map"').length
     assert_equal 1, html.scan('L.marker').length
   end
+
+  test 'that NodeShared can be used to convert short codes like [map:content:lat:lon] into maps which display notes, but only those tagged with "blog"' do
+    before = "Here are some notes in a map: \n\n[map:tag:blog:71.00:52.00] \n\nThis is how you make it work:\n\n`[map:tag:blog:71.00:52.00]`\n\n `[map:tag:blog:71.00:52.00]`\n\nMake sense?"
+    html = NodeShared.notes_map(before)
+    assert_equal 1, html.scan('<div class="leaflet-map"').length
+    assert_equal 1, html.scan('L.marker').length
+  end
 end


### PR DESCRIPTION
Ability to filter an inline map by tag, using `[map:tag:__tagname__:lat:lon]`

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
