### PR TITLE
Fix in embeds grid - unique ids

### DIFF
--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -78,7 +78,7 @@
   $(".<%= className %>-<%= randomSeed %> .show-all a").click(function() { 
     $(".<%= className %>-<%= randomSeed %> tr.hide").toggleClass("hide");
   });
-  $(".grid-embed").click(function() {
+  $(".<%= className %>-<%= randomSeed %> .grid-embed").click(function() {
     prompt('Use this HTML code to embed this table on another site.', '<iframe border=0 width="100%" height="500px" src="//publiclab.org/embed/grid/&?t=<% if type != "notes" %><%= type %>:<% end %><%= tagname %>"></iframe>')
   });
   setupGridSorters(".<%= className %>-<%= randomSeed %>");

--- a/test/unit/node_shared_test.rb
+++ b/test/unit/node_shared_test.rb
@@ -7,7 +7,7 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert html
     assert_equal 1, html.scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
     assert_equal 1, html.scan('<table').length
-    assert_equal 5, html.scan('notes-grid-test').length
+    assert_equal 6, html.scan('notes-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [questions:foo] into tables which list questions' do
@@ -16,7 +16,7 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert html
     assert_equal 1, html.scan('<table class="table inline-grid questions-grid questions-grid-test questions-grid-test-').length
     assert_equal 1, html.scan('<table').length
-    assert_equal 5, html.scan('questions-grid-test').length
+    assert_equal 6, html.scan('questions-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [activities:foo] into tables which list activity notes' do
@@ -26,7 +26,7 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert_equal 1, html.scan('<table class="table inline-grid activity-grid activity-grid-spectrometer activity-grid-spectrometer-').length
     assert_equal 7, html.scan('<td').length
     assert_equal 1, html.scan('<table').length
-    assert_equal 5, html.scan('activity-grid-spectrometer').length
+    assert_equal 6, html.scan('activity-grid-spectrometer').length
   end
 
   test 'that NodeShared can be used to convert short codes like [upgrades:foo] into tables which list upgrade notes' do
@@ -35,7 +35,7 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert html
     assert_equal 1, html.scan('<table class="table inline-grid upgrades-grid upgrades-grid-test upgrades-grid-test-').length
     assert_equal 1, html.scan('<table').length
-    assert_equal 5, html.scan('upgrades-grid-test').length
+    assert_equal 6, html.scan('upgrades-grid-test').length
   end
 
   test 'that NodeShared can be used to convert short codes like [notes:foo] into tables which list notes, even after text has been markdown-ified' do


### PR DESCRIPTION
* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
