### PR TITLE
typeahead search reworking

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -1,7 +1,7 @@
 require 'grape'
 require 'grape-entity'
 
-module Search
+module Srch
   class Search < Grape::API
     # Endpoint definitions
     resource :srch do

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -1,7 +1,7 @@
 require 'grape'
 require 'grape-entity'
 
-module Srch
+module Search
   class Search < Grape::API
     # Endpoint definitions
     resource :srch do

--- a/app/assets/javascripts/restful_typeahead.js
+++ b/app/assets/javascripts/restful_typeahead.js
@@ -2,6 +2,12 @@
   The restful_typeahead.js script provides generic typeahead functionality for the plots2 Rails app.
   The set of functions here are intended to provide a link between the data available through the RESTful 
   search API and the UI components.  
+
+
+* ensure 3 letters are typed before searching
+* pressing enter on an option just loads that option
+* clicking on an option just loads that option
+
 **/
 
   //RESTful typeahead base URL
@@ -9,22 +15,23 @@
   var idcount = 0;
   var minQry = 3;
   var keycount = 0;
+
   /**
     This call performs two setup operations in support of typeahead usage.  The usage is separated by the organization of the data that is returned.  General document typeahead searches return a 'docList', which is a list of document data and their URLs (not used in typeahead functionality at this time).  Conversely, that tag searches/suggestions return tag data, which can be associated with multiple URLs, and is thus less specific but could be more informative.
     First, set any input field with the classes of 'search-query' and 'typeahead' to act as a typeahead field.  If the input field has the attribute 'srchGroup=[all | questions | profiles | notes]', then that particular method in the typeahead service is called.  Otherwise, it defaults to 'all'.
     Second, set any input field with the  classes of 'search-query' and 'tagsrch' to act as a tag-centric typeahead field.
   **/
   jQuery(document).ready(function() {
-	$('input.search-query.typeahead').each(function() {
-		var resultList = setupSrchSuggest(this);
-		typeaheadSearchKeys(this, resultList);
-		hideResultsOnBlur(this, resultList);
-	});
-	$('input.search-query.tagsrch').each(function() {
-		var resultList = setupTagSuggest(this);
-		typeaheadTagKeys(this, resultList);
-		hideResultsOnBlur(this, resultList);
-	});
+    $('input.search-query.typeahead').each(function() {
+      var resultList = setupSrchSuggest(this);
+      typeaheadSearchKeys(this, resultList);
+      hideResultsOnBlur(this, resultList);
+    });
+    $('input.search-query.tagsrch').each(function() {
+      var resultList = setupTagSuggest(this);
+      typeaheadTagKeys(this, resultList);
+      hideResultsOnBlur(this, resultList);
+    });
   });
 
   /**
@@ -32,204 +39,215 @@
     Returns a reference (jQuery object) for the associated list element
   **/
   function setupSrchSuggest(inelem) {
-	var elemRef = $(inelem);
-	var inid = elemRef.attr('id');
-	//Check to see if the element is looking for a defined qry type; otherwise default to 'all'
-	var ttype = 'all';
-	var intype = elemRef.attr('qrytype');
-	if (intype) {
-		ttype = intype;
-	} else {
-		//set the qrytype attribute to 'all'
-		elemRef.attr('qrytype',ttype);
-	}
-	if (!inid) {
-		//create a dynamic id if there is none
-		idcount += 1;
-		inid = 'srchInput_'+ttype+'_'+idcount;
-		elemRef.attr('id',inid);
-	}
-	//Check that there is a datalist element--if not, create one
-	var listid = elemRef.attr('data-results');
-	var listelem = $('#'+listid);
-	if (!listid) {
-		//create a datalist
-		listid = 'dlist_'+inid;
-		elemRef.attr('data-results',listid);
-		var inputtop = elemRef.position().top;
-		var inputht = elemRef.outerHeight();
-		var inputleft = elemRef.position().left;
-		var listhtml = '<ul class="typeahead-results dropdown-menu" id="'+listid+'" style="display:none;"></ul>';
-		listelem = $(listhtml).insertAfter(elemRef);
-		listelem.css("top",inputtop+inputht);
-		listelem.css("left",inputleft);
-	}
-	return listelem;
+    var elemRef = $(inelem);
+    var inid = elemRef.attr('id');
+    //Check to see if the element is looking for a defined qry type; otherwise default to 'all'
+    var ttype = 'all';
+    var intype = elemRef.attr('qrytype');
+    if (intype) {
+      ttype = intype;
+    } else {
+      //set the qrytype attribute to 'all'
+      elemRef.attr('qrytype',ttype);
+    }
+    if (!inid) {
+      //create a dynamic id if there is none
+      idcount += 1;
+      inid = 'srchInput_'+ttype+'_'+idcount;
+      elemRef.attr('id',inid);
+    }
+    //Check that there is a datalist element--if not, create one
+    var listid = elemRef.attr('data-results');
+    var listelem = $('#'+listid);
+    if (!listid) {
+      //create a datalist <ul> HTML element
+      listid = 'dlist_'+inid;
+      elemRef.attr('data-results',listid);
+      var inputtop = elemRef.position().top;
+      var inputht = elemRef.outerHeight();
+      var inputleft = elemRef.position().left;
+      var listhtml = '<ul class="typeahead-results dropdown-menu" id="'+listid+'" style="display:none;"></ul>';
+      listelem = $(listhtml).insertAfter(elemRef);
+      listelem.css("top",inputtop+inputht);
+      listelem.css("left",inputleft);
+    }
+    return listelem;
   }
 
   /**
-    Set up to perform search on key stroke entries for the input element.  If "Enter" or "Esc" is the key stroke, then hide the typeahead.
+    Set up to perform search on key stroke entries for the input element.  
+    If "Enter" or "Esc" is the key stroke, then hide the typeahead.
   **/
   function typeaheadSearchKeys(ielem, reslist) {
-        var elemRef = $(ielem);
-        var listelem = $(reslist);
-	elemRef.on("keyup", function(e) {
-		e.preventDefault();
-		var kcode = e.which || e.keyCode;
-		if (kcode == 13 || kcode == 27) {
-			//hit enter or escape, so hide the typeahead
-			listelem.css("display","none");
-		} else {
-			typeaheadSearch(this);
-		}
-	});
+    var elemRef = $(ielem);
+    var listelem = $(reslist);
+    elemRef.on("keyup", function(e) {
+      e.preventDefault();
+      var kcode = e.which || e.keyCode;
+      if (kcode == 13 || kcode == 27) {
+        //hit enter or escape, so hide the typeahead
+        listelem.css("display","none");
+      } else {
+        typeaheadSearch(this);
+      }
+    });
   }
 
   /**
-    Set up to perform tag search on key stroke entries for the input element.  If "Enter" or "Esc" is the key stroke, then hide the typeahead.
+    Set up to perform tag search on key stroke entries for the input element. 
+    If "Enter" or "Esc" is the key stroke, then hide the typeahead.
   **/
   function typeaheadTagKeys(ielem, reslist) {
-	var elemRef = $(ielem);
-	var listelem = $(reslist);
-	elemRef.on("keyup", function(e) {
-		e.preventDefault();
-		var kcode = e.which || e.keyCode;
-		if (kcode == 13 || kcode == 27) {
-			//hit enter or escape, so hide the typeahead
-			listelem.css("display","none");
-		} else {
-			typeaheadTags(this);
-		}
-	});
-
+    var elemRef = $(ielem);
+    var listelem = $(reslist);
+    elemRef.on("keyup", function(e) {
+      e.preventDefault();
+      var kcode = e.which || e.keyCode;
+      if (kcode == 13 || kcode == 27) {
+        //hit enter or escape, so hide the typeahead
+        listelem.css("display","none");
+      } else {
+        typeaheadTags(this);
+      }
+    });
   }
 
   /**
     On lost focus (blur) of the input element, hide the result list
   **/
   function hideResultsOnBlur(ielem, resList) {
-	var elemRef = $(ielem);
-	var listelem = $(resList);
-        elemRef.on("blur", function(e) {
-		var dlist = $("#"+$(this).attr("data-results")).hide();
-	});
+    var elemRef = $(ielem);
+    var listelem = $(resList);
+          elemRef.on("blur", function(e) {
+      var dlist = $("#"+$(this).attr("data-results")).hide();
+    });
   }
 
   /**
-    Process the element's typed values and perform the query; display the results in the associated datalist
+    Process the element's typed values and perform the query; 
+    display the results in the associated datalist.
   **/
   function typeaheadSearch(srchElem) {
-	var qtype = $(srchElem).attr('qrytype');
-	keycount += 1;
-	var qparams = new Object();
-	qparams.srchString = $(srchElem).val();
-	qparams.seq = keycount;
-	//checks to reduce server load and minimize long return values
-        if (!qparams.srchString) return;
-        if (qparams.srchString == '' || qparams.srchString == ' ') return;
-        if (qparams.srchString.length < minQry) return;
-        $.getJSON(typeaheadBase+qtype,qparams,function(qdata) {
-		if (qdata.srchParams) {
-			if (qdata.srchParams.seq >= keycount) {		
-				typeaheadTagList(srchElem, qdata);
-			}
-		}
-	});
+    var qtype = $(srchElem).attr('qrytype');
+    keycount += 1;
+    var qparams = new Object();
+    qparams.srchString = $(srchElem).val();
+    qparams.seq = keycount;
+    //checks to reduce server load and minimize long return values
+    if (!qparams.srchString) return;
+    if (qparams.srchString == '' || qparams.srchString == ' ') return;
+    if (qparams.srchString.length < minQry) return;
+    $.getJSON(typeaheadBase + qtype, qparams, function(qdata) {
+      if (qdata.srchParams) {
+        if (qdata.srchParams.seq >= keycount) {    
+          typeaheadTagList(srchElem, qdata);
+        }
+      }
+    });
   }
 
   /**
     Handle the return values for a typeahead call
+    THIS CODE WAS UNUSED - apparently we're only using typeaheadTagList?
   **/
+/*
   function typeaheadDocList(ielem, docList) {
-	var elemRef = $(ielem);
-	var elemList = $('#'+elemRef.attr('data-results'));
-	elemList.html('');
-	if (docList.items) {
-		for (var i=0;i<docList.items.length;i++) {
-			var listopt = $('<li data-text="'+docList.items[i].docTitle+'"><span class="fa fa-'+docList.items[i].docType+'"></span><a href="#">&nbsp;'+docList.items[i].docTitle+'</a></li>');
-			listopt.on('mousedown',function(e) {
-				e.preventDefault();
-				elemRef.val($(this).attr('data-text'));
-				elemList.css("display","none");
-			});
-			elemList.append(listopt);
-		}
-	}
-	//elemList.toggleClass('results-noshow',false);
-	elemList.css("display","block");
+    var elemRef = $(ielem);
+    var elemList = $('#'+elemRef.attr('data-results'));
+    elemList.html('');
+    if (docList.items) {
+      for (var i = 0; i < docList.items.length; i++) {
+        var val = docList.items[i].docVal;
+        var type = docList.items[i].docType;
+        var url = docList.items[i].docUrl;
+        var listopt = $('<li data-url="' + url + '" data-text="' + val + '"><a href="#"><i class="fa fa-' + type + '"></i>&nbsp;' + val + '</a></li>');
+        listopt.on('mousedown', clickTypeaheadItem);
+        elemList.append(listopt);
+      }
+    }
+    //elemList.toggleClass('results-noshow',false);
+    elemList.css("display","block");
+  }
+*/
+
+  /**
+    Handle a click on one of the displayed suggestions in the typeahead "dropdown"
+    We actually just use URLs here, but in case the <a> element doesn't get a click
+  **/
+  function clickTypeaheadItem(e) {
+    e.preventDefault();
+    window.location = $(this).attr('data-url');
   }
 
   /**
     Set up the tag search function for the given element
   **/
   function setupTagSuggest(inelem) {
-	var elemRef = $(inelem);
-	var inid = elemRef.attr('id');
-	if (!inid) {
-		//create a dynamic id if there is none
-		idcount += 1;
-		inid = 'tagInput_'+idcount;
-		elemRef.attr('id',inid);
-	}
-	//Check that there is a datalist element--if not, create one
-	var listid = elemRef.attr('data-results');
-	var listelem = $('#'+listid);
-	if (!listid) {
-		//create a datalist
-		listid = 'dlist_'+inid;
-		elemRef.attr('data-results',listid);
-		var inputtop = elemRef.position().top;
-		var inputht = elemRef.outerHeight();
-		var inputleft = elemRef.position().left;
-		var listhtml = '<ul class="typeahead-results dropdown-menu" id="'+listid+'" style="display:none;"></ul>';
-		listelem = $(listhtml).insertAfter(elemRef);
-		listelem.css("top",inputtop+inputht);
-		listelem.css("left",inputleft);
-	}
-	return listelem;
+    var elemRef = $(inelem);
+    var inid = elemRef.attr('id');
+    if (!inid) {
+      //create a dynamic id if there is none
+      idcount += 1;
+      inid = 'tagInput_'+idcount;
+      elemRef.attr('id',inid);
+    }
+    //Check that there is a datalist element--if not, create one
+    var listid = elemRef.attr('data-results');
+    var listelem = $('#'+listid);
+    if (!listid) {
+      //create a datalist
+      listid = 'dlist_'+inid;
+      elemRef.attr('data-results',listid);
+      var inputtop = elemRef.position().top;
+      var inputht = elemRef.outerHeight();
+      var inputleft = elemRef.position().left;
+      var listhtml = '<ul class="typeahead-results dropdown-menu" id="'+listid+'" style="display:none;"></ul>';
+      listelem = $(listhtml).insertAfter(elemRef);
+      listelem.css("top",inputtop+inputht);
+      listelem.css("left",inputleft);
+    }
+    return listelem;
   }
 
   /**
     Process the element's typed values and perform the tag query; display the results in the associated datalist
   **/
   function typeaheadTags(tagElem) {
-	keycount += 1;
-	var qparams = new Object();
-	qparams.srchString = $(tagElem).val();
-	qparams.seq = keycount;
-	$.getJSON(typeaheadBase+'tags',qparams,function(qdata) {
-		if (qdata.srchParams) {
-			if (qdata.srchParams.seq >= keycount) {		
-				typeaheadTagList(tagElem, qdata);
-			}
-		}
-	});
+    keycount += 1;
+    var qparams = new Object();
+    qparams.srchString = $(tagElem).val();
+    qparams.seq = keycount;
+    if (qparams.srchString.length < minQry) return;
+    $.getJSON(typeaheadBase+'tags', qparams, function(qdata) {
+      if (qdata.srchParams) {
+        if (qdata.srchParams.seq >= keycount) {    
+          typeaheadTagList(tagElem, qdata);
+        }
+      }
+    });
   }
 
   /**
-    Handle the return values for a typeahead call
+    Handle the return values for a typeahead call by
+    inserting them into the <ul> datalist
   **/
   function typeaheadTagList(ielem, tagList) {
-	var elemRef = $(ielem);
-	var elemList = $('#'+elemRef.attr('data-results'));
-	elemList.html('');
-	if (tagList.items) {
-		for (var i=0;i<tagList.items.length;i++) {
-			var listopt = $('<li data-text="'+tagList.items[i].tagVal+'"><a href="#"><i class="fa fa-'+tagList.items[i].tagType+'"></i>&nbsp;'+tagList.items[i].tagVal+'</a></li>');
-			listopt.on('mousedown',function(e) {
-				e.preventDefault();
-				elemRef.val($(this).attr('data-text'));
-				elemList.css("display","none");
-			});
-			elemList.append(listopt);
-		}
-		$(elemList).find('li').mousedown( function(e) {
-			e.preventDefault();
-			elemRef.val($(this).attr('data-text'));
-			elemList.css("display","none");
-		});
-	}
-	elemList.css("display","block");
+    var elemRef = $(ielem);
+    var elemList = $('#'+elemRef.attr('data-results'));
+    elemList.html('');
+    if (tagList.items) {
+      for (var i=0;i<tagList.items.length;i++) {
+        var val = tagList.items[i].tagVal;
+        var type = tagList.items[i].tagType;
+        var url = tagList.items[i].tagSource || '/tag/' + val;
+        var listopt = $('<li data-url="' + url + '" data-text="' + val + '"><a href="' + url + '"><i class="fa fa-' + type + '"></i>&nbsp;' + val + '</a></li>');
+        listopt.on('mousedown', clickTypeaheadItem);
+        elemList.append(listopt);
+      }
+      $(elemList).find('li').mousedown(clickTypeaheadItem);
+    }
+    if (tagList.items.length > 0) elemList.css("display","block");
+    else elemList.css("display","none");
   }
 
 

--- a/app/views/admin/useremail.html.erb
+++ b/app/views/admin/useremail.html.erb
@@ -3,7 +3,7 @@
 
   <h3>User lookup by email:</h3> 
 
-  <p>Moderators and admins have the ability to search for usernames associated with a given email address. This ability is meant to assist in answering requests submit by email where the user forgot specify his or her username; clearly the email address of the sender is known.</p>
+  <p>Moderators and admins have the ability to search for usernames associated with a given email address. This ability is meant to assist in answering requests submit by email where the user forgot specify their username; clearly the email address of the sender is known.</p>
 
   <%= form_tag do %>
     <%= text_field_tag(:address, value = @address) %>

--- a/app/views/subscription_mailer/notify_node_creation.html.erb
+++ b/app/views/subscription_mailer/notify_node_creation.html.erb
@@ -3,7 +3,7 @@
 <p>Public Lab contributor <a href='https://<%= ActionMailer::Base.default_url_options[:host] %>/profile/<%= @node.author.name %>'><%= @node.author.name %></a> just <% if @node.has_power_tag('question') %>asked a question<% else %>posted a new research note<% end %> entitled '<b><%= @node.title %></b>':</p>
 
 <% if @node.has_power_tag('question') %>
-<p>Help him/her by posting an answer here: https://<%= ActionMailer::Base.default_url_options[:host] %><%= @node.path(:question) %></p>
+<p>Help them by posting an answer here: https://<%= ActionMailer::Base.default_url_options[:host] %><%= @node.path(:question) %></p>
 <% else %>
 <p>Read and respond to the post here: https://<%= ActionMailer::Base.default_url_options[:host] %><%= @node.path %></p>
 <% end %>


### PR DESCRIPTION
Hi, @david-days - finally got to do some more tweaking to the typeahead search and adjusted a few things; the code is very readable, thanks!

I did notice we don't seem to be using the separate `Doc`-based typeahead code, and I commented it out. We get both types (Tags, documents) via the same JSON API, and that seems fine (i did some extending of the API to include TagSource for both types). So we could adjust the naming to acknowledge the use of one type, or we could rewire things... I guess easier to just use less redundant code?

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
