### PR TITLE
attempt to simplify user/drupaluser relation

### DIFF
--- a/app/models/drupal_users.rb
+++ b/app/models/drupal_users.rb
@@ -16,7 +16,7 @@ class DrupalUsers < ActiveRecord::Base
   has_many :answer_selections, foreign_key: :user_id
   has_many :comments, foreign_key: 'uid'
   has_one :location_tag, foreign_key: 'uid', dependent: :destroy
-
+  has_one :rusers, foreign_key: :id
 
   include SolrToggle
   searchable if: :internalShouldIndexSolr do
@@ -27,10 +27,6 @@ class DrupalUsers < ActiveRecord::Base
 
   def internalShouldIndexSolr
     shouldIndexSolr && status == 1
-  end
-
-  def user
-    User.find_by_username name
   end
 
   def username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
   do_not_validate_attachment_file_type :photo_file_name
   # validates_attachment_content_type :photo_file_name, :content_type => %w(image/jpeg image/jpg image/png)
 
-  has_one :drupal_users, foreign_key: :uid
+  has_one :users, foreign_key: :uid
   has_many :images, foreign_key: :uid
   has_many :node, foreign_key: 'uid'
   has_many :user_tags, foreign_key: 'uid', dependent: :destroy
@@ -71,6 +71,10 @@ class User < ActiveRecord::Base
 
   def destroy_drupal_user
     drupal_user.destroy
+  end
+  
+  def drupal_user
+    self.user
   end
 
   def notes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
   do_not_validate_attachment_file_type :photo_file_name
   # validates_attachment_content_type :photo_file_name, :content_type => %w(image/jpeg image/jpg image/png)
 
-  has_one :users, foreign_key: :uid
+  has_one :user, foreign_key: :uid
   has_many :images, foreign_key: :uid
   has_many :node, foreign_key: 'uid'
   has_many :user_tags, foreign_key: 'uid', dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,8 +25,7 @@ class User < ActiveRecord::Base
   do_not_validate_attachment_file_type :photo_file_name
   # validates_attachment_content_type :photo_file_name, :content_type => %w(image/jpeg image/jpg image/png)
 
-  # this doesn't work... we should have a uid field on User
-  # has_one :drupal_users, :conditions => proc { ["drupal_users.name =  ?", self.username] }
+  has_one :drupal_users, foreign_key: :uid
   has_many :images, foreign_key: :uid
   has_many :node, foreign_key: 'uid'
   has_many :user_tags, foreign_key: 'uid', dependent: :destroy
@@ -72,12 +71,6 @@ class User < ActiveRecord::Base
 
   def destroy_drupal_user
     drupal_user.destroy
-  end
-
-  # this is ridiculous. We need to store uid in this model.
-  # ...migration is in progress. start getting rid of these calls...
-  def drupal_user
-    DrupalUsers.find_by_name(username)
   end
 
   def notes


### PR DESCRIPTION
This is a small change but is pretty fundamental and may fail... likely if `user.drupal_user` and `drupal_user.user` don't work as we imagine with the `has_one` ActiveRecord relations. 

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
