### PR TITLE
Add description to tag popup

### DIFF
--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,7 +1,7 @@
 <p>
   <% @node.community_tags.each do |tag| %>
     <% if power_tag^tag.name.include?(':') %>
-      <span id="tag_<%= tag.tid %>" class="label <%= label_name %>" data-toggle="tooltip" data-html="true" title="created by <strong><%= tag.try(:author).try(:username) %></strong> <%= time_ago_in_words(Time.at(tag.date)) %> ago">
+      <span id="tag_<%= tag.tid %>" class="label <%= label_name %>" data-toggle="tooltip" data-html="true" title="<% unless tag.tag.description.empty? %> <%= tag.tag.description %> |<% end %> created by <strong><%= tag.try(:author).try(:username) %></strong> <%= time_ago_in_words(Time.at(tag.date)) %> ago">
         <a class="tag-name" href="<%= "/maps" if @node.type == "map" %>/tag/<%= tag.name %>"><%= tag.name %></a>
         <% if current_user && (tag.uid == @node.uid || current_user.role == "admin" || current_user.role == "moderator") %>
           <% if tag.name.include? ':' %>

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,7 +1,7 @@
 <p>
   <% @node.community_tags.each do |tag| %>
     <% if power_tag^tag.name.include?(':') %>
-      <span id="tag_<%= tag.tid %>" class="label <%= label_name %>" data-toggle="tooltip" data-html="true" title="<% unless tag.tag.description.empty? %> <%= tag.tag.description %> |<% end %> created by <strong><%= tag.try(:author).try(:username) %></strong> <%= time_ago_in_words(Time.at(tag.date)) %> ago">
+      <span id="tag_<%= tag.tid %>" class="label <%= label_name %>" data-toggle="tooltip" data-html="true" title="<% if tag.try(:tag).try(:description) && !tag.try(:tag).try(:description).empty? %> <%= tag.try(:tag).try(:description) %> |<% end %> created by <strong><%= tag.try(:author).try(:username) %></strong> <%= time_ago_in_words(Time.at(tag.date)) %> ago">
         <a class="tag-name" href="<%= "/maps" if @node.type == "map" %>/tag/<%= tag.name %>"><%= tag.name %></a>
         <% if current_user && (tag.uid == @node.uid || current_user.role == "admin" || current_user.role == "moderator") %>
           <% if tag.name.include? ':' %>


### PR DESCRIPTION
Fixes #1406 

This pull request addresses issue #1406. It takes advice from the suggested solution and adds the description to the tag popup, separating the "created by" text from the description with a vertical pipe.

Below are some screenshots of the changes made:

**A tag with a description.**
![with description](https://cloud.githubusercontent.com/assets/16845804/26463078/292fec58-4151-11e7-85d6-89e00d6c634b.png)

**A tag without a description.**
![no description](https://cloud.githubusercontent.com/assets/16845804/26463093/30b5ab84-4151-11e7-957e-c14bd16993ca.png)
