### PR TITLE
Typo breaking count on contributors page

### DIFF
--- a/config/locales/views/tag/contributors/de.yml
+++ b/config/locales/views/tag/contributors/de.yml
@@ -9,7 +9,7 @@ de:
       following: "Folgende"
       unfollow: "Klicken Sie hier um unfollow"
       follow: "Folgen"
-      people_watching_tag: "%[count} Personen beobachten Diesen Tag"
+      people_watching_tag: "%{count} Personen beobachten Diesen Tag"
       no_contributors: "Keine Mitwirkenden für diesen Tag ; versuchen, für '<b>%{tag}</b>' Suche"
       contributor: "Beiträger"
       notes: "Notizen"

--- a/config/locales/views/tag/contributors/en.yml
+++ b/config/locales/views/tag/contributors/en.yml
@@ -9,7 +9,7 @@ en:
       following: "Following"
       unfollow: "Click to unfollow"
       follow: "Follow"
-      people_watching_tag: "%[count} people are watching this tag"
+      people_watching_tag: "%{count} people are watching this tag"
       no_contributors: "No contributors for that tag; try searching for '<b>%{tag}</b>'"
       contributor: "Contributor"
       notes: "Notes"


### PR DESCRIPTION
Don't have the site running locally yet, but just a small typo fix I came across. 

<img width="997" alt="screen shot 2017-06-01 at 2 27 30 pm" src="https://cloud.githubusercontent.com/assets/9449641/26697244/e56941aa-46d6-11e7-922a-100cb04dec57.png">

