### PR TITLE
rewiring searches_controller to use SearchService

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -31,7 +31,7 @@ class SearchesController < ApplicationController
     @users = SearchService.new.users(params[:id])
     set_sidebar :tags, [params[:id]]
 
-    @notes = SearchService.new.notes(params[:id])
+    @nodes = SearchService.new.nodes(params[:id])
   end
 
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -31,11 +31,7 @@ class SearchesController < ApplicationController
     @users = SearchService.new.users(params[:id])
     set_sidebar :tags, [params[:id]]
 
-    # Adapt to SearchService:
-    @notes = Node.paginate(page: params[:page])
-                 .order('node.nid DESC')
-                 .where('(type = "note" OR type = "page" OR type = "map") AND node.status = 1 AND (node.title LIKE ? OR node_revisions.title LIKE ? OR node_revisions.body LIKE ?)', '%' + params[:id] + '%', '%' + params[:id] + '%', '%' + params[:id] + '%')
-                 .includes(:drupal_node_revision)
+    @notes = SearchService.new.textSearch_notes(params[:id])
   end
 
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -31,7 +31,7 @@ class SearchesController < ApplicationController
     @users = SearchService.new.users(params[:id])
     set_sidebar :tags, [params[:id]]
 
-    @notes = SearchService.new.textSearch_notes(params[:id])
+    @notes = SearchService.new.textSearch_notes(params[:id]).getDocs
   end
 
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -31,7 +31,7 @@ class SearchesController < ApplicationController
     @users = SearchService.new.users(params[:id])
     set_sidebar :tags, [params[:id]]
 
-    @notes = SearchService.new.textSearch_notes(params[:id]).getDocs
+    @notes = SearchService.new.textSearch_notes(params[:id]).items
   end
 
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -31,7 +31,7 @@ class SearchesController < ApplicationController
     @users = SearchService.new.users(params[:id])
     set_sidebar :tags, [params[:id]]
 
-    @notes = SearchService.new.textSearch_notes(params[:id]).items
+    @notes = SearchService.new.notes(params[:id])
   end
 
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -16,6 +16,10 @@ class SearchService
     @tags ||= find_tags(params)
   end
 
+  def nodes(params)
+    @nodes ||= find_nodes(params)
+  end
+
   def notes(params)
     @notes ||= find_notes(params)
   end
@@ -45,6 +49,12 @@ class SearchService
     Comment.limit(limit)
            .order('nid DESC')
            .where('status = 1 AND comment LIKE ?', '%' + input + '%')
+  end
+
+  def find_nodes(input, limit = 5)
+    Node.limit(limit)
+        .order('nid DESC')
+        .where('node.status = 1 AND title LIKE ?', '%' + input + '%')
   end
 
   ## search for node title only

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -14,8 +14,8 @@ class SearchesControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:tagnames)
     assert_not_nil assigns(:users)
-    assert_not_nil assigns(:notes)
-    assert_equal node(:about).id, assigns(:notes).first.id
+    assert_not_nil assigns(:nodes)
+    assert_equal node(:about).id, assigns(:nodes).first.id
   end
 
   test "search dynamic search page at /search/dynamic" do


### PR DESCRIPTION
Re #1463

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
