### PR TITLE
.gitignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ data
 .DS_Store
 .idea
 .ruby-version
+Gemfile.lock
 coverage*
 development.sqlite
 test.sqlite


### PR DESCRIPTION
@icarito and @ananyo2012 -- i know we've been through this a bit, but I wanted to try adding this since almost every contributor is getting stuck on the Gemfile.lock changes. And when it is necessary, we can always do `git add Gemfile.lock` -- right? or maybe an `-f`?

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
