### PR TITLE
DrupalNodeRevision => Revision model renam

### DIFF
--- a/app/assets/javascripts/post.js
+++ b/app/assets/javascripts/post.js
@@ -14,7 +14,7 @@ jQuery(document).ready(function() {
       $('.side-dropzone').css('background','#fcc')
       alert_notice('Click <b>Publish</b> again to publish without a main image, but it is recommended that you add one.', {'scroll': true})
     } else {
-      $('#new_drupal_node_revision#new_drupal_node_revision,#edit_drupal_node_revision').submit()
+      $('#new_revision#new_revision,#edit_revision').submit()
     }
   }
   $(".publish").bind("click",publish)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -73,9 +73,9 @@ class AdminController < ApplicationController
 
   def spam_revisions
     if current_user && (current_user.role == 'moderator' || current_user.role == 'admin')
-      @revisions = DrupalNodeRevision.paginate(page: params[:page])
-                                     .order('timestamp DESC')
-                                     .where(status: 0)
+      @revisions = Revision.paginate(page: params[:page])
+                           .order('timestamp DESC')
+                           .where(status: 0)
       render template: 'admin/spam'
     else
       flash[:error] = 'Only moderators can moderate revisions.'
@@ -140,7 +140,7 @@ class AdminController < ApplicationController
   end
 
   def mark_spam_revision
-    @revision = DrupalNodeRevision.find_by_vid params[:vid]
+    @revision = Revision.find_by_vid params[:vid]
     if current_user && (current_user.role == 'moderator' || current_user.role == 'admin')
       if @revision.status == 1
         @revision.spam
@@ -163,7 +163,7 @@ class AdminController < ApplicationController
 
   def publish_revision
     if current_user && (current_user.role == 'moderator' || current_user.role == 'admin')
-      @revision = DrupalNodeRevision.find params[:vid]
+      @revision = Revision.find params[:vid]
       @revision.publish
       @revision.author.unban
       flash[:notice] = 'Item published.'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,10 +33,10 @@ class ApplicationController < ActionController::Base
                         .collect(&:nid)
       @notes = if params[:controller] == 'questions'
                  Node.questions
-                     .joins(:drupal_node_revision)
+                     .joins(:revision)
                else
                  Node.research_notes
-                     .joins(:drupal_node_revision)
+                     .joins(:revision)
                      .order('node.nid DESC')
                      .paginate(page: params[:page])
                end
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
       end
 
       @wikis = Node.order('changed DESC')
-                   .joins(:drupal_node_revision)
+                   .joins(:revision)
                    .where('node_revisions.status = 1 AND node.status = 1 AND type = "page"')
                    .limit(10)
                    .group('node_revisions.nid')

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -44,9 +44,9 @@ class HomeController < ApplicationController
     @note_count = Node.select(%i[created type status])
                       .where(type: 'note', status: 1, created: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
                       .count
-    @wiki_count = DrupalNodeRevision.select(:timestamp)
-                                    .where(timestamp: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
-                                    .count
+    @wiki_count = Revision.select(:timestamp)
+                          .where(timestamp: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
+                          .count
     @blog = Tag.find_nodes_by_type('blog', 'note', 1).first
     # remove "classroom" postings; also switch to an EXCEPT operator in sql, see https://github.com/publiclab/plots2/issues/375
     hidden_nids = Node.joins(:node_tag)
@@ -73,14 +73,14 @@ class HomeController < ApplicationController
     @wikis = Node.where(type: 'page', status: 1)
                  .order('nid DESC')
                  .limit(10)
-    revisions = DrupalNodeRevision.joins(:node)
-                                  .order('timestamp DESC')
-                                  .where('type = (?)', 'page')
-                                  .where('node.status = 1')
-                                  .where('node_revisions.status = 1')
-                                  .where('timestamp - node.created > ?', 300) # don't report edits within 5 mins of page creation
-                                  .limit(10)
-                                  .group('node.title')
+    revisions = Revision.joins(:node)
+                        .order('timestamp DESC')
+                        .where('type = (?)', 'page')
+                        .where('node.status = 1')
+                        .where('node_revisions.status = 1')
+                        .where('timestamp - node.created > ?', 300) # don't report edits within 5 mins of page creation
+                        .limit(10)
+                        .group('node.title')
     # group by day: http://stackoverflow.com/questions/5970938/group-by-day-from-timestamp
     revisions = revisions.group('DATE(FROM_UNIXTIME(timestamp))') if Rails.env == 'production'
     @wikis += revisions

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -14,7 +14,7 @@ class NotesController < ApplicationController
   def places
     @title = 'Places'
     @notes = Node.where(status: 1, type: %w[page place])
-                 .includes(:drupal_node_revision, :tag)
+                 .includes(:revision, :tag)
                  .where('term_data.name = ?', 'chapter')
                  .page(params[:page])
                  .order('node_revisions.timestamp DESC')

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -14,9 +14,9 @@ class StatsController < ApplicationController
     @notes = Node.select(%i[created type status])
                  .where(type: 'note', status: 1, created: @start.to_i..@end.to_i)
                  .count
-    @wikis = DrupalNodeRevision.select(:timestamp)
-                               .where(timestamp: @start.to_i..@end.to_i)
-                               .count - @notes # because notes each have one revision
+    @wikis = Revision.select(:timestamp)
+                     .where(timestamp: @start.to_i..@end.to_i)
+                     .count - @notes # because notes each have one revision
     @people = User.where(created_at: @start..@end)
                   .joins('INNER JOIN users ON users.uid = rusers.id')
                   .where('users.status = 1')
@@ -33,9 +33,9 @@ class StatsController < ApplicationController
     @weekly_notes = Node.select(%i[created type status])
                         .where(type: 'note', status: 1, created: @time.to_i - 1.weeks.to_i..@time.to_i)
                         .count
-    @weekly_wikis = DrupalNodeRevision.select(:timestamp)
-                                      .where(timestamp: @time.to_i - 1.weeks.to_i..@time.to_i)
-                                      .count
+    @weekly_wikis = Revision.select(:timestamp)
+                            .where(timestamp: @time.to_i - 1.weeks.to_i..@time.to_i)
+                            .count
     @weekly_members = User.where(created_at: @time - 1.weeks..@time)
                           .joins('INNER JOIN users ON users.uid = rusers.id')
                           .where('users.status = 1')
@@ -43,9 +43,9 @@ class StatsController < ApplicationController
     @monthly_notes = Node.select(%i[created type status])
                          .where(type: 'note', status: 1, created: @time.to_i - 1.months.to_i..@time.to_i)
                          .count
-    @monthly_wikis = DrupalNodeRevision.select(:timestamp)
-                                       .where(timestamp: @time.to_i - 1.months.to_i..@time.to_i)
-                                       .count
+    @monthly_wikis = Revision.select(:timestamp)
+                             .where(timestamp: @time.to_i - 1.months.to_i..@time.to_i)
+                             .count
     @monthly_members = User.where(created_at: @time - 1.months..@time)
                            .joins('INNER JOIN users ON users.uid = rusers.id')
                            .where('users.status = 1')
@@ -54,9 +54,9 @@ class StatsController < ApplicationController
     @notes_per_week_past_year = Node.select(%i[created type status])
                                     .where(type: 'note', status: 1, created: @time.to_i - 1.years.to_i..@time.to_i)
                                     .count / 52.0
-    @edits_per_week_past_year = DrupalNodeRevision.select(:timestamp)
-                                                  .where(timestamp: @time.to_i - 1.years.to_i..@time.to_i)
-                                                  .count / 52.0
+    @edits_per_week_past_year = Revision.select(:timestamp)
+                                        .where(timestamp: @time.to_i - 1.years.to_i..@time.to_i)
+                                        .count / 52.0
 
     @graph_notes = Node.weekly_tallies('note', 52, @time).to_a.sort.to_json
     @graph_wikis = Node.weekly_tallies('page', 52, @time).to_a.sort.to_json

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -33,14 +33,14 @@ class TagController < ApplicationController
       @wildcard = true
       @tags = Tag.where('name LIKE (?)', params[:id][0..-2] + '%')
       nodes = Node.where(status: 1, type: node_type)
-                  .includes(:drupal_node_revision, :tag)
+                  .includes(:revision, :tag)
                   .where('term_data.name LIKE (?) OR term_data.parent LIKE (?)', params[:id][0..-2] + '%', params[:id][0..-2] + '%')
                   .page(params[:page])
                   .order('node_revisions.timestamp DESC')
     else
       @tags = Tag.find_all_by_name params[:id]
       nodes = Node.where(status: 1, type: node_type)
-                  .includes(:drupal_node_revision, :tag)
+                  .includes(:revision, :tag)
                   .where('term_data.name = ? OR term_data.parent = ?', params[:id], params[:id])
                   .page(params[:page])
                   .order('node_revisions.timestamp DESC')
@@ -198,7 +198,7 @@ class TagController < ApplicationController
   def rss
     if params[:tagname][-1..-1] == '*'
       @notes = Node.where(status: 1, type: 'note')
-                   .includes(:drupal_node_revision, :tag)
+                   .includes(:revision, :tag)
                    .where('term_data.name LIKE (?)', params[:tagname][0..-2] + '%')
                    .limit(20)
                    .order('node_revisions.timestamp DESC')
@@ -224,7 +224,7 @@ class TagController < ApplicationController
     @tagnames = [params[:id]]
     @tag = Tag.find_by_name params[:id]
     @notes = Node.where(status: 1, type: 'note')
-                 .includes(:drupal_node_revision, :tag)
+                 .includes(:revision, :tag)
                  .where('term_data.name = ?', params[:id])
                  .order('node_revisions.timestamp DESC')
     @users = @notes.collect(&:author).uniq

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -117,10 +117,10 @@ class UsersController < ApplicationController
                           .where(status: 1)
                           .order('node.nid DESC')
     @answered_questions = questions.select{|q| q.answers.collect(&:author).include?(@user)}
-    wikis = DrupalNodeRevision.order("nid DESC")
-                              .where('node.type' => 'page', 'node.status' => 1, uid: @user.uid)
-                              .joins(:node)
-                              .limit(20)
+    wikis = Revision.order("nid DESC")
+                    .where('node.type' => 'page', 'node.status' => 1, uid: @user.uid)
+                    .joins(:node)
+                    .limit(20)
     @wikis = wikis.collect(&:parent).uniq
     if @user.status == 0
       if current_user && (current_user.role == "admin" || current_user.role == "moderator")

--- a/app/models/concerns/node_shared.rb
+++ b/app/models/concerns/node_shared.rb
@@ -14,7 +14,7 @@ module NodeShared
     body.gsub(/[^\>`](\<p\>)?\[notes\:(\S+)\]/) do |_tagname|
       tagname = Regexp.last_match(2).parameterize
       nodes = Node.where(status: 1, type: 'note')
-                  .includes(:drupal_node_revision, :tag)
+                  .includes(:revision, :tag)
                   .where('term_data.name = ?', tagname)
                   .order('node_revisions.timestamp DESC')
       output = ''
@@ -38,7 +38,7 @@ module NodeShared
     body.gsub(/[^\>`](\<p\>)?\[questions\:(\S+)\]/) do |_tagname|
       tagname = Regexp.last_match(2).parameterize
       nodes = Node.where(status: 1, type: 'note')
-                  .includes(:drupal_node_revision, :tag)
+                  .includes(:revision, :tag)
                   .where('term_data.name = ?', "question:#{tagname}")
                   .order('node_revisions.timestamp DESC')
       output = ''

--- a/app/models/drupal_users.rb
+++ b/app/models/drupal_users.rb
@@ -143,7 +143,7 @@ class DrupalUsers < ActiveRecord::Base
   end
 
   def node_count
-    Node.count(:all, conditions: { status: 1, uid: uid }) + DrupalNodeRevision.count(:all, conditions: { uid: uid })
+    Node.count(:all, conditions: { status: 1, uid: uid }) + Revision.count(:all, conditions: { uid: uid })
   end
 
   # accepts array of tag names (strings)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -42,7 +42,7 @@ class Node < ActiveRecord::Base
     updated_at.strftime('%B %Y')
   end
 
-  has_many :drupal_node_revision, foreign_key: 'nid', dependent: :destroy
+  has_many :revision, foreign_key: 'nid', dependent: :destroy
   # wasn't working to tie it to .vid, manually defining below
   #  has_one :drupal_main_image, :foreign_key => 'vid', :dependent => :destroy
   #  has_many :drupal_content_field_image_gallery, :foreign_key => 'nid'
@@ -195,12 +195,12 @@ class Node < ActiveRecord::Base
   end
 
   def revisions
-    drupal_node_revision
+    revision
       .order('timestamp DESC')
   end
 
   def revision_count
-    drupal_node_revision
+    revision
       .count
   end
 
@@ -307,7 +307,7 @@ class Node < ActiveRecord::Base
   # The key word "response" can be customized, i.e. `replication:<nid>` for other uses.
   def response_count(key = 'response')
     Node.where(status: 1, type: 'note')
-        .includes(:drupal_node_revision, :tag)
+        .includes(:revision, :tag)
         .where('term_data.name = ?', "#{key}:#{id}")
         .count
   end
@@ -527,10 +527,10 @@ class Node < ActiveRecord::Base
 
   def new_revision(params)
     title = params[:title] || self.title
-    DrupalNodeRevision.new(nid: id,
-                           uid: params[:uid],
-                           title: title,
-                           body: params[:body])
+    Revision.new(nid: id,
+                 uid: params[:uid],
+                 title: title,
+                 body: params[:body])
   end
 
   # handle creating a new note with attached revision and main image
@@ -661,9 +661,9 @@ class Node < ActiveRecord::Base
           end
           tag.save!
           node_tag = NodeTag.new(tid: tag.id,
-                                                uid: user.uid,
-                                                date: DateTime.now.to_i,
-                                                nid: id)
+                                 uid: user.uid,
+                                 date: DateTime.now.to_i,
+                                 nid: id)
           if node_tag.save
             saved = true
           else
@@ -716,13 +716,13 @@ class Node < ActiveRecord::Base
 
   def self.activities(tagname)
     Node.where(status: 1, type: 'note')
-        .includes(:drupal_node_revision, :tag)
+        .includes(:revision, :tag)
         .where('term_data.name LIKE ?', "activity:#{tagname}")
   end
 
   def self.upgrades(tagname)
     Node.where(status: 1, type: 'note')
-        .includes(:drupal_node_revision, :tag)
+        .includes(:revision, :tag)
         .where('term_data.name LIKE ?', "upgrade:#{tagname}")
   end
 

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -13,7 +13,7 @@ class Revision < ActiveRecord::Base
   self.table_name = 'node_revisions'
   self.primary_key = 'vid'
 
-  belongs_to :node, foreign_key: 'nid', dependent: :destroy, counter_cache: true
+  belongs_to :node, foreign_key: 'nid', dependent: :destroy, counter_cache: :drupal_node_revisions_count
   has_one :drupal_users, foreign_key: 'uid'
 
   validates :title,

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -1,4 +1,4 @@
-class DrupalNodeRevision < ActiveRecord::Base
+class Revision < ActiveRecord::Base
 
   include SolrToggle
   searchable if: :shouldIndexSolr do
@@ -82,17 +82,17 @@ class DrupalNodeRevision < ActiveRecord::Base
   end
 
   def is_initial?
-    parent.drupal_node_revision.count == 1
+    parent.revision.count == 1
   end
 
   def previous
-    parent.drupal_node_revision.order('timestamp DESC')
+    parent.revision.order('timestamp DESC')
           .where('timestamp < ?', timestamp)
           .first
   end
 
   def next
-    parent.drupal_node_revision.order('timestamp DESC')
+    parent.revision.order('timestamp DESC')
           .where('timestamp > ?', timestamp)
           .last
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -74,7 +74,7 @@ class Tag < ActiveRecord::Base
                   .includes(:tag)
                   .where('term_data.name IN (?)', tags.collect(&:parent))
     Node.where('node.nid IN (?)', (nodes + parents).collect(&:nid))
-        .includes(:drupal_node_revision, :tag)
+        .includes(:revision, :tag)
         .where(status: 1)
         .order('node_revisions.timestamp DESC')
         .limit(limit)
@@ -96,7 +96,7 @@ class Tag < ActiveRecord::Base
       tag = Tag.where(name: tagname).last
       next unless tag
       parents = Node.where(status: 1, type: type)
-                    .includes(:drupal_node_revision, :tag)
+                    .includes(:revision, :tag)
                     .where('term_data.name LIKE ?', tag.parent)
       nids += tag_nids + parents.collect(&:nid)
     end
@@ -192,7 +192,7 @@ class Tag < ActiveRecord::Base
 
   def self.find_research_notes(tagnames, limit = 10)
     Node.research_notes.where(status: 1)
-        .includes(:drupal_node_revision, :tag)
+        .includes(:revision, :tag)
         .where('term_data.name IN (?)', tagnames)
         .order('node_revisions.timestamp DESC')
         .limit(limit)

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -49,7 +49,7 @@
 
   <div class="row">
     <% activity.each_with_index do |node, i| %>
-      <% if node.is_a?(DrupalNodeRevision) || node.type == 'page' %>
+      <% if node.is_a?(Revision) || node.type == 'page' %>
         <%= render partial: "dashboard/node_wiki",     locals: { node: node, index: i } %>
       <% elsif node.is_a?(Comment) %>
         <%= render partial: "dashboard/node_comment",  locals: { node: node, index: i } %>

--- a/app/views/dashboard/_node_meta.html.erb
+++ b/app/views/dashboard/_node_meta.html.erb
@@ -1,8 +1,8 @@
-<% unless node.is_a?(Comment) || node.is_a?(DrupalNodeRevision) || node.type == 'page' %>
+<% unless node.is_a?(Comment) || node.is_a?(Revision) || node.type == 'page' %>
   <%= t('dashboard.dashboard.by') %> <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a> 
 <% end %>
 <%= distance_of_time_in_words(node.created_at, Time.current, false, :scope => :'datetime.time_ago_in_words') %>
-<% node = node.parent if node.is_a?(DrupalNodeRevision) %>
+<% node = node.parent if node.is_a?(Revision) %>
 <span class="">
   <% if params[:controller] == 'questions' %>
     | <a href="<%= node.path(:question) %>#answers"><i class="fa fa-comments-o" style="color: #DAA583;"></i> <%= node.answers.length %></a>

--- a/app/views/dashboard/_node_wiki.html.erb
+++ b/app/views/dashboard/_node_wiki.html.erb
@@ -23,13 +23,13 @@
       </a> 
     </h4>
 
-    <% if node.is_a?(DrupalNodeRevision) && node.previous %>
+    <% if node.is_a?(Revision) && node.previous %>
       <a class="btn btn-default btn-xs pull-right btn-diff btn-diff-<%= index %>"><%= t('dashboard._node_wiki.changes') %> &raquo;</a>
     <% end %>
  
     <p class="meta"><%= render partial: "dashboard/node_meta", locals: { node: node } %></p>
 
-    <% if node.is_a?(DrupalNodeRevision) && node.previous %>
+    <% if node.is_a?(Revision) && node.previous %>
       <div data-diff-a="<%= node.previous.vid %>" data-diff-b="<%= node.vid %>" class="well wiki-diff wiki-diff-<%= index %>" style="display:none;"><i class="fa fa-circle-o-notch fa-spin"></i></div>
     <% end %>
 

--- a/app/views/dashboard/_wiki.html.erb
+++ b/app/views/dashboard/_wiki.html.erb
@@ -35,7 +35,7 @@
 
           <%= distance_of_time_in_words(wiki.created_at, Time.current, false, :scope => :'datetime.time_ago_in_words') %>
 
-          <% if wiki.is_a?(DrupalNodeRevision) && wiki.previous %>
+          <% if wiki.is_a?(Revision) && wiki.previous %>
            - <a class="btn-diff btn-diff-<%= index %>"><%= t('dashboard._wiki.changes') %></a>
           <% end %>
 
@@ -52,7 +52,7 @@
         </a> 
       </h4>
 
-      <% if wiki.is_a?(DrupalNodeRevision) && wiki.previous %>
+      <% if wiki.is_a?(Revision) && wiki.previous %>
         <div data-diff-a="<%= wiki.previous.vid %>" 
              data-diff-b="<%= wiki.vid %>" 
              class="well wiki-diff wiki-diff-<%= index %>" 

--- a/app/views/editor/post.html.erb
+++ b/app/views/editor/post.html.erb
@@ -66,7 +66,7 @@
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages :header_message => "Your note couldn't be saved." %></div><% end %>
   <% end %>
 
-  <%= form_for @revision, :as => :drupal_node_revision, :url => url, :html => {:class => "form well"} do |f| %>
+  <%= form_for @revision, :as => :revision, :url => url, :html => {:class => "form well"} do |f| %>
 
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages :header_message => "Your note couldn't be saved." %></div><% end %>
 

--- a/app/views/editor/question.html.erb
+++ b/app/views/editor/question.html.erb
@@ -66,7 +66,7 @@
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages :header_message => "Your note couldn't be saved." %></div><% end %>
   <% end %>
 
-  <%= form_for @revision, :as => :drupal_node_revision, :url => url, :html => {:class => "form well"} do |f| %>
+  <%= form_for @revision, :as => :revision, :url => url, :html => {:class => "form well"} do |f| %>
 
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages :header_message => "Your note couldn't be saved." %></div><% end %>
 

--- a/app/views/features/new.html.erb
+++ b/app/views/features/new.html.erb
@@ -2,7 +2,7 @@
 
 <% url = { :controller => "features", :action => "create", :id => params[:id] } %>
 
-<%= form_for @revision, :as => :drupal_node_revision, :url => url, :html => {:class => "form well"} do |f| %>
+<%= form_for @revision, :as => :revision, :url => url, :html => {:class => "form well"} do |f| %>
 
   <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages :header_message => "Your note couldn't be saved." %></div><% end %>
 

--- a/app/views/map/edit.html.erb
+++ b/app/views/map/edit.html.erb
@@ -15,7 +15,7 @@
   end 
   %>
 
-  <%= form_for @revision, :as => :drupal_node_revision, :url => url, :html => {:class => "form"} do |f| %>
+  <%= form_for @revision, :as => :revision, :url => url, :html => {:class => "form"} do |f| %>
 
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages :header_message => "Your map couldn't be saved." %></div><% end %>
 

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -67,7 +67,7 @@
 
   <hr />
 
-  <h4><%= raw t('notes.stats.wiki_page_edits', :count => DrupalNodeRevision.count(:all)) %></h4>
+  <h4><%= raw t('notes.stats.wiki_page_edits', :count => Revision.count(:all)) %></h4>
   <p><%= raw t('notes.stats.edits_per_week', :count => @edits_per_week_past_year.round(2)) %></p>
 
 </div>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -38,7 +38,7 @@
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages %></div><% end %>
   <% end %>
 
-  <%= form_for @revision, :as => :drupal_node_revision, :url => url, :html => {:class => "form well"} do |f| %>
+  <%= form_for @revision, :as => :revision, :url => url, :html => {:class => "form well"} do |f| %>
 
     <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages %></div><% end %>
   
@@ -88,7 +88,7 @@
     <script>
       (function(){
         publish = function(e) {
-            $('#new_drupal_node_revision').submit()
+            $('#new_revision').submit()
         }
         $(".publish").bind("click",publish)
       })()

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,7 @@ basic_user.save({})
     "status"=>1, "comment"=>0, "cached_likes"=>0
   #web_node_counter = DrupalNodeCounter.create! "nid"=>web_page.nid,
     #"totalcount"=>1
-  web_node_revisions = DrupalNodeRevision.create! "nid"=>web_page.nid,
+  web_node_revisions = Revision.create! "nid"=>web_page.nid,
     "uid"=>admin.uid, "title"=>page.capitalize, "body"=>"#{page} - page", "teaser"=>"",
     "log"=>"", "format"=>1
 end
@@ -40,7 +40,7 @@ end
 # set up a blog entry with a comment and a like
 blog_post = Node.create! "type"=>"note", "title"=>"Blog Post", "uid"=>admin.id,
   "status"=>1, "comment"=>1, "cached_likes"=>1
-blog_post_revisions = DrupalNodeRevision.create! "nid"=>blog_post.nid,
+blog_post_revisions = Revision.create! "nid"=>blog_post.nid,
     "uid"=>admin.uid, "title"=>"Blog Post", "body"=>"Blog post body", "teaser"=>"",
     "log"=>"", "format"=>1
 blog_post_tag = Tag.create! "name"=>"blog", "description"=>"", "weight"=>0
@@ -54,8 +54,8 @@ blog_post_comment = Comment.create! "nid"=>blog_post.id, "uid"=>admin.id,
 35.times do |t|
   map_node = Node.create! "type"=>"map", "title"=>"test map #{t}", "uid"=>1,
     "status"=>1
-  DrupalNodeRevision.attr_accessible :nid, :vid
-  map_node_revision =  DrupalNodeRevision.create! "nid" => map_node.nid, "vid" => map_node.nid,
+  Revision.attr_accessible :nid, :vid
+  map_node_revision =  Revision.create! "nid" => map_node.nid, "vid" => map_node.nid,
     "uid"=>1, "title"=>"Test Map #{t}", "body"=>"Body of revision #{t}" 
   tag_lat = Tag.create! name: "lat:#{rand * 80}", description: "Desc #{t}", weight: 5
   tag_lon = Tag.create! name: "lon:#{rand * 80}", description: "Desc #{t}", weight: 5

--- a/test/functional/features_controller_test.rb
+++ b/test/functional/features_controller_test.rb
@@ -90,7 +90,7 @@ class FeaturesControllerTest < ActionController::TestCase
     UserSession.create(rusers(:admin))
 
     node = node(:feature)
-    assert_difference 'DrupalNodeRevision.count' do
+    assert_difference 'Revision.count' do
       get :update,
           id: node.id,
           body: "A new feature to <a href=''>display</a> with additions"

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -32,17 +32,17 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'should show only unmoderated spam' do
     @wikis = Node.where(type: 'page')
-    revisions = DrupalNodeRevision.joins(:node)
-                                  .where('type = (?)', 'page')
-                                  .where('node_revisions.status = 1')
+    revisions = Revision.joins(:node)
+                        .where('type = (?)', 'page')
+                        .where('node_revisions.status = 1')
     @wikis += revisions
 
     get :dashboard
 
     @wikis.each do |obj|
-      if obj.class == DrupalNodeRevision && obj.status == 1
+      if obj.class == Revision && obj.status == 1
         assert_select '.wiki'
-      elsif obj.class == DrupalNodeRevision && obj.status != 1
+      elsif obj.class == Revision && obj.status != 1
         assert_select false, '.wiki'
       end
     end

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -143,7 +143,7 @@ class WikiControllerTest < ActionController::TestCase
   test 'basic user blocked from editing a locked wiki page' do
     node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
     # then try editing it
-    assert_difference 'DrupalNodeRevision.count', 0 do
+    assert_difference 'Revision.count', 0 do
       post :edit,
            id: 'organizers'
     end
@@ -154,7 +154,7 @@ class WikiControllerTest < ActionController::TestCase
   test 'basic user blocked from updating a locked wiki page' do
     node(:organizers).add_tag('locked', rusers(:admin)) # lock the page with a tag
     # then try editing it
-    assert_difference 'DrupalNodeRevision.count', 0 do
+    assert_difference 'Revision.count', 0 do
       post :update,
            id: node(:organizers).id
     end
@@ -259,7 +259,7 @@ class WikiControllerTest < ActionController::TestCase
   #  test "admin user should not delete wiki revision if its the only revision" do
   #    UserSession.create(rusers(:admin))
   ## this will require creating a wiki page with only one revision, to be sure
-  ## this could also be done in a unit test if we add a before_destroy filter on the DrupalNodeRevision model
+  ## this could also be done in a unit test if we add a before_destroy filter on the Revision model
   #    UserSession.find.destroy
   #  end
 
@@ -440,7 +440,7 @@ class WikiControllerTest < ActionController::TestCase
     UserSession.create(rusers(:jeff))
     node = node(:about)
 
-    assert_difference 'DrupalNodeRevision.count' do
+    assert_difference 'Revision.count' do
       assert_difference "Node.find(#{node.id}).revisions.count" do
         get :replace, id: node.id, before: 'Public', after: 'Private'
       end
@@ -456,7 +456,7 @@ class WikiControllerTest < ActionController::TestCase
     assert !node.latest.body.include?('Private')
     assert node.latest.body.include?('Public')
 
-    assert_difference 'DrupalNodeRevision.count' do
+    assert_difference 'Revision.count' do
       assert_difference "Node.find(#{node.id}).revisions.count" do
         xhr :post, :replace, id: node.id, before: 'Public', after: 'Private'
       end
@@ -475,7 +475,7 @@ class WikiControllerTest < ActionController::TestCase
     node = node(:about)
     assert node.latest.update_attribute('body', 'Public Lab')
 
-    assert_difference 'DrupalNodeRevision.count', 0 do
+    assert_difference 'Revision.count', 0 do
       assert_difference "Node.find(#{node.id}).revisions.count", 0 do
         xhr :post, :replace, id: node.id, before: 'Elephants', after: 'Tigers'
       end

--- a/test/integration/wiki_creation_test.rb
+++ b/test/integration/wiki_creation_test.rb
@@ -36,7 +36,7 @@ class WikiCreationTest < ActionDispatch::IntegrationTest
 
     assert_equal node, nil
     assert_equal '/wiki/create', path
-    assert_select 'h2', '1 error prohibited this drupal node revision from being saved'
+    assert_select 'h2', '1 error prohibited this revision from being saved'
 
     # Now fill the body, and check it succeeds
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ class ActiveSupport::TestCase
   set_fixture_class node: Node
   set_fixture_class rusers: User
   set_fixture_class users: DrupalUsers
-  set_fixture_class node_revisions: DrupalNodeRevision
+  set_fixture_class node_revisions: Revision
   set_fixture_class tag_selection: TagSelection
   set_fixture_class tags: Tag
   set_fixture_class community_tags: NodeTag

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -107,8 +107,8 @@ class NodeTest < ActiveSupport::TestCase
   test 'create a node_revision' do
     # in testing, uid and id should be matched, although this is not yet true in production db
     revision_count = node(:one).revisions.length
-    node_revision =  DrupalNodeRevision.new(uid: rusers(:bob).id,
-                                            nid: node(:one).nid)
+    node_revision =  Revision.new(uid: rusers(:bob).id,
+                                  nid: node(:one).nid)
     node_revision.title = 'My new node'
     node_revision.body = 'My new node'
     assert node_revision.save!
@@ -121,7 +121,7 @@ class NodeTest < ActiveSupport::TestCase
     assert_equal node.revisions.first, node.latest
     assert node.revisions.first.timestamp.to_i > node.revisions.last.timestamp.to_i
     assert_not_equal node.revisions.last, node.latest
-    assert_equal node.drupal_node_revision.order('timestamp DESC').first, node.latest
+    assert_equal node.revision.order('timestamp DESC').first, node.latest
   end
 
   test 'latest revision not a moderated revision' do

--- a/test/unit/revision_test.rb
+++ b/test/unit/revision_test.rb
@@ -1,16 +1,16 @@
 require 'test_helper'
 
-class DrupalNodeRevisionsTest < ActiveSupport::TestCase
+class RevisionsTest < ActiveSupport::TestCase
   test 'create a node_revision' do
     node = Node.new(uid: rusers(:bob).id,
                     type: 'page')
     node.title = 'My new node for revision testing'
     assert node.save!
     # in testing, uid and id should be matched, although this is not yet true in production db
-    node_revision = DrupalNodeRevision.new(title: 'My new node',
-                                           body: 'My new node',
-                                           uid: rusers(:bob).id,
-                                           nid: node(:one).nid)
+    node_revision = Revision.new(title: 'My new node',
+                                 body: 'My new node',
+                                 uid: rusers(:bob).id,
+                                 nid: node(:one).nid)
     assert node_revision.save!
     assert_not_equal 0, node_revision.timestamp
     assert_not_nil node_revision.timestamp
@@ -42,10 +42,10 @@ class DrupalNodeRevisionsTest < ActiveSupport::TestCase
   test 'previous and next revisions' do
     revision = node_revisions(:about)
     # does previous respect status = 1? no.
-    new_revision = DrupalNodeRevision.new(title: revision.title,
-                                          body:  'New body',
-                                          uid:   rusers(:bob).id,
-                                          nid:   revision.nid)
+    new_revision = Revision.new(title: revision.title,
+                                body:  'New body',
+                                uid:   rusers(:bob).id,
+                                nid:   revision.nid)
 
     assert_difference 'revision.parent.revisions.length', 1 do
       assert new_revision.save
@@ -55,10 +55,10 @@ class DrupalNodeRevisionsTest < ActiveSupport::TestCase
     assert_equal new_revision.previous, revision
     assert_equal revision.next, new_revision
 
-    new_revision_2 = DrupalNodeRevision.new(title: revision.title,
-                                            body:  'New body 2',
-                                            uid:   rusers(:bob).id,
-                                            nid:   revision.nid)
+    new_revision_2 = Revision.new(title: revision.title,
+                                  body:  'New body 2',
+                                  uid:   rusers(:bob).id,
+                                  nid:   revision.nid)
 
     assert_difference 'revision.parent.revisions.length', 1 do
       assert new_revision_2.save


### PR DESCRIPTION
Last of the first batch of legacy renamings in #956

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

