### PR TITLE
[API] Commenting through a token

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -48,6 +48,9 @@ class CommentController < ApplicationController
 
     if @user && @user.token == @token
       begin
+        # The create_comment is a function that has been defined inside the
+        # CommentHelper module inside app/helpers/comment_helper.rb and can be
+        # used in here because the module was `include`d right at the beginning
         @comment = create_comment(@node, @user, @body)
         respond_to do |format|
           format.all { render :nothing => true, :status => :created }

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -36,6 +36,22 @@ class CommentController < ApplicationController
     end
   end
 
+  def create_by_token
+    # Parse the user's token from the headers
+
+    # Use logic similar to the above create controller but with the user that
+    # the token belongs to instead of the `current_user`
+
+    # In order to avoid looking up the entire database for a user having a
+    # matching token, we could instead ask the user to pass username/id in the
+    # params along with the node id and comment body.
+    # This would also mean that if someone tries to bruteforce a token, they
+    # would to do so for each user individually.
+
+    # If the username/id and token do not match, send an error in the same
+    # format as the request (JSON/XML)
+  end
+
   # create answer comments
   def answer_create
     @answer_id = params[:aid]

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -49,32 +49,17 @@ class CommentController < ApplicationController
     if @user && @user.token == @token
       begin
         @comment = create_comment(@node, @user, @body)
-        msg = {
-          status: :created,
-          message: 'Created'
-        }
         respond_to do |format|
-          format.xml { render xml: msg.to_xml }
-          format.json { render json: msg.to_json }
+          format.all { render :nothing => true, :status => :created }
         end
       rescue CommentError
-        msg = {
-          status: :bad_request,
-          message: 'Bad Request'
-        }
         respond_to do |format|
-          format.xml { render xml: msg.to_xml }
-          format.json { render json: msg.to_json }
+          format.all { render :nothing => true, :status => :bad_request }
         end
       end
     else
-      msg = {
-        status: :unauthorized,
-        message: 'Unauthorized'
-      }
       respond_to do |format|
-        format.xml { render xml: msg.to_xml }
-        format.json { render json: msg.to_json }
+        format.all { render :nothing => true, :status => :unauthorized }
       end
     end
   end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -47,12 +47,12 @@ class CommentController < ApplicationController
       # TODO: Do the usual commenting stuff
     else
       msg = {
-        :status => :unauthorized
-        :message => "Unauthorized"
+        status: :unauthorized
+        message: "Unauthorized"
       }
       respond_to do |format|
-        format.xml { render :xml => msg.to_xml }
-        format.json { render :json => msg.to_json }
+        format.xml { render xml: msg.to_xml }
+        format.json { render json: msg.to_json }
       end
     end
   end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -42,9 +42,9 @@ class CommentController < ApplicationController
 
   def create_by_token
     @node = Node.find params[:id]
-    @user = Users.find_by_username params[:username]
-    @body = pararms[:body]
-    @token = request.headers["token"]
+    @user = User.find_by_username params[:username]
+    @body = params[:body]
+    @token = request.headers['Token']
 
     if @user && @user.token == @token
       begin

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -47,7 +47,7 @@ class CommentController < ApplicationController
       # TODO: Do the usual commenting stuff
     else
       msg = {
-        status: :unauthorized
+        status: :unauthorized,
         message: "Unauthorized"
       }
       respond_to do |format|

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -44,14 +44,14 @@ class CommentController < ApplicationController
     @node = Node.find params[:id]
     @user = User.find_by_username params[:username]
     @body = params[:body]
-    @token = request.headers['Token']
+    @token = request.env['rack.session']['token']
 
     if @user && @user.token == @token
       begin
         @comment = create_comment(@node, @user, @body)
         msg = {
           status: :created,
-          message: "Created"
+          message: 'Created'
         }
         respond_to do |format|
           format.xml { render xml: msg.to_xml }
@@ -60,7 +60,7 @@ class CommentController < ApplicationController
       rescue CommentError
         msg = {
           status: :bad_request,
-          message: "Bad Request"
+          message: 'Bad Request'
         }
         respond_to do |format|
           format.xml { render xml: msg.to_xml }
@@ -70,7 +70,7 @@ class CommentController < ApplicationController
     else
       msg = {
         status: :unauthorized,
-        message: "Unauthorized"
+        message: 'Unauthorized'
       }
       respond_to do |format|
         format.xml { render xml: msg.to_xml }

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -1,3 +1,12 @@
+def create_comment(node_id, user, body)
+  @node = Node.find node_id
+  @comment = @node.add_comment(uid: user.uid, body: body)
+  if user && @comment.save
+    @comment.notify user
+    return @comment
+  end
+end
+
 class CommentController < ApplicationController
   respond_to :html, :xml, :json
   before_filter :require_user, only: %i[create update delete]

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -1,17 +1,6 @@
-class CommentError < ArgumentError
-end
-
-def create_comment(node, user, body)
-  @comment = node.add_comment(uid: user.uid, body: body)
-  if user && @comment.save
-    @comment.notify user
-    return @comment
-  else
-    raise CommentError.new()
-  end
-end
-
 class CommentController < ApplicationController
+  include CommentHelper
+
   respond_to :html, :xml, :json
   before_filter :require_user, only: %i[create update delete]
 

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -37,19 +37,24 @@ class CommentController < ApplicationController
   end
 
   def create_by_token
-    # Parse the user's token from the headers
+    @username = params[:username]
+    @node_id = params[:id]
+    @body = pararms[:body]
+    @token = request.headers["token"]
 
-    # Use logic similar to the above create controller but with the user that
-    # the token belongs to instead of the `current_user`
-
-    # In order to avoid looking up the entire database for a user having a
-    # matching token, we could instead ask the user to pass username/id in the
-    # params along with the node id and comment body.
-    # This would also mean that if someone tries to bruteforce a token, they
-    # would to do so for each user individually.
-
-    # If the username/id and token do not match, send an error in the same
-    # format as the request (JSON/XML)
+    @user = Users.find_by_username @username
+    if @user && @user.token == @token
+      # TODO: Do the usual commenting stuff
+    else
+      msg = {
+        :status => :unauthorized
+        :message => "Unauthorized"
+      }
+      respond_to do |format|
+        format.xml { render :xml => msg.to_xml }
+        format.json { render :json => msg.to_json }
+      end
+    end
   end
 
   # create answer comments

--- a/app/helpers/comment_helper.rb
+++ b/app/helpers/comment_helper.rb
@@ -1,0 +1,14 @@
+module CommentHelper
+  class CommentError < ArgumentError
+  end
+
+  def create_comment(node, user, body)
+    @comment = node.add_comment(uid: user.uid, body: body)
+    if user && @comment.save
+      @comment.notify user
+      return @comment
+    else
+      raise CommentError.new()
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Plots2::Application.routes.draw do
   mount GrapeSwaggerRails::Engine => '/api/d1ocs'
   #end
 
+  # Manually written API functions
+  get '/api/comment', to: 'comment#create_by_token'
 
   resources :rusers
   resources :user_sessions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Plots2::Application.routes.draw do
   mount JasmineFixtureServer => '/spec/javascripts/fixtures' if defined?(Jasmine::Jquery::Rails::Engine)
 
   # Manually written API functions
-  post '/bot/comment/id.:format', to: 'comment#create_by_token'
+  post '/comment/create/token/id.:format', to: 'comment#create_by_token'
 
   #Search RESTful endpoints
   #constraints(subdomain: 'api') do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,14 +3,14 @@ Plots2::Application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   mount JasmineFixtureServer => '/spec/javascripts/fixtures' if defined?(Jasmine::Jquery::Rails::Engine)
 
+  # Manually written API functions
+  post '/bot/comment/id.:format', to: 'comment#create_by_token'
+
   #Search RESTful endpoints
   #constraints(subdomain: 'api') do
   mount Srch::API => '/api'
   mount GrapeSwaggerRails::Engine => '/api/d1ocs'
   #end
-
-  # Manually written API functions
-  get '/api/comment', to: 'comment#create_by_token'
 
   resources :rusers
   resources :user_sessions

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -268,6 +268,22 @@ class CommentControllerTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
+  test 'should not post an invalid comment successfully' do
+    @params = {
+      id: 1,
+      body: '',
+      username: 'Bob',
+      format: 'json'
+    }
+
+    @headers = {
+      'token' => 'abcdefg12345'
+    }
+
+    post :create_by_token, @params, @headers
+    assert_response :bad_request
+  end
+
   test 'should post comment through valid token successfully' do
     @params = {
       id: 1,

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -253,16 +253,18 @@ class CommentControllerTest < ActionController::TestCase
   end
 
   test 'should post comment through token successfully' do
-    get :create_by_token,
-      {
-        id: 1,
-        body: 'Test Comment',
-        username: "Bob"
-      },{
-        'Accept' => 'application/json',
-        'Content-Type' => 'application/json',
-        'Token' => 'abcdefg12345'
-      }
+    @params = {
+      id: 1,
+      body: "Test Comment",
+      username: "Bob",
+      format: 'json'
+    }
+
+    @headers = {
+      "token" => "abcdefg12345"
+    }
+
+    post :create_by_token, @params, @headers
     assert_response :success
   end
 end

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -252,7 +252,7 @@ class CommentControllerTest < ActionController::TestCase
     # tag followers can be found in tag_selection.yml
   end
 
-  test 'should post comment through valid token successfully' do
+  test 'should not post comment through invalid token successfully' do
     @params = {
       id: 1,
       body: 'Test Comment',
@@ -268,7 +268,7 @@ class CommentControllerTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
-  test 'should not post comment through invalid token successfully' do
+  test 'should post comment through valid token successfully' do
     @params = {
       id: 1,
       body: 'Test Comment',

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -252,19 +252,36 @@ class CommentControllerTest < ActionController::TestCase
     # tag followers can be found in tag_selection.yml
   end
 
-  test 'should post comment through token successfully' do
+  test 'should post comment through valid token successfully' do
     @params = {
       id: 1,
-      body: "Test Comment",
-      username: "Bob",
+      body: 'Test Comment',
+      username: 'Bob',
       format: 'json'
     }
 
     @headers = {
-      "token" => "abcdefg12345"
+      'token' => 'invalid-token'
+    }
+
+    post :create_by_token, @params, @headers
+    assert_response :unauthorized
+  end
+
+  test 'should not post comment through invalid token successfully' do
+    @params = {
+      id: 1,
+      body: 'Test Comment',
+      username: 'Bob',
+      format: 'json'
+    }
+
+    @headers = {
+      'token' => 'abcdefg12345'
     }
 
     post :create_by_token, @params, @headers
     assert_response :success
   end
+
 end

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -53,7 +53,7 @@ class CommentControllerTest < ActionController::TestCase
     end
     assert_response :success
     assert_not_nil :comment
-    #assert_template partial: 'wiki/_comment' 
+    #assert_template partial: 'wiki/_comment'
     #should uncomment above once comment displaying partial is implemented for wikis.
   end
 
@@ -250,5 +250,19 @@ class CommentControllerTest < ActionController::TestCase
     assert ActionMailer::Base.deliveries.collect(&:to).include?([rusers(:bob).email])
     assert ActionMailer::Base.deliveries.collect(&:to).include?([rusers(:moderator).email])
     # tag followers can be found in tag_selection.yml
+  end
+
+  test 'should post comment through token successfully' do
+    get :create_by_token,
+      {
+        id: 1,
+        body: 'Test Comment',
+        username: "Bob"
+      },{
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'Token' => 'abcdefg12345'
+      }
+    assert_response :success
   end
 end


### PR DESCRIPTION
@jywarren take a look. The function does not do anything yet, but a laid out a possible flow about how it could work. Maybe you had something else in mind? I'd be happy to incorporate your suggestions.

```ruby
def create_by_token
    # Parse the user's token from the headers

    # Use logic similar to the above create controller but with the user that
    # the token belongs to instead of the `current_user`

    # In order to avoid looking up the entire database for a user having a
    # matching token, we could instead ask the user to pass username/id in the
    # params along with the node id and comment body.
    # This would also mean that if someone tries to bruteforce a token, they
    # would to do so for each user individually.

    # If the username/id and token do not match, send an error in the same
    # format as the request (JSON/XML)
  end
```