### PR TITLE
Excluding non-UTF-8 names from migration

### DIFF
--- a/db/migrate/20170704165711_add_user_bio_and_token.rb
+++ b/db/migrate/20170704165711_add_user_bio_and_token.rb
@@ -7,12 +7,14 @@ class AddUserBioAndToken < ActiveRecord::Migration
 
     # copy bios into new fields for non-spam users
     DrupalUsers.where('status != 0').each do |u|
-      user = u.user
-      if user and defined? :u.status then
-        user.status = u.status
-        user.bio = DrupalProfileValue.find_by_uid(user.id, conditions: { fid: 7 }) || ''
-        user.token = SecureRandom.uuid
-        user.save({})
+      if u.name == u.name.encode('UTF-8') # exclude non-UTF-8 names
+        user = u.user
+        if user and defined? :u.status then
+          user.status = u.status
+          user.bio = DrupalProfileValue.find_by_uid(user.id, conditions: { fid: 7 }) || ''
+          user.token = SecureRandom.uuid
+          user.save({})
+        end
       end
     end
     drop_table :location_tags


### PR DESCRIPTION
Follow-up fix to #1511, attempting to deal with this error on staging server:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8_general_ci,COERCIBLE) for operation '=': SELECT  `rusers`.* FROM `rusers`  WHERE `rusers`.`username` = 'トリーバーチ クラッチ' LIMIT 1
```

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
