### PR TITLE
tweak to inline wiki newline handling

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -327,7 +327,11 @@ class WikiController < ApplicationController
   def replace
     @node = Node.find(params[:id])
     if params[:before] && params[:after]
-      if output = @node.replace(params[:before], params[:after], current_user)
+      # during round trip, strings are getting "\r\n" newlines converted to "\n",
+      # so we're ensuring they remain "\r\n"; this may vary based on platform, unfortunately
+      before = params[:before].gsub("\n", "\r\n")
+      after  = params[:after]#.gsub( "\n", "\r\n")
+      if output = @node.replace(before, after, current_user)
         flash[:notice] = 'New revision created with your additions.' unless request.xhr?
       else
         flash[:error] = 'There was a problem replacing that text.' unless request.xhr?


### PR DESCRIPTION
fixes #1501

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue
