### PR TITLE
testing for replication entries

### DIFF
--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -41,7 +41,6 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     # here we test to see that the requested replications are shown on the bottom of the note
     assert_equal 1, node.response_count('replication')
     assert_select "table.notes-grid-replication-#{node.id}"
-    assert_select "table.notes-grid-replication-#{node.id} tr.title"
 
     seeks_reps.destroy
 

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -35,7 +35,6 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
 
     assert_select 'table.notes-grid-test'
     assert_select 'table.activity-grid-test'
-    assert_select 'table.activity-grid-test tr.title'
     assert_select 'table.upgrades-grid-test'
     assert_select 'table.notes-grid-shouldnt', false
 

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -29,7 +29,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_select 'h1', title
 
     assert_not_nil NodeShared.notes_grid('test')
-    assert_nil     Node.activities('shouldnt')
+    assert_equal   [], Node.activities('shouldnt')
     assert_not_nil Node.upgrades('test')
 
     assert_select 'table.notes-grid-test'

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -28,6 +28,10 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
 
     assert_select 'h1', title
 
+    assert_not_nil NodeShared.notes_grid('test')
+    assert_nil     Node.activities('shouldnt')
+    assert_not_nil Node.upgrades('test')
+
     assert_select 'table.notes-grid-test'
     assert_select 'table.activity-grid-test'
     assert_select 'table.activity-grid-test tr.title'

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -29,6 +29,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_select 'h1', title
 
     assert_not_nil NodeShared.notes_grid('test')
+    assert_equal   1, NodeShared.notes_grid('test').length
     assert_equal   [], Node.activities('shouldnt')
     assert_not_nil Node.upgrades('test')
 

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -29,7 +29,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_select 'h1', title
 
     assert_not_nil NodeShared.notes_grid('test')
-    assert_equal   1, NodeShared.notes_grid('test').length
+    assert_equal   4, NodeShared.notes_grid('test').length
     assert_equal   [], Node.activities('shouldnt')
     assert_not_nil Node.upgrades('test')
 
@@ -39,7 +39,10 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_select 'table.upgrades-grid-test'
     assert_select 'table.notes-grid-shouldnt', false
 
+    # here we test to see that the requested replications are shown on the bottom of the note
+    assert_equal 1, node.response_count('replication')
     assert_select "table.notes-grid-replication-#{node.id}"
+    assert_select "table.notes-grid-replication-#{node.id} tr.title"
 
     seeks_reps.destroy
 

--- a/test/integration/node_insert_extras_test.rb
+++ b/test/integration/node_insert_extras_test.rb
@@ -30,6 +30,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
 
     assert_select 'table.notes-grid-test'
     assert_select 'table.activity-grid-test'
+    assert_select 'table.activity-grid-test tr.title'
     assert_select 'table.upgrades-grid-test'
     assert_select 'table.notes-grid-shouldnt', false
 


### PR DESCRIPTION
Testing for issue described in #1566, hopefully later fixes #1566

This should fail at first!

* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
