### PR TITLE
rusers.status index

### DIFF
--- a/db/migrate/20170824172336_add_rusers_indices.rb
+++ b/db/migrate/20170824172336_add_rusers_indices.rb
@@ -1,0 +1,9 @@
+class AddRusersIndices < ActiveRecord::Migration
+  def up
+    add_index "rusers", ["status"], :name => "index_rusers_on_status"
+  end
+
+  def down
+    remove_index :rusers, :status
+  end
+end

--- a/db/migrate/20170824172336_add_rusers_indices.rb
+++ b/db/migrate/20170824172336_add_rusers_indices.rb
@@ -1,9 +1,11 @@
 class AddRusersIndices < ActiveRecord::Migration
   def up
-    add_index "rusers", ["status"], :name => "index_rusers_on_status"
+    add_index "rusers", ["status"], name: "index_rusers_on_status"
+    add_index "rusers", ["created_at"], name: "index_rusers_created_at"
   end
 
   def down
     remove_index :rusers, :status
+    remove_index :rusers, :created_at
   end
 end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -341,6 +341,7 @@ ActiveRecord::Schema.define(:version => 20170726174757) do
     t.integer  "status",                                   :default => 0
   end
 
+  add_index "rusers", ["status"], :name => "index_rusers_on_status"
   add_index "rusers", ["username"], :name => "index_rusers_on_username"
 
   create_table "tag_selections", :id => false, :force => true do |t|

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -342,6 +342,7 @@ ActiveRecord::Schema.define(:version => 20170726174757) do
   end
 
   add_index "rusers", ["status"], :name => "index_rusers_on_status"
+  add_index "rusers", ["created_at"], :name => "index_rusers_created_at"
   add_index "rusers", ["username"], :name => "index_rusers_on_username"
 
   create_table "tag_selections", :id => false, :force => true do |t|

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170726174757) do
+ActiveRecord::Schema.define(:version => 20170824172336) do
 
   create_table "answer_selections", :force => true do |t|
     t.integer "user_id"


### PR DESCRIPTION
* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue


Note to selves -- we could also later search for the code causing this slow query:

```sql
mysql-slow.log:SELECT COUNT() FROM rusers INNER JOIN users ON users.uid = rusers.id WHERE (rusers.created_at BETWEEN '2013-02-03 00:00:00' AND '2014-02-06 00:00:00') AND (users.status = 1); mysql-slow.log:SELECT COUNT() FROM rusers INNER JOIN users ON users.uid = rusers.id WHERE (rusers.created_at BETWEEN '2012-09-07 00:00:00' AND '2013-09-10 00:00:00') AND (users.status = 1); mysql-slow.log:SELECT COUNT(*) FROM rusers INNER JOIN users ON users.uid = rusers.id WHERE (rusers.created_at BETWEEN '2013-06-08 00:00:00' AND '2014-05-27 00:00:00') AND (users.status = 1);

```

and could add a `select()` condition to not select the new (big) `rusers.bio` field. 