### PR TITLE
Update notes_controller_test.rb to test for xhr error reporting and change note posting error handling in json

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -135,7 +135,7 @@ class NotesController < ApplicationController
       else
         if request.xhr? # rich editor!
           errors = @node.errors
-          errors = errors.merge(@revision.errors) if @revision && @revision.errors
+          errors = errors.to_hash.merge(@revision.errors.to_hash) if @revision && @revision.errors
           render json: errors
         else
           render template: 'editor/post'

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -353,7 +353,21 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_not_nil @response.body
-    assert_equal [], @response.body
+    assert_equal "{\"title\":[\"can't be blank\"],\"path\":[\"This title has already been taken\"]}", @response.body
+  end
+
+  test 'returning json errors on xhr note update' do
+    user = UserSession.create(rusers(:jeff))
+
+    xhr :post,
+        :update,
+        id: node(:blog).id,
+        title: ''
+
+    assert_response :success
+    assert_not_nil @response.body
+    json = JSON.parse(@response.body)
+    assert !json['title'].empty?
   end
 
   # def test_cannot_delete_post_if_not_yours
@@ -483,20 +497,6 @@ class NotesControllerTest < ActionController::TestCase
          title: node.title + ' amended'
 
     assert_response :redirect
-  end
-
-  test 'returning json errors on xhr note update' do
-    user = UserSession.create(rusers(:jeff))
-
-    xhr :post,
-        :update,
-        id: node(:blog).id,
-        title: ''
-
-    assert_response :success
-    assert_not_nil @response.body
-    json = JSON.parse(@response.body)
-    assert !json['title'].empty?
   end
 
   test 'should redirect to question path if node is a question when visiting shortlink' do

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -353,7 +353,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_not_nil @response.body
-    assert_equal { errors: [] }, @response.body
+    assert_equal [], @response.body
   end
 
   # def test_cannot_delete_post_if_not_yours

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -1,21 +1,3 @@
-# def index
-# def tools
-# def places
-# def shortlink
-# def raw
-# def show
-# def create
-# def edit
-# def update
-# def delete
-# def author
-# def author_topic
-# def liked
-# def popular
-# def rss
-# def liked_rss
-# def rsvp
-
 require 'test_helper'
 
 class NotesControllerTest < ActionController::TestCase
@@ -344,7 +326,7 @@ class NotesControllerTest < ActionController::TestCase
     assert_not_nil @response.body
     assert_equal '/notes/Bob/' + Time.now.strftime('%m-%d-%Y') + '/a-completely-unique-snowflake', @response.body
   end
-
+  
   test 'post_note_error_no_title_xhr' do
     UserSession.create(rusers(:bob))
 
@@ -358,6 +340,20 @@ class NotesControllerTest < ActionController::TestCase
     json = JSON.parse(@response.body)
     assert_equal ["can't be blank"], json['title']
     assert !json['title'].empty?
+  end
+
+  test 'posting note with an error using xhr (rich editor) returns a JSON error' do
+    UserSession.create(rusers(:bob))
+
+    xhr :post,
+        :create,
+        body: 'This is a fascinating post about a balloon mapping event.',
+        title: '',
+        tags: 'balloon-mapping,event'
+
+    assert_response :success
+    assert_not_nil @response.body
+    assert_equal { errors: [] }, @response.body
   end
 
   # def test_cannot_delete_post_if_not_yours


### PR DESCRIPTION
Fixes #1595

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

This should fail at first!