### PR TITLE
allow moderators to accept answers

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -57,7 +57,7 @@ class AnswersController < ApplicationController
   def accept
     @answer = Answer.find(params[:id])
 
-    if current_user.uid == @answer.node.uid
+    if (current_user.role == "admin" || current_user.role == "moderator" || current_user.uid == @answer.node.uid)
       respond_to do |format|
         if @answer.accepted
           @answer.accepted = false

--- a/app/views/questions/_answer.html.erb
+++ b/app/views/questions/_answer.html.erb
@@ -39,7 +39,7 @@
       <% if answer.accepted %>
         <a <% if current_user && current_user.uid == answer.node.uid %> href="/answers/accept/<%= answer.id %>" <% end %> data-remote="true" id="answer-<%= answer.id %>-accept" class="answer-accept btn btn-sm btn-success">Accepted</a>
       <% else %>
-        <% if current_user && current_user.uid == answer.node.uid %>
+        <% if current_user && (current_user.role == "admin" || current_user.role == "moderator" || current_user.uid == answer.node.uid) %>
           <a href="/answers/accept/<%= answer.id %>" data-remote="true" id="answer-<%= answer.id %>-accept" class="answer-accept btn btn-sm btn-default">Accept this answer</a>
         <% end %>
       <% end %>

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -104,4 +104,17 @@ class AnswersControllerTest < ActionController::TestCase
     assert !answer.accepted
     assert_template text: "Answer couldn't be accepted"
   end
+  
+  test 'should allow accepting answer if logged in user is moderator' do
+    UserSession.create(rusers(:moderator))
+    answer = answers(:one)
+    answer.accepted = false
+    answer.save
+    assert !answer.accepted
+    xhr :get, :accept, id: answer.id
+    answer.reload
+    assert_response :success
+    assert answer.accepted
+  end
+
 end


### PR DESCRIPTION
This could use some tests. 

* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

