### PR TITLE
columns on front page and activity

### DIFF
--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -1,6 +1,9 @@
-<h3><i><%= t('dashboard._activity.activity') %></i></h3>
-<a href="/post" class="btn btn-sm btn-default pull-right" type="button"><i class="fa fa-plus-circle"></i><span class="hidden-xs"> <%= t('dashboard._activity.share_work') %></span></a>
-<a style="margin-right:2px;" href="/dashboard" class="btn btn-sm btn-default pull-right" type="button"><i class="fa fa-refresh"></i></a>
+<h3 id="activity-header"><i><%= t('dashboard._activity.activity') %></i></h3>
+
+<div class="activity-menu">
+  <a href="/post" class="btn btn-sm btn-default pull-right" type="button"><i class="fa fa-plus-circle"></i><span class="hidden-xs"> <%= t('dashboard._activity.share_work') %></span></a>
+  <a style="margin-right:2px;" href="/dashboard" class="btn btn-sm btn-default pull-right" type="button"><i class="fa fa-refresh"></i></a>
+</div>
 
 <div class="meta activity-dropdown">
   <div class="btn-group">

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -93,7 +93,7 @@
 
   <div class="col-md-4">
     <img class="img img-circle" src="//i.publiclab.org/system/images/photos/000/006/671/original/canoe.jpg"/>
-    <h2> <%= t('home.home.the_problem.title') %> </h2>
+    <h2 class="the-problem"> <%= t('home.home.the_problem.title') %> </h2>
     <h4><%= t('home.home.the_problem.lack_access') %> <a href="/tools"><%= t('home.home.the_problem.tools') %></a> <%= t('home.home.the_problem.need_participation') %></h4>
     <p><a href="/blog" class="btn btn-primary btn-lg">Read stories &raquo;</a></p>
   </div>
@@ -108,7 +108,7 @@
 
   <div class="col-md-4">
     <img class="img img-circle" src="//i.publiclab.org/system/images/photos/000/006/673/large/LizBklnNRG.jpg"/>
-    <h2> <%= t('home.home.the_solution.title') %> </h1>
+    <h2> <%= t('home.home.the_solution.title') %> </h2>
     <h4><%= t('home.home.the_solution.join_us_today') %> <a href="/archive"><%= t('home.home.the_solution.growing_data') %></a> <%= t('home.home.the_solution.local_environments') %></h4>
     <p><a href="/methods" class="btn btn-primary btn-lg">Browse methods &raquo;</a></p>
   </div>

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -35,7 +35,10 @@
 
 <h3 style="text-align:center;color:#888;">
   <a href="https://twitter.com/intent/follow?original_referer=http%3A%2F%2Fpubliclab.org%2Fhome&region=follow_link&screen_name=PublicLab&tw_p=followbutton&variant=2.0"><i style="text-decoration:none;" class="fa fa-twitter"></i></a>
+  &nbsp;
   <a href="https://www.facebook.com/PublicLab"><i style="text-decoration:none;" class="fa fa-facebook"></i></a> 
+  &nbsp;
+  <a href="https://instagram.com/publiclab"><i style="text-decoration:none;" class="fa fa-instagram"></i></a>
 </h3>
 
 <br />
@@ -57,71 +60,72 @@
   h1, h2, h3, h4 {
     font-family:Junction Light;
   }
-  #bottom h1 {
-    font-size:4em;
-    line-height:1.2em;
+  #bottom {
+    padding-bottom: 20px;
+  }
+  #bottom img {
+    width: 90%;
+    padding:5%;
+  }
+  #bottom h2 {
+    margin-bottom:14px;
+    padding:10px;
   }
   #bottom h4 {
     color:#888;
     font-size:1.6em;
     line-height:1.2em;
+    padding:10px;
+  }
+  #bottom p {
+    padding:10px;
+  }
+  #activity-header {
+    display: none;
+  }
+  .activity-menu,
+  .activity-dropdown {
+    display: none;
   }
 </style>
 
 <div id="bottom">
-<div class="row" style="padding:40px 0;">
 
-  <img style="margin-bottom:30px;" class="hidden-lg col-xs-12 col-md-4 img img-circle" src="//i.publiclab.org/system/images/photos/000/006/671/original/canoe.jpg"/>
-  <img style="margin:0;" class="visible-lg col-md-4 img img-circle" src="//i.publiclab.org/system/images/photos/000/006/671/original/canoe.jpg"/>
-
-  <div class="visible-lg col-md-8" style="padding-top:30px;padding-left:20px;">
-    <h1> <%= t('home.home.the_problem.title') %> </h1>
-    <h4><%= t('home.home.the_problem.lack_access') %> <a href="/tools"><%= t('home.home.the_problem.tools') %></a> <%= t('home.home.the_problem.need_participation') %></h4>
-  </div>
-
-  <div class="hidden-lg col-md-8" style="padding-top:30px;">
+  <div class="col-md-4">
+    <img class="img img-circle" src="//i.publiclab.org/system/images/photos/000/006/671/original/canoe.jpg"/>
     <h2> <%= t('home.home.the_problem.title') %> </h2>
     <h4><%= t('home.home.the_problem.lack_access') %> <a href="/tools"><%= t('home.home.the_problem.tools') %></a> <%= t('home.home.the_problem.need_participation') %></h4>
-  </div>
-</div>
-
-<hr />
-<div class="row" style="padding:40px 0;">
-
-  <img style="margin-bottom:30px;" class="hidden-lg col-xs-12 col-md-4 img img-circle" src="//i.publiclab.org/system/images/photos/000/006/672/original/ne-barn.jpg"/>
-
-  <div class="visible-lg col-md-8" style="padding-top:30px;padding-right:50px;">
-    <h1> <%= t('home.home.the_collaboration.title') %> </h1>
-    <h4><%= t('home.home.the_collaboration.open_network') %> <a href="/wiki/organizers"><%= t('home.home.the_collaboration.organizers') %></a>, <%= t('home.home.the_collaboration.create_low_cost_solutions') %> <a href="/wiki/nonprofit-initiatives"><%= t('home.home.the_collaboration.monitoring') %></a>.</h4>
-    <h4><%= t('home.home.the_collaboration.discover') %> <a href="/places"><%= t('home.home.the_collaboration.locally_important_matters') %></a> <%= t('home.home.the_collaboration.global_community') %></h4>
+    <p><a href="/blog" class="btn btn-primary btn-lg">Read stories &raquo;</a></p>
   </div>
 
-  <div class="hidden-lg col-md-8" style="padding-top:30px;">
+  <div class="col-md-4">
+    <img class="img img-circle" src="//i.publiclab.org/system/images/photos/000/006/672/original/ne-barn.jpg"/>
     <h2> <%= t('home.home.the_collaboration.title') %> </h2>
     <h4><%= t('home.home.the_collaboration.open_network') %> <a href="/wiki/organizers"><%= t('home.home.the_collaboration.organizers') %></a>, <%= t('home.home.the_collaboration.create_low_cost_solutions') %> <a href="/wiki/initiatives"><%= t('home.home.the_collaboration.monitoring') %></a>.</h4>
     <h4><%= t('home.home.the_collaboration.discover') %> <a href="/places"><%= t('home.home.the_collaboration.locally_important_matters') %></a> <%= t('home.home.the_collaboration.global_community') %></h4>
+    <p><a href="/questions" class="btn btn-primary btn-lg">Ask a question &raquo;</a></p>
   </div>
 
-  <img style="margin:0;" class="visible-lg col-xs-12 col-md-4 img img-circle" src="//i.publiclab.org/system/images/photos/000/006/672/original/ne-barn.jpg"/>
-</div>
-
-<hr />
-<div class="row" style="padding:40px 0;">
-
-  <img style="margin-bottom:30px;" class="hidden-lg col-xs-12 col-md-4 img img-circle" src="//i.publiclab.org/system/images/photos/000/006/673/large/LizBklnNRG.jpg"/>
-  <img style="margin:0;" class="visible-lg col-md-4 img img-circle" src="//i.publiclab.org/system/images/photos/000/006/673/large/LizBklnNRG.jpg"/>
-
-  <div class="visible-lg col-md-8" style="padding-top:30px;padding-left:20px;padding-right:50px;">
-    <h1> <%= t('home.home.the_solution.title') %> </h1>
+  <div class="col-md-4">
+    <img class="img img-circle" src="//i.publiclab.org/system/images/photos/000/006/673/large/LizBklnNRG.jpg"/>
+    <h2> <%= t('home.home.the_solution.title') %> </h1>
     <h4><%= t('home.home.the_solution.join_us_today') %> <a href="/archive"><%= t('home.home.the_solution.growing_data') %></a> <%= t('home.home.the_solution.local_environments') %></h4>
+    <p><a href="/methods" class="btn btn-primary btn-lg">Browse methods &raquo;</a></p>
   </div>
 
-  <div class="hidden-lg col-md-8" style="padding-top:30px;">
-    <h2> <%= t('home.home.the_solution.title') %> </h2>
-    <h4><%= t('home.home.the_solution.join_us_today') %> <a href="/archive"><%= t('home.home.the_solution.growing_data') %></a> <%= t('home.home.the_solution.local_environments') %></h4>
-  </div>
-</div>
+  <br style="clear:both;" />
 
 </div>
+
+<hr style="clear:both;padding:20px;" />
+
+<h2><center>Recent community activity</center></h2>
+
+<p><center><a href="/research">See more &raquo;</a></center></p>
+
+<%= render partial: "dashboard/activity", locals: { activity: @activity, notes: @notes } %>
+
+<%= stylesheet_link_tag "dashboard" %>
+<%= javascript_include_tag "dashboard" %>
 
 </div>

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -88,7 +88,7 @@ class HomeControllerTest < ActionController::TestCase
 
       get 'home'
       assert_template 'home/home'
-      assert_select 'h1', I18n.t('home.home.the_problem.title')
+      assert_select 'h2.the-problem', I18n.t('home.home.the_problem.title')
       assert true
     end
   end


### PR DESCRIPTION
* [ ] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

Reflowing of the 3 sections on the front page, and adding "community activity" below it.

![screenshot 2017-09-16 at 4 59 37 pm](https://user-images.githubusercontent.com/24359/30515974-733a11da-9b00-11e7-8e4e-45c3f2ee3188.png)
