### PR TITLE
Add node revisers to list of email recipients on new comments (1589)

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -110,12 +110,9 @@ class Comment < ActiveRecord::Base
 
     notify_callout_users
 
+    # notify other commenters, revisers, and likers, but not those already @called out
     already = mentioned_users.collect(&:uid) + [parent.uid]
-    uids = []
-    # notify other commenters, and likers, but not those already @called out
-    (parent.comments.collect(&:uid) + parent.likers.collect(&:uid)).uniq.each do |u|
-      uids << u unless already.include?(u)
-    end
+    uids = uids_to_notify - already
 
     notify_users(uids, current_user)
     notify_tag_followers(already + uids)

--- a/app/models/concerns/comments_shared.rb
+++ b/app/models/concerns/comments_shared.rb
@@ -12,4 +12,20 @@ module CommentsShared
   def author
     DrupalUsers.find_by_uid uid
   end
+
+  def parent_commenter_uids
+    parent.comments.collect(&:uid)
+  end
+
+  def parent_liker_uids
+    parent.likers.collect(&:uid)
+  end
+
+  def parent_reviser_uids
+    (parent.revision.collect(&:uid).uniq - [parent.author.uid])
+  end
+
+  def uids_to_notify
+    (parent_commenter_uids + parent_liker_uids + parent_reviser_uids).uniq
+  end
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -182,7 +182,7 @@ class Node < ActiveRecord::Base
   def answered
     self.answers && self.answers.length > 0
   end
-  
+
   # users who like this node
   def likers
     node_selections

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -21,4 +21,4 @@ test:
     read_timeout: 120
     log_level: WARNING
     path: "/solr/default"
-  disabled: true
+  disabled: false

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -21,4 +21,4 @@ test:
     read_timeout: 120
     log_level: WARNING
     path: "/solr/default"
-  disabled: false
+  disabled: true

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -16,29 +16,37 @@ second:
   timestamp: <%= Time.now.to_i + 2 %>
   thread: /02
 
+third:
+  uid: 3
+  nid: 2
+  status: 1
+  comment: Another note comment
+  timestamp: <%= Time.now.to_i + 3 %>
+  thread: /03
+
 legacy:
   uid: 0
   nid: 1
   status: 1
   comment: Hey there!
-  timestamp: <%= Time.now.to_i + 3 %>
-  thread: /03
+  timestamp: <%= Time.now.to_i + 4 %>
+  thread: /04
 
 admin:
   uid: 5
   nid: 1
   status: 1
   comment: Admin comment
-  timestamp: <%= Time.now.to_i + 4 %>
-  thread: /04
+  timestamp: <%= Time.now.to_i + 5 %>
+  thread: /05
 
 moderator:
   uid: 6
   nid: 1
   status: 1
   comment: Moderator comment
-  timestamp: <%= Time.now.to_i + 5 %>
-  thread: /05
+  timestamp: <%= Time.now.to_i + 6 %>
+  thread: /06
 
 answer_comment_one:
   uid: 1
@@ -46,7 +54,7 @@ answer_comment_one:
   aid: 1
   status: 1
   comment: Answer comment one
-  timestamp: <%= Time.now.to_i + 6 %>
+  timestamp: <%= Time.now.to_i + 7 %>
 
 answer_comment_two:
   uid: 2
@@ -54,7 +62,7 @@ answer_comment_two:
   aid: 1
   status: 1
   comment: Answer comment two
-  timestamp: <%= Time.now.to_i + 7 %>
+  timestamp: <%= Time.now.to_i + 8 %>
 
 question:
   uid: 1
@@ -62,14 +70,14 @@ question:
   aid: 0
   status: 1
   comment: Question comment
-  timestamp: <%= Time.now.to_i + 8 %>
+  timestamp: <%= Time.now.to_i + 9 %>
   thread: /01
 
 comment_status_0:
   uid: 1
   status: 0
   comment: I love a good comment!
-  timestamp: <%= Time.now.to_i + 9 %>
+  timestamp: <%= Time.now.to_i + 10 %>
 
 comment_status_1:
   uid: 1
@@ -84,7 +92,7 @@ question_one:
   aid: 0
   status: 1
   comment: Question comment one
-  timestamp: <%= Time.now.to_i + 10 %>
+  timestamp: <%= Time.now.to_i + 11 %>
   thread: /02
 
 question_callout:
@@ -93,7 +101,7 @@ question_callout:
   aid: 0
   status: 1
   comment: Hey, @bob nice question
-  timestamp: <%= Time.now.to_i + 11 %>
+  timestamp: <%= Time.now.to_i + 12 %>
   thread: /03
 
 question_tag:
@@ -102,5 +110,5 @@ question_tag:
   aid: 0
   status: 1
   comment: 'Question #everything'
-  timestamp: <%= Time.now.to_i + 12 %>
+  timestamp: <%= Time.now.to_i + 13 %>
   thread: /04

--- a/test/fixtures/node_revisions.yml
+++ b/test/fixtures/node_revisions.yml
@@ -18,6 +18,20 @@ about_rev_2:
   title: About
   body: All about Public Lab, AGAIN
 
+about_rev_3:
+  nid: 2
+  vid: 3
+  uid: 1
+  title: About
+  body: All about Public Lab, ONCE AGAIN
+
+about_rev_3:
+  nid: 2
+  vid: 3
+  uid: 1
+  title: About
+  body: All about Public Lab, ONCE MORE
+
 three:
   nid: 3
   uid: 3

--- a/test/fixtures/node_selections.yml
+++ b/test/fixtures/node_selections.yml
@@ -1,6 +1,7 @@
 good_like:
   user_id: 1
-  nid: 1
+  nid: 2
+  liking: true
 
 unbanned_spammer_like:
   user_id: 3

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -176,4 +176,28 @@ class CommentTest < ActiveSupport::TestCase
     )
     assert comment.save
   end
+
+  test 'should return a list of node commenter uids' do
+    comment = comments(:third)
+
+    assert_equal [rusers(:spammer).uid, rusers(:jeff).uid], comment.parent_commenter_uids
+  end
+
+  test 'should return a list of node liker uids' do
+    comment = comments(:third)
+
+    assert_equal [rusers(:bob).uid], comment.parent_liker_uids
+  end
+
+  test 'should return a list of node reviser uids' do
+    comment = comments(:third)
+
+    assert_equal [rusers(:jeff).uid], comment.parent_reviser_uids
+  end
+
+  test 'should return a combined list of all commenter, liker, and reviser uids for node' do
+    comment = comments(:third)
+
+    assert_equal [rusers(:spammer).uid, rusers(:jeff).uid, rusers(:bob).uid], comment.uids_to_notify
+  end
 end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -10,7 +10,7 @@ class NodeTest < ActiveSupport::TestCase
     assert_equal 1, node.status
     assert !node.answered
   end
-  
+
   test 'basic question attributes' do
     question = node(:question)
     assert question.answered
@@ -153,7 +153,7 @@ class NodeTest < ActiveSupport::TestCase
 
   test 'should have subscribers' do
     node = tag_selection(:awesome).tag.nodes.first
-    assert_equal 7, node.subscribers.length
+    assert_equal 6, node.subscribers.length
   end
 
   test 'should have place node icon according to tagging' do


### PR DESCRIPTION
Resolves #1589

## Summary

As part of the notification process for comments on wiki pages, it's important that any authors of revisions to the same wiki are also notified of new comments.

## Implementation

This work accomplishes that goal by making a few updates to the `#notify` method within `comment.rb`:

1. Add four methods to the `CommentsShared` concern located at `app/models/concerns/comments_shared.rb`:
* `parent_commenter_uids` (collects all the uids for the parent node's comments)
* `parent_liker_uids` (collects all the uids for the parent node's likers)
* `parent_revisers_uids` (collects all the uids for the parent node's revisers, minus the original author)
* `uids_to_notify` (a summation of the three above, uniqued to avoid duplication)

2. Refactor the guts of the alread- tested `#notify` method on the `Comment` model as follows:

FROM:
```ruby
already = mentioned_users.collect(&:uid) + [parent.uid]

uids = []
# notify other commenters, and likers, but not those already @called out
(parent.comments.collect(&:uid) + parent.likers.collect(&:uid)).uniq.each do |u|
  uids << u unless already.include?(u)
end
```

TO:
```ruby
# notify other commenters, revisers, and likers, but not those already @called out
already = mentioned_users.collect(&:uid) + [parent.uid]
uids = uids_to_notify - already
```

That list of uids is then passed on to the already-tested `notify_users` method, which finds all users matching those in the list, and sends them an email via the `CommentMailer`.

## Additional Notes

There's an `#answer_comment_notify` method within the same `comment.rb`, which seems to function very similarly to the `#notify` method I've refactored. I considered mirroring my refactor there, but believed it to be outside the scope of this particular ticket, so decided against it. However, if the code I've produced here is amenable to you, I'd be happy to take a stab at refactoring that similarly, and perhaps even DRYing the two methods up via another method export into the shared concern. Perhaps something like `notify(current_user, answer: false)`, that makes use of an options hash as the second argument which indicates node type and helps determine which users to notify. Or perhaps a single-responsibility PORO whose job is simply to collect the relevant uids is better. I may be off base there, given my very remedial exposure to the codebase at this point, but just thought I'd throw those ideas out there.

Thanks!