### PR TITLE
updated rich editor with jquery compatibility fixes

### DIFF
--- a/app/views/editor/questionRich.html.erb
+++ b/app/views/editor/questionRich.html.erb
@@ -5,6 +5,16 @@
 
 <link href="/lib/publiclab-editor/dist/PublicLab.Editor.css" rel="stylesheet">
 
+<!-- required for TagsModule -->
+<script src="/lib/typeahead.js/dist/typeahead.jquery.js"></script>
+<script src="/lib/typeahead.js/dist/bloodhound.js"></script>
+<script src="/lib/bootstrap-tokenfield/dist/bootstrap-tokenfield.js"></script>
+
+<!-- required for MainImageModule -->
+<script src="/lib/jquery-file-upload/js/vendor/jquery.ui.widget.js"></script>
+<script src="/lib/jquery-file-upload/js/jquery.iframe-transport.js"></script>
+<script src="/lib/jquery-file-upload/js/jquery.fileupload.js"></script>
+
 <script src="/lib/publiclab-editor/dist/PublicLab.Editor.js"></script>
 
 <div class="alert alert-success">This is the new rich Questions form. <a href="/questions/new?legacy=true">Click here for the legacy form</a>.</div>

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -3,6 +3,16 @@
 <link href="/lib/bootstrap-tokenfield/dist/css/tokenfield-typeahead.min.css" rel="stylesheet">
 <link href="/lib/bootstrap-tokenfield/dist/css/bootstrap-tokenfield.min.css" rel="stylesheet">
 
+<!-- required for TagsModule -->
+<script src="/lib/typeahead.js/dist/typeahead.jquery.js"></script>
+<script src="/lib/typeahead.js/dist/bloodhound.js"></script>
+<script src="/lib/bootstrap-tokenfield/dist/bootstrap-tokenfield.js"></script>
+
+<!-- required for MainImageModule -->
+<script src="/lib/jquery-file-upload/js/vendor/jquery.ui.widget.js"></script>
+<script src="/lib/jquery-file-upload/js/jquery.iframe-transport.js"></script>
+<script src="/lib/jquery-file-upload/js/jquery.fileupload.js"></script>
+
 <link href="/lib/publiclab-editor/dist/PublicLab.Editor.css" rel="stylesheet">
 
 <script src="/lib/publiclab-editor/dist/PublicLab.Editor.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "leaflet": "0.7.3",
     "moment": "~2.10.6",
     "junction": "theleagueof/junction",
-    "publiclab-editor": "~0.3.0",
+    "publiclab-editor": "~1.0.0",
     "inline-markdown-editor": "~0.3.0",
     "leaflet-d3": "^0.3.8",
     "woofmark": "~4.2.0",
@@ -25,7 +25,8 @@
     "i18n-js": "^2.1.2",
     "short-code-forms": "jywarren/short-code-forms#~0.0.1",
     "leaflet-blurred-location": "publiclab/leaflet-blurred-location#master",
-    "chart.js": "v2.7.0"
+    "chart.js": "v2.7.0",
+    "typeahead.js-browserify": "~1.0.7"
   },
   "resolutions": {
     "jquery": "~2.1.0",

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "leaflet": "0.7.3",
     "moment": "~2.10.6",
     "junction": "theleagueof/junction",
-    "publiclab-editor": "publiclab/PublicLab.Editor#remove-jquery",
+    "publiclab-editor": "publiclab/PublicLab.Editor#~1.0.0",
     "inline-markdown-editor": "~0.3.0",
     "leaflet-d3": "^0.3.8",
     "woofmark": "~4.2.0",

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "leaflet": "0.7.3",
     "moment": "~2.10.6",
     "junction": "theleagueof/junction",
-    "publiclab-editor": "~1.0.0",
+    "publiclab-editor": "publiclab/PublicLab.Editor#remove-jquery",
     "inline-markdown-editor": "~0.3.0",
     "leaflet-d3": "^0.3.8",
     "woofmark": "~4.2.0",

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "short-code-forms": "jywarren/short-code-forms#~0.0.1",
     "leaflet-blurred-location": "publiclab/leaflet-blurred-location#master",
     "chart.js": "v2.7.0",
-    "typeahead.js-browserify": "~1.0.7"
+    "typeahead.js-browserify": "Javier-Rotelli/typeahead.js-browserify#~1.0.7"
   },
   "resolutions": {
     "jquery": "~2.1.0",


### PR DESCRIPTION
* [ ] all tests pass -- `rake test:all`

In prep for `v1.0.0` -- https://github.com/publiclab/PublicLab.Editor/pull/110

Be sure to switch `bower.json` to `v1.0.0` instead of the `remove-jquery` branch once v1 publishes!