### PR TITLE
front page 20m fragment caching

### DIFF
--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -124,7 +124,9 @@
 <p><center><a href="/research">See more &raquo;</a></center></p>
 
 <div class="dashboard">
-  <%= render partial: "dashboard/activity", locals: { activity: @activity, notes: @notes } %>
+  <% cache('home-activity', expires_in: 20.minutes) do %>
+    <%= render partial: "dashboard/activity", locals: { activity: @activity, notes: @notes } %>
+  <% end %>
 </div>
 
 <%= stylesheet_link_tag "dashboard" %>


### PR DESCRIPTION
@icarito - to reduce load from new activity feed on front page, a heavy query, in #1617. Should expire every 20m, we should check this once live.

* [ ] all tests pass -- `rake test:all`
