### PR TITLE
remove "everything" tag from tag notifications -- fixes #1692

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -24,7 +24,7 @@ class SubscriptionMailer < ActionMailer::Base
     mail(to: node.author.email, subject: subject).deliver
   end
 
-def notify_tag_added(node, tag, current_user)
+ def notify_tag_added(node, tag, current_user)
     @tag = tag
     @node = node
     @current_user = current_user
@@ -33,9 +33,9 @@ def notify_tag_added(node, tag, current_user)
     users_with_everything_tag = Tag.followers('everything')
     final_users_ids = nil 
     if(!users_to_email.nil? && !users_with_everything_tag.nil?)
-      final_users_ids = users_to_email.pluck(:id) - users_with_everything_tag.pluck(:uid)
+      final_users_ids = users_to_email.collect(&:id) - users_with_everything_tag.collect(&:uid)
     elsif(!users_to_email.nil?) 
-      final_users_ids = users_to_email.pluck(:id)
+      final_users_ids = users_to_email.collect(&:id)
     end
     final_users_to_email = User.find(final_users_ids) 
     final_users_to_email.each do |user|

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -24,16 +24,24 @@ class SubscriptionMailer < ActionMailer::Base
     mail(to: node.author.email, subject: subject).deliver
   end
 
-  def notify_tag_added(node, tag, current_user)
+ def notify_tag_added(node, tag, current_user)
     @tag = tag
     @node = node
     @current_user = current_user
-    given_tags = node.tags.reject { |t| t == tag}
+    given_tags = node.tags.reject { |t| t == tag} 
     users_to_email = tag.followers_who_dont_follow_tags(given_tags)
-    users_to_email.each do |user|
+    users_with_everything_tag = Tag.followers('everything')
+    final_users_ids = nil 
+    if(!users_to_email.nil? && !users_with_everything_tag.nil?)
+      final_users_ids = users_to_email.pluck(:uid) - users_with_everything_tag(:user_id)
+    elsif(!users_to_email.nil?) 
+      final_users_ids = users_to_email.pluck(:uid)
+    end
+    final_users_to_email = User.find(final_users_ids) 
+    final_users_to_email.each do |user|
       @user = user
       unless user.id == current_user.id 
-        mail(to: user.email, subject: "New tag added on #{node.title}").deliver 
+         mail(to: user.email, subject: "New tag added on #{node.title}").deliver 
       end
     end
     @footer = feature('email-footer')

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -24,7 +24,7 @@ class SubscriptionMailer < ActionMailer::Base
     mail(to: node.author.email, subject: subject).deliver
   end
 
- def notify_tag_added(node, tag, current_user)
+def notify_tag_added(node, tag, current_user)
     @tag = tag
     @node = node
     @current_user = current_user
@@ -33,9 +33,9 @@ class SubscriptionMailer < ActionMailer::Base
     users_with_everything_tag = Tag.followers('everything')
     final_users_ids = nil 
     if(!users_to_email.nil? && !users_with_everything_tag.nil?)
-      final_users_ids = users_to_email.pluck(:uid) - users_with_everything_tag(:user_id)
+      final_users_ids = users_to_email.pluck(:id) - users_with_everything_tag.pluck(:uid)
     elsif(!users_to_email.nil?) 
-      final_users_ids = users_to_email.pluck(:uid)
+      final_users_ids = users_to_email.pluck(:id)
     end
     final_users_to_email = User.find(final_users_ids) 
     final_users_to_email.each do |user|

--- a/test/unit/subscription_mailer_test.rb
+++ b/test/unit/subscription_mailer_test.rb
@@ -70,6 +70,7 @@ class SubscriptionMailerTest < ActionMailer::TestCase
     users_not_following_tags = new_tag.followers_who_dont_follow_tags(node_tags)
     users_to_email = users_not_following_tags.reject { |u| u.uid == user.uid }
     u_e = Tag.followers('everything')
+    assert !u_e.empty?
     users_to_email_without_exception = users_to_email.reject { |u| u_e.include? u }
     assert_difference 'ActionMailer::Base.deliveries.size', users_to_email_without_exception.count do
       SubscriptionMailer.notify_tag_added(node, new_tag, user)

--- a/test/unit/subscription_mailer_test.rb
+++ b/test/unit/subscription_mailer_test.rb
@@ -69,7 +69,9 @@ class SubscriptionMailerTest < ActionMailer::TestCase
     user = users(:spammer)
     users_not_following_tags = new_tag.followers_who_dont_follow_tags(node_tags)
     users_to_email = users_not_following_tags.reject { |u| u.uid == user.uid }
-    assert_difference 'ActionMailer::Base.deliveries.size', users_to_email.count do
+    u_e = Tag.followers('everything')
+    users_to_email_without_exception = users_to_email.reject { |u| u_e.include? u }
+    assert_difference 'ActionMailer::Base.deliveries.size', users_to_email_without_exception.count do
       SubscriptionMailer.notify_tag_added(node, new_tag, user)
     end
     assert !ActionMailer::Base.deliveries.empty?


### PR DESCRIPTION
1.) Indentation done .
2.) Error removed
This solves the issue #1692 .

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [X] all tests pass -- `rake test:all`
* [X] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [X] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
