### PR TITLE
Remove activity from front page as a perfomance test

### DIFF
--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -113,18 +113,4 @@
 
 </div>
 
-<hr style="clear:both;padding:20px;" />
-
-<h2><center>Recent community activity</center></h2>
-
-<p><center><a href="/research">See more &raquo;</a></center></p>
-
-<div class="dashboard">
-  <% cache('home-activity', expires_in: 60.minutes) do %>
-    <%= render partial: "dashboard/activity", locals: { activity: @activity, notes: @notes } %>
-  <% end %>
-  <%= stylesheet_link_tag "dashboard" %>
-  <%= javascript_include_tag "dashboard" %>
-</div>
-
 </div>


### PR DESCRIPTION
@icarito -- In this PR i remove:

```ruby

<hr style="clear:both;padding:20px;" />

<h2><center>Recent community activity</center></h2>

<p><center><a href="/research">See more &raquo;</a></center></p>

<div class="dashboard">
  <% cache('home-activity', expires_in: 60.minutes) do %>
    <%= render partial: "dashboard/activity", locals: { activity: @activity, notes: @notes } %>
  <% end %>
  <%= stylesheet_link_tag "dashboard" %>
  <%= javascript_include_tag "dashboard" %>
</div>
```

From the bottom of the front page -- we could do this and run it for a day or two to see if that really is the issue causing ~10x time to first byte. 

If it is, we look deeper into exactly why -- we could, for example, not show any images, as a test.

If it isn't, we can look elsewhere. Make sense? 