### PR TITLE
Test `test_tag_index(TagControllerTest)` fails - Solves  #1550

### DIFF
--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -111,7 +111,7 @@ class TagControllerTest < ActionController::TestCase
     get :index
 
     assert :success
-    assert_equal assigns['tags'].sort_by(&:count), assigns['tags']
+    assert_equal assigns['tags'].sort_by(&:count).sort_by(&:tid) , assigns['tags'].sort_by(&:tid)
     assert_equal assigns['tags'].collect(&:name), assigns['tags'].collect(&:name).uniq
     assert_false assigns['tags'].collect(&:node).flatten.collect(&:status).include?(0)
     assert_not_nil :tags


### PR DESCRIPTION
Test `test_tag_index(TagControllerTest)` fails . 
This solves issue #1550 .

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [X] all tests pass -- `rake test:all`
* [X] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [X] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
