### PR TITLE
Fix to issue #1722 - Finds the search bar input tag from its ID instead of its tag name

### DIFF
--- a/app/views/tag/index.html.erb
+++ b/app/views/tag/index.html.erb
@@ -7,12 +7,12 @@
        <h1 style="font-family:Junction Light;"><%= t('tag.index.popular_tags') %></h1>
      </th>
      <th style="width: 50% ; text-align: right ;">
-      
+
 
       <a class="btn btn-default" rel="popover" data-trigger="focus" data-placement="bottom" data-html="true" data-content=" <a href = <%= tags_path(1) %> >Number of uses</a> <br> <a href = <%= tags_path(2) %> >Alphabetically</a>">
         <i class="fa fa-sort"></i> <%=t('tag.index.sort_by') %>
       </a>
-    
+
      </th>
    </tr>
  </table>
@@ -24,11 +24,11 @@
            var key = e.which;
            if(key == 13)  // the enter key code
             {
-             var pre = document.getElementsByTagName("input")[1].value ;
+             var pre = document.getElementById("myInput").value ;
 
-              window.location.href = " <%= tags_path %>"+"/"+pre  
+              window.location.href = " <%= tags_path %>"+"/"+pre
             }
-          });   
+          });
     </script>
     <br><br>
 
@@ -67,5 +67,5 @@
   <%= will_paginate @tags, :renderer => BootstrapPagination::Rails if @paginated %>
 
   <hr />
-  
+
 </div>


### PR DESCRIPTION
In plots2/app/views/tag/index.html.erb line 27, changes:

`var pre = document.getElementsByTagName("input")[1].value ;`
to:
`var pre = document.getElementById("myInput").value ;`

Fixes #1722 