### PR TITLE
Users with subscription 'everything' should also be emailed (Resolves #1761)

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -30,7 +30,8 @@ class Answer < ActiveRecord::Base
       AnswerMailer.notify_question_author(node.author, self).deliver
     end
 
-    uids = (node.answers.collect(&:uid) + node.likers.collect(&:uid)).uniq
+    users_with_everything_tag = Tag.followers('everything') 
+    uids = (node.answers.collect(&:uid) + node.likers.collect(&:uid) + users_with_everything_tag.collect(&:uid)).uniq
 
     # notify other answer authors and users who liked the question
     DrupalUsers.where('uid IN (?)', uids).each do |user|

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -29,10 +29,8 @@ class Answer < ActiveRecord::Base
     if current_user.uid != node.author.uid
       AnswerMailer.notify_question_author(node.author, self).deliver
     end
-
     users_with_everything_tag = Tag.followers('everything') 
     uids = (node.answers.collect(&:uid) + node.likers.collect(&:uid) + users_with_everything_tag.collect(&:uid)).uniq
-
     # notify other answer authors and users who liked the question
     DrupalUsers.where('uid IN (?)', uids).each do |user|
       if (user.uid != current_user.uid) && (user.uid != node.author.uid)

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -21,6 +21,22 @@ class AnswersControllerTest < ActionController::TestCase
     assert_not_nil assigns(:answer)
   end
 
+  test 'Users with subscription=everything should also be emailed ' do
+    UserSession.create(rusers(:bob))
+    node = node(:question)
+    initial_mail_count = ActionMailer::Base.deliveries.size
+    assert_difference 'Answer.count' do
+      xhr :post, :create,
+          nid: node.nid,
+          body: 'Sample answer by the current user'
+    end
+
+    user_with_everything_tag = rusers(:moderator)
+    assert_not_equal initial_mail_count, ActionMailer::Base.deliveries.size
+    assert ActionMailer::Base.deliveries.collect(&:to).include?([user_with_everything_tag.mail])
+    assert_response :success
+  end
+
   test 'should get update if user is logged in' do
     UserSession.create(rusers(:bob))
     answer = answers(:one)

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -33,7 +33,7 @@ class AnswersControllerTest < ActionController::TestCase
 
     user_with_everything_tag = rusers(:moderator)
     assert_not_equal initial_mail_count, ActionMailer::Base.deliveries.size
-    assert ActionMailer::Base.deliveries.collect(&:to).include?([user_with_everything_tag.mail])
+    assert ActionMailer::Base.deliveries.collect(&:to).include?([user_with_everything_tag.email])
     assert_response :success
   end
 


### PR DESCRIPTION
Currently when an answer is added to a node then only following are notified :
1.) Author
2.) Users who have given answers to the node .
3.) Users who have liked the node .

This PR solves the issue #1761 and users subscribed with 'everything' will also get mail when a new answer is added .

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [X] all tests pass -- `rake test:all`
* [X] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [X] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
