### PR TITLE
@user made work after bullets (2)

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,5 +1,5 @@
 module Callouts
-  FINDER = /(^|\s)\@([\w-]+)/
+  FINDER = /([^`\w]|^)\@([\w-]+)/
   HASHTAG = /(\s)\#([:a-zA-Z0-9_-]+)/
   PRETTYLINKMD = '\1[@\2](/profile/\2)'
   HASHLINKMD = '\1[#\2](/tag/\2)'


### PR DESCRIPTION
I guess this will pass 
Nor '''' nor any word character present before @

```
  FINDER = /([^`\w]|^)\@([\w-]+)/
```

Link to rubular http://rubular.com/r/bPteNKTbfr

Fixes #1751