### PR TITLE
moves coauthored notes to user model (resolves #1793)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -107,13 +107,9 @@ class UsersController < ApplicationController
                        .page(params[:page])
                        .order("nid DESC")
                        .where(status: 1, uid: @user.uid)
-    coauthored_tag = "with:"+@user.name 
-    @coauthored = Node.where(status: 1, type: "note")
-                  .includes(:revision, :tag)
-                  .references(:term_data, :node_revisions)
-                  .where('term_data.name = ? OR term_data.parent = ?', coauthored_tag.to_s , coauthored_tag.to_s)
-                  .page(params[:page])
-                  .order('node_revisions.timestamp DESC')                   
+    @coauthored = @profile_user.coauthored_notes
+                               .page(params[:page])
+                               .order('node_revisions.timestamp DESC')
     @questions = @user.user.questions
                            .order('node.nid DESC')
                            .paginate(:page => params[:page], :per_page => 30)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,10 +100,11 @@ class User < ActiveRecord::Base
   end
 
   def coauthored_notes
-    coauthored_tag = "with:"+self.name.downcase
+    coauthored_tag = "with:" + self.name.downcase
     Node.where(status: 1, type: "note")
         .includes(:revision, :tag)
-        .where('term_data.name = ? OR term_data.parent = ?', coauthored_tag , coauthored_tag)
+        .references(:term_data, :node_revisions)
+        .where('term_data.name = ? OR term_data.parent = ?', coauthored_tag.to_s , coauthored_tag.to_s)
   end
 
   def generate_reset_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,10 +100,10 @@ class User < ActiveRecord::Base
   end
 
   def coauthored_notes
-    coauthored_tag = "with:"+self.name
+    coauthored_tag = "with:"+self.name.downcase
     Node.where(status: 1, type: "note")
         .includes(:revision, :tag)
-        .where('term_data.name = ? OR term_data.parent = ?', coauthored_tag.to_s , coauthored_tag.to_s)
+        .where('term_data.name = ? OR term_data.parent = ?', coauthored_tag , coauthored_tag)
   end
 
   def generate_reset_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,13 @@ class User < ActiveRecord::Base
         .order('created DESC')
   end
 
+  def coauthored_notes
+    coauthored_tag = "with:"+self.name
+    Node.where(status: 1, type: "note")
+        .includes(:revision, :tag)
+        .where('term_data.name = ? OR term_data.parent = ?', coauthored_tag.to_s , coauthored_tag.to_s)
+  end
+
   def generate_reset_key
     # invent a key and save it
     key = ''

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -100,8 +100,8 @@ class UserTest < ActiveSupport::TestCase
     assert bob.coauthored_notes.empty?
 
     jeffs_note = nodes(:one)
-    jeffs_note.tag.create(name: "with:bob")
-
+    jeffs_note.add_tag('with:bob', jeff)
+    
     coauthored_note = bob.coauthored_notes.first
 
     assert_not_nil coauthored_note

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -94,4 +94,17 @@ class UserTest < ActiveSupport::TestCase
     assert bob.has_power_tag("question")
   end
 
+  test 'returns nodes coauthored by user with coauthored_notes method' do
+    jeff = users(:jeff)
+    bob = users(:bob)
+    assert bob.coauthored_notes.empty?
+
+    jeffs_note = nodes(:one)
+    jeffs_note.tag.create(name: "with:bob")
+
+    coauthored_note = bob.coauthored_notes.first
+
+    assert_not_nil coauthored_note
+    assert_equal jeffs_note, coauthored_note
+  end
 end


### PR DESCRIPTION
This pull is in progress

- [x] Create `coauthored_notes` method in User.rb and use in user_controller
- [x] Write unit tests for method

In reference to issue #1793 