### PR TITLE
Social Media Feature on profile page (Part of #1802)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,16 +128,16 @@ class UsersController < ApplicationController
     @twitter = nil 
     @facebook = nil
     @github = nil 
-    if User.user_has_power_tag("twitter" , @user.uid) == true 
-      twitter_user_name = User.get_value_of_power_tag("twitter" , @user.uid)
+    if @profile_user.has_power_tag("twitter") == true 
+      twitter_user_name = @profile_user.get_value_of_power_tag("twitter")
       @twitter = "https://twitter.com/" + twitter_user_name.to_s  
     end
-    if User.user_has_power_tag("facebook" , @user.uid) == true 
-      facebook_user_name = User.get_value_of_power_tag("facebook" , @user.uid)
+    if @profile_user.has_power_tag("facebook") == true 
+      facebook_user_name = @profile_user.get_value_of_power_tag("facebook")
       @facebook = "https://facebook.com/" + facebook_user_name.to_s
     end
-    if User.user_has_power_tag("github" , @user.uid) == true 
-      github_user_name = User.get_value_of_power_tag("github" ,  @user.uid)
+    if @profile_user.has_power_tag("github") == true 
+      github_user_name = @profile_user.get_value_of_power_tag("github")
       @github = "https://github.com/" + github_user_name.to_s
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,16 +128,16 @@ class UsersController < ApplicationController
     @twitter = nil 
     @facebook = nil
     @github = nil 
-    if User.user_has_power_tag("twitter" , @profile_user.id) == true 
-      twitter_user_name = User.get_value_of_power_tag("twitter" , @profile_user.id)
+    if User.user_has_power_tag("twitter" , @user.uid) == true 
+      twitter_user_name = User.get_value_of_power_tag("twitter" , @user.uid)
       @twitter = "https://twitter.com/" + twitter_user_name.to_s  
     end
-    if User.user_has_power_tag("facebook" , @profile_user.id) == true 
-      facebook_user_name = User.get_value_of_power_tag("facebook" , @profile_user.id)
+    if User.user_has_power_tag("facebook" , @user.uid) == true 
+      facebook_user_name = User.get_value_of_power_tag("facebook" , @user.uid)
       @facebook = "https://facebook.com/" + facebook_user_name.to_s
     end
-    if User.user_has_power_tag("github" , @profile_user.id) == true 
-      github_user_name = User.get_value_of_power_tag("github" , @profile_user.id)
+    if User.user_has_power_tag("github" , @user.uid) == true 
+      github_user_name = User.get_value_of_power_tag("github" ,  @user.uid)
       @github = "https://github.com/" + github_user_name.to_s
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -125,6 +125,22 @@ class UsersController < ApplicationController
                     .joins(:node)
                     .limit(20)
     @wikis = wikis.collect(&:parent).uniq
+    @twitter = nil 
+    @facebook = nil
+    @github = nil 
+    if User.user_has_power_tag("twitter" , @profile_user.id) == true 
+      twitter_user_name = User.get_value_of_power_tag("twitter" , @profile_user.id)
+      @twitter = "https://twitter.com/" + twitter_user_name.to_s  
+    end
+    if User.user_has_power_tag("facebook" , @profile_user.id) == true 
+      facebook_user_name = User.get_value_of_power_tag("facebook" , @profile_user.id)
+      @facebook = "https://facebook.com/" + facebook_user_name.to_s
+    end
+    if User.user_has_power_tag("github" , @profile_user.id) == true 
+      github_user_name = User.get_value_of_power_tag("github" , @profile_user.id)
+      @github = "https://github.com/" + github_user_name.to_s
+    end
+
     if @user.status == 0
       if current_user && (current_user.role == "admin" || current_user.role == "moderator")
         flash.now[:error] = I18n.t('users_controller.user_has_been_banned')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,22 @@ class User < ActiveRecord::Base
     user_tags.collect(&:value).include?(tagname)
   end
 
+   # power tags have "key:value" format, and should be searched with a "key:*" wildcard
+  def self.user_has_power_tag(key , user_id)
+    all_key_tags_ids = Tag.where('name LIKE ?' , key + ':%').collect(&:tid)
+    tids = TagSelection.where('user_id = ? AND tid IN (?)', user_id, all_key_tags_ids)
+    !tids.nil? 
+  end
+
+  def self.get_value_of_power_tag(key , user_id)
+    all_key_tags = Tag.where('name LIKE ?' , key + ':%') 
+    all_key_tags_ids = all_key_tags.collect(&:tid)
+    tids = TagSelection.where('user_id = ? AND tid IN (?)', user_id, all_key_tags_ids).collect(&:tid) 
+    tname = Tag.find(tids.first)
+    tvalue = tname.name.partition(':').last  
+    tvalue
+  end 
+
   def subscriptions(type = :tag)
     if type == :tag
       TagSelection.find_all_by_user_id uid, conditions: { following: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,16 +140,16 @@ class User < ActiveRecord::Base
   end
 
    # power tags have "key:value" format, and should be searched with a "key:*" wildcard
-  def self.user_has_power_tag(key , user_id)
+  def has_power_tag(key)
     all_key_tags_ids = Tag.where('name LIKE ?' , key + ':%').collect(&:tid)
-    tids = TagSelection.where('user_id = ? AND tid IN (?)', user_id, all_key_tags_ids)
+    tids = TagSelection.where('user_id = ? AND tid IN (?)', self.id , all_key_tags_ids)
     !tids.blank? 
   end
 
-  def self.get_value_of_power_tag(key , user_id)
+  def get_value_of_power_tag(key)
     all_key_tags = Tag.where('name LIKE ?' , key + ':%') 
     all_key_tags_ids = all_key_tags.collect(&:tid)
-    tids = TagSelection.where('user_id = ? AND tid IN (?)', user_id, all_key_tags_ids).collect(&:tid) 
+    tids = TagSelection.where('user_id = ? AND tid IN (?)', self.id , all_key_tags_ids).collect(&:tid) 
     tname = Tag.find(tids.first)
     tvalue = tname.name.partition(':').last  
     tvalue

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,7 +143,7 @@ class User < ActiveRecord::Base
   def self.user_has_power_tag(key , user_id)
     all_key_tags_ids = Tag.where('name LIKE ?' , key + ':%').collect(&:tid)
     tids = TagSelection.where('user_id = ? AND tid IN (?)', user_id, all_key_tags_ids)
-    !tids.nil? 
+    !tids.blank? 
   end
 
   def self.get_value_of_power_tag(key , user_id)

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -5,7 +5,25 @@
       <img class="img-circle" id="profile-photo" style="width:50%;margin-bottom:20px;" src="<%= @user.user.profile_image %>" />
     </div>
   <% end %>
-
+  
+  <div style="text-align: -webkit-center;">
+    <% if @twitter.nil? == false %>
+      <a href="<%= @twitter %>" >
+      <i class="fa fa-twitter-square fa-3x" aria-hidden="true"></i>
+      </a>
+    <% end %>
+    <% if @facebook.nil? == false %>
+        <a href="<%= @facebook %>" >
+       <i class="fa fa-facebook-square fa-3x" aria-hidden="true"></i>
+       </a>
+    <% end %>
+    <% if @github.nil? == false %>
+        <a href="<%= @github %>" >
+       <i class="fa fa-github-square fa-3x" aria-hidden="true"></i>
+       </a>
+    <% end %>
+  </div>
+  <br>
   <% if current_user && @profile_user %>
     <% unless current_user == @profile_user %>
       <hr />

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -9,17 +9,17 @@
   <div style="text-align: -webkit-center;">
     <% if @twitter.nil? == false %>
       <a href="<%= @twitter %>" >
-      <i class="fa fa-twitter-square fa-3x" aria-hidden="true"></i>
+      <i class="fa fa-twitter fa-3x" aria-hidden="true"></i>
       </a>
     <% end %>
     <% if @facebook.nil? == false %>
         <a href="<%= @facebook %>" >
-       <i class="fa fa-facebook-square fa-3x" aria-hidden="true"></i>
+       <i class="fa fa-facebook fa-3x" aria-hidden="true"></i>
        </a>
     <% end %>
     <% if @github.nil? == false %>
         <a href="<%= @github %>" >
-       <i class="fa fa-github-square fa-3x" aria-hidden="true"></i>
+       <i class="fa fa-github fa-3x" aria-hidden="true"></i>
        </a>
     <% end %>
   </div>

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -177,6 +177,16 @@ class NodeTest < ActiveSupport::TestCase
     assert_equal node.normal_tags, [node_tags(:test2)]
   end
 
+  test 'returns power tag' do
+    node = node(:blog)
+    assert_equal node.power_tag_objects("lat") , [node_tags(:map_lat)]
+  end
+
+  test 'has power tag' do
+    node = node(:blog) 
+    assert node.has_power_tag("lat")
+  end
+
   test 'should show question icon for question node' do
     node = node(:question)
     assert_equal 'question-circle', node.icon

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -83,4 +83,15 @@ class UserTest < ActiveSupport::TestCase
     node2 = rusers(:lurker).node.find_by_nid(20)
      assert_equal [node2], lurker.content_followed_in_past_period(2.hours.ago)
   end
+
+  test 'returns value of power tag' do
+    bob = rusers(:bob)
+    assert_equal bob.get_value_of_power_tag("question") , "spectrometer"
+  end
+
+  test 'has power tag' do
+    bob = rusers(:bob)
+    assert bob.has_power_tag("question")
+  end
+
 end


### PR DESCRIPTION
Issue #1802 .

@jywarren sir , @ebarry mam...kindly review this ! Thanks !

To add Social media icons on profile page (twitter , facebook , github) , user should follow power tags twitter:_____   , facebook:_____  and github:______ respectively .
The blanks above are the name of user in url of the respective social media sites .

Example : https://github.com/sagarpreet-chadha   then power tag is
 github:sagarpreet-chadha 

Screenshot :  

<img width="1436" alt="screen shot 2017-12-01 at 3 06 49 pm" src="https://user-images.githubusercontent.com/14952645/33477345-5febd2e4-d6ab-11e7-9d56-fc7133d9c306.png">



Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [X] all tests pass -- `rake test:all`
* [X] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [X] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
