### PR TITLE
Attempt to reproduce Solr maxWarmingSearchers 503 error in Integration test

### DIFF
--- a/test/solr/node_integration_test.rb
+++ b/test/solr/node_integration_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class NodeUpdateTest < ActionDispatch::IntegrationTest
+
+  test 'edit note after creating a new note' do
+
+    post '/user_sessions', user_session: {
+      username: users(:bob).username,
+      password: 'secretive'
+    }
+
+    title = 'My second post about balloon mapping'
+
+    post '/notes/create',
+         title: title,
+         body: 'This is a fascinating post about a balloon mapping event.',
+         tags: 'balloon-mapping,event'
+
+    follow_redirect!
+    assert_equal '/notes/' + users(:bob).username + '/' +
+                 Time.now.strftime('%m-%d-%Y') + '/' + title.parameterize, path
+
+    get '/dashboard'
+
+    assert_response :success
+
+  end
+end

--- a/test/solr/node_search_test.rb
+++ b/test/solr/node_search_test.rb
@@ -2,6 +2,13 @@ require 'test_helper'
 
 class NodeSearchTest < ActiveSupport::TestCase
 
+  test 'create a node' do
+    node = Node.new(uid: users(:bob).id,
+                    type: 'note',
+                    title: 'My new node for node creation testing')
+    assert node.save
+  end
+  
   test "plain Node.search returns something" do
     search = Node.search
     assert_not_nil search.results


### PR DESCRIPTION
Related to #1784

In Staging, I've been able to get a maxWarmingSearchers 503 error after posting a note at http://staging.publiclab.org/post

So I'm trying to reproduce this result in a test, by adding a note creation and subsequent loading of `/dashboard` in an integration test.

****

My efforts to make a test so far haven't worked, but I was able to:

1. i enable solr on staging (or unstable) - confirm with http://staging.publiclab.org/api/typeahead/all?srchString=precocious
2. i go to /post and post something (no image)
3. the site shows 503 maxWarmers error on http://staging.publiclab.org/dashboard

(note, i just tried this again and it did not work due to the email-sending issue on containers with no email setup, see #1570 and #1613)