### PR TITLE
showing basic user as a moderator corrected (fixes #1918 )

### DIFF
--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -5,7 +5,7 @@
 			<p> This page shows a list of all Public Lab contributors and is sorted by those who have posted most recently. Click the profile link to view their posting activity. </p>
 		</div>
 	</div>
-  <% if current_user && current_user.role = "admin" && current_user.role = "moderator" %>
+  <% if current_user && current_user.role == "admin" && current_user.role == "moderator" %>
     <h2><%= t('users.list.user_moderation') %></h2>
     <p><%= t('users.list.admins_ban_spam') %> </p>
   <% end %>
@@ -29,7 +29,7 @@
       <td><%= time_ago_in_words(Time.at(user.last['changed'])) if user.last %></td>
       <td><%= user.node_count %> <%= t('users.list.notes_and_edits') %></td>
       <td><%= distance_of_time_in_words(user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></td>
-      <% if current_user && current_user.role = "admin" && current_user.role = "moderator" %>
+      <% if current_user && current_user.role == "admin" && current_user.role == "moderator" %>
       <td>
         <% if user.status == 0 %>
           <i class='fa fa-ban' style="color:#a00;"></i> <%= t('users.list.banned') %>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -5,7 +5,7 @@
 			<p> This page shows a list of all Public Lab contributors and is sorted by those who have posted most recently. Click the profile link to view their posting activity. </p>
 		</div>
 	</div>
-  <% if current_user && current_user.role == "admin" && current_user.role == "moderator" %>
+  <% if current_user && (current_user.role == "admin" || current_user.role == "moderator") %>
     <h2><%= t('users.list.user_moderation') %></h2>
     <p><%= t('users.list.admins_ban_spam') %> </p>
   <% end %>
@@ -19,7 +19,7 @@
       <th><%= t('users.list.last_activity') %></th>
       <th><%= t('users.list.history') %></th>
       <th><%= t('users.list.joined') %></th>
-      <% if current_user && current_user.role == "admin" && current_user.role == "moderator" %>
+      <% if current_user && (current_user.role == "admin" && current_user.role == "moderator") %>
         <th><%= t('users.list.moderation') %></th>
       <% end %>
     </tr>
@@ -29,7 +29,7 @@
       <td><%= time_ago_in_words(Time.at(user.last['changed'])) if user.last %></td>
       <td><%= user.node_count %> <%= t('users.list.notes_and_edits') %></td>
       <td><%= distance_of_time_in_words(user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></td>
-      <% if current_user && current_user.role == "admin" && current_user.role == "moderator" %>
+      <% if current_user && (current_user.role == "admin" || current_user.role == "moderator") %>
       <td>
         <% if user.status == 0 %>
           <i class='fa fa-ban' style="color:#a00;"></i> <%= t('users.list.banned') %>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -19,7 +19,7 @@
       <th><%= t('users.list.last_activity') %></th>
       <th><%= t('users.list.history') %></th>
       <th><%= t('users.list.joined') %></th>
-      <% if current_user && current_user.role = "admin" && current_user.role = "moderator" %>
+      <% if current_user && current_user.role == "admin" && current_user.role == "moderator" %>
         <th><%= t('users.list.moderation') %></th>
       <% end %>
     </tr>


### PR DESCRIPTION
fixes #1918 
* [X] all tests pass -- `rake test:all`
* [X] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [X] pull request is descriptively named with #number reference back to original issue

  