### PR TITLE
Made RSS feed a valid one + functional test for it 

### DIFF
--- a/app/views/notes/rss.rss.builder
+++ b/app/views/notes/rss.rss.builder
@@ -1,14 +1,15 @@
-xml.instruct! :xml, :version => "1.0" 
-xml.rss :version => "2.0" do
+xml.instruct!
+xml.rss :version => '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom' do
   xml.channel do
     xml.title "Recent research notes on PublicLab.org"
     xml.description "Open source environmental science research at Public Lab"
     xml.link "https://#{ request.host }/feed.rss"
-
+    xml.tag! 'atom:link', :rel => 'self', :type => 'application/rss+xml', :href => request.host.to_s
+    
    @notes.each do |node|
 
      body = node.latest.render_body
-     body = "<p><![CDATA[ <img src='"+node.main_images.path(:default)+"' alt='"+node.main_image.title+"' > ]]></p> " + node.body if node.main_image
+     body = "<p><![CDATA[ <img src='"+node.main_image.path(:default)+"' alt='"+node.main_image.title+"' > ]]></p> " + node.body if node.main_image
 
      xml.item do
        xml.title       node.title

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -576,9 +576,9 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   def test_get_rss_feed
-  get :rss, :format => "rss"
-  assert_response :success   
-  assert_equal 'application/rss+xml', @response.content_type
-end
+    get :rss, :format => "rss"
+    assert_response :success   
+    assert_equal 'application/rss+xml', @response.content_type
+  end
 
 end

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -574,4 +574,11 @@ class NotesControllerTest < ActionController::TestCase
       assert_equal I18n.t('notes_controller.research_note_published'), flash[:notice]
     end
   end
+
+  def test_get_rss_feed
+  get :rss, :format => "rss"
+  assert_response :success   
+  assert_equal 'application/rss+xml', @response.content_type
+end
+
 end


### PR DESCRIPTION
Some changes to #1958 .

- Made changes to `rss.rss.builder` and made it a valid one according to [https://validator.w3.org/feed/check.cgi](https://validator.w3.org/feed/check.cgi) . 

- Functional test also added to check the same .


* [X] all tests pass -- `rake test:all`
* [X] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [X] pull request is descriptively named with #number reference back to original issue



Thanks!
