### PR TITLE
Issue 2081: Added link to notification e-mail for moderators

### DIFF
--- a/app/views/admin_mailer/notify_moderators_of_spam.html.erb
+++ b/app/views/admin_mailer/notify_moderators_of_spam.html.erb
@@ -12,6 +12,8 @@
 
 <div style="color:#aaa;">
 
+<p>Visit the spam page here: <a href="http://publiclab.org/spam">http://publiclab.org/spam</a></p>
+
 <p>You received this email because you are <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/wiki/moderation">a Public Lab community moderator</a></p>
 
 <p>To discuss spam/abuse, forward this to <a href="mailto:moderators@<%= ActionMailer::Base.default_url_options[:host] %>">moderators@<%= ActionMailer::Base.default_url_options[:host] %></a></p>


### PR DESCRIPTION
Fixes #2081 
* [x] all tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
