### PR TITLE
Even treatment of heading on /wiki

### DIFF
--- a/app/views/wiki/_wikis.html.erb
+++ b/app/views/wiki/_wikis.html.erb
@@ -1,7 +1,7 @@
 <table class="table">
   <tr>
     <%= raw t('wiki._wikis.table_content') %>
-    <th><i class="fa fa-star-o"></i> <%= t('wiki._wikis.likes') %></th>
+    <th> <%= t('wiki._wikis.likes') %></th>
   </tr>
   <% @wikis.each do |wiki| %>
     <tr>


### PR DESCRIPTION
On /wiki we have uneven headings. Notice the star symbol only for the likes. It looks ugly.
![image](https://user-images.githubusercontent.com/20972099/35810817-eaf65400-0ab2-11e8-9b5a-b880839ec324.png)
I have made it like this.
![image](https://user-images.githubusercontent.com/20972099/35810798-dcd5759a-0ab2-11e8-97c4-8b6127edbf9e.png)
