### PR TITLE
Improve element selectors in i18n tests #2220

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -13,7 +13,7 @@ class I18nTest < ActionDispatch::IntegrationTest
     available_testing_locales.each do |lang|
       get '/home'
       get_via_redirect '/change_locale/' + lang.to_s
-      assert_select 'p.facebook-summary', I18n.t('layout._header.summary')
+      assert_select '[p.facebook-summary]', I18n.t('layout._header.summary')
       post '/user_sessions', user_session: {
         username: users(:jeff).username,
         password: 'secretive'
@@ -106,7 +106,7 @@ class I18nTest < ActionDispatch::IntegrationTest
            tags: 'Some-tag',
            status: 4
       get '/dashboard'
-      assert_select 'a.btn btn-default btn-xs', I18n.t('dashboard._node_moderate.approve')
+      assert_select '[a.btn btn-default btn-xs]', I18n.t('dashboard._node_moderate.approve')
     end
   end
 
@@ -476,7 +476,7 @@ class I18nTest < ActionDispatch::IntegrationTest
 
       get nodes(:first_timer_note).path
       assert_template 'notes/show'
-      assert_select 'div.alert alert-warning', ActionView::Base.full_sanitizer.sanitize(I18n.t('notes.show.note_no_tags'))
+      assert_select '[div.alert alert-warning]', ActionView::Base.full_sanitizer.sanitize(I18n.t('notes.show.note_no_tags'))
     end
   end
 

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -13,7 +13,7 @@ class I18nTest < ActionDispatch::IntegrationTest
     available_testing_locales.each do |lang|
       get '/home'
       get_via_redirect '/change_locale/' + lang.to_s
-      assert_select 'p[class=facebook-summary]', I18n.t('layout._header.summary')
+      assert_select 'p.facebook-summary', I18n.t('layout._header.summary')
       post '/user_sessions', user_session: {
         username: users(:jeff).username,
         password: 'secretive'
@@ -106,7 +106,7 @@ class I18nTest < ActionDispatch::IntegrationTest
            tags: 'Some-tag',
            status: 4
       get '/dashboard'
-      assert_select 'a[class=btn btn-default btn-xs]', I18n.t('dashboard._node_moderate.approve')
+      assert_select 'a.btn btn-default btn-xs', I18n.t('dashboard._node_moderate.approve')
     end
   end
 
@@ -124,7 +124,7 @@ class I18nTest < ActionDispatch::IntegrationTest
            tags: 'question',
            status: 1
       get '/dashboard'
-      assert_select 'a[class=btn btn-default btn-xs pull-right respond answer]', I18n.t('dashboard._node_question.post_answer')
+      assert_select 'a.btn btn-default btn-xs pull-right respond answer', I18n.t('dashboard._node_question.post_answer')
     end
   end
 
@@ -476,7 +476,7 @@ class I18nTest < ActionDispatch::IntegrationTest
 
       get nodes(:first_timer_note).path
       assert_template 'notes/show'
-      assert_select 'div[class=alert alert-warning]', ActionView::Base.full_sanitizer.sanitize(I18n.t('notes.show.note_no_tags'))
+      assert_select 'div.alert alert-warning', ActionView::Base.full_sanitizer.sanitize(I18n.t('notes.show.note_no_tags'))
     end
   end
 


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] all tests pass -- `rake test:all`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request is descriptively named with #number reference back to original issue

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!

Hi I had some trouble installing the application specifically the part from 
Run rake db:setup to set up the database -> gave me the most trouble didnt work i dont think
Install static assets (like external javascript libraries, fonts) with bower install
(optional, not recommended) Install solr engine rails generate sunspot_rails:install
(optional, not recommended) Start the solr server in foreground by using bundle exec rake sunspot:solr:start
(optional, not recommended) Index your search database in solr server using bundle exec rake sunspot:reindex
Start rails with passenger start from the Rails root and open http://localhost:3000 in a web browser.
Wheeeee! You're up and running! Log in with test usernames "user", "moderator", or "admin", and password "password".
Run rake test to confirm that your install is working properly. For some setups, you may see warnings even if test pass; see this issue we're working to resolve. and on 

but the changes seemed easy enough so i still made them 