### PR TITLE
Improve readability of tags page

### DIFF
--- a/app/views/tag/index.html.erb
+++ b/app/views/tag/index.html.erb
@@ -1,6 +1,4 @@
-<%= render :partial => "sidebar/featured" %>
-
-<div class="col-md-9">
+<div class="col-md-12">
   <table style="width:100%">
     <tr>
      <th style="width: 50% ;">


### PR DESCRIPTION
This PR changes the readability on `tags/` page. It removes the sidebar and changes the grid size, showing the content on full-width display.

fixes #2337 

![captura de tela de 2018-02-15 12-42-31](https://user-images.githubusercontent.com/10670581/36280710-040c9694-1250-11e8-9fbf-9e876a24c2fc.png)

:white_check_mark: tests passed