### PR TITLE
Adding feature to allow raw HTML pages

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -792,6 +792,8 @@ class Node < ActiveRecord::Base
       else
         true
       end
+    elsif tagname == 'format:raw' && user.role != 'admin'
+      errors ? "Only admins may create raw pages." : false
     elsif tagname[0..4] == 'rsvp:' && user.username != tagname.split(':')[1]
       errors ? I18n.t('node.only_RSVP_for_yourself') : false
     elsif tagname == 'locked' && user.role != 'admin'

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -100,6 +100,16 @@ class Revision < ActiveRecord::Base
     body = body.gsub(Callouts.const_get(:HASHTAG), Callouts.const_get(:HASHLINKHTML))
     body_extras(body)
   end
+  
+  # filtered version of node content, but without running Markdown
+  def render_body_raw
+    body = self.body || ''
+    body = body.to_html
+    body = body.gsub(Callouts.const_get(:FINDER), Callouts.const_get(:PRETTYLINKHTML))
+    body = body.gsub(Callouts.const_get(:HASHTAGNUMBER), Callouts.const_get(:NODELINKHTML))
+    body = body.gsub(Callouts.const_get(:HASHTAG), Callouts.const_get(:HASHLINKHTML))
+    insert_extras(body_extras(body))
+  end
 
   # filtered version additionally appending http/https protocol to protocol-relative URLs like "/foo"
   # render_body plus making all relative links absolute

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -74,7 +74,11 @@
           <%= render :partial => "notes/comments", :locals => {:nodes => @nodes} %>
       <% else %>
         <div <% unless @node.has_tag('style:wide') %>style="max-width:800px;"<% end %> id="content" class="pl-content wiki">
-          <%= raw auto_link(insert_extras(@revision.render_body), sanitize: false) %>
+          <% if @node.has_tag('format:raw') %>
+            <%= raw @revision.render_body_raw %>
+          <% else %>
+            <%= raw auto_link(insert_extras(@revision.render_body), sanitize: false) %>
+          <% end %>
         </div>
         <% if params[:raw] == 'true' %>
           <div style="display:none;" id="content-raw-markdown" class="pl-content wiki"><%= raw insert_extras(@revision.body_raw) %></div>


### PR DESCRIPTION
That still preserve inline tags, but don't otherwise render Markdown (to allow complex custom layouts on locked pages)