### PR TITLE
"Show more" sort bug

### DIFF
--- a/app/assets/javascripts/grids.js
+++ b/app/assets/javascripts/grids.js
@@ -10,6 +10,7 @@ function sortGrid(type, selector, headerLink) {
       headerLink = $(headerLink),
       desc = headerLink.hasClass('desc'),
       header = table.find('tr:first').detach(),
+      footer = table.find('tfoot').detach(),
       rows = table.find('tr').detach();
 
   rows = rows.sort(function(a, b){
@@ -39,6 +40,7 @@ function sortGrid(type, selector, headerLink) {
 
   table.html(rows);
   table.prepend(header);
+  table.append(footer);
 
 console.log('rows')
 rows.each(function(row) {

--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -52,14 +52,14 @@
       <% end %>
     <% end %>
   </tr>
-  <% if index == 9 %>
-    <tr class="show-all">
-      <td><a>Show <%= nodes.length - 10 %> more <b class="caret"></b></a></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-  <% end %>
+<% end %>
+<% if nodes.count > 9 %>
+    <tfoot>
+      <th class="show-all"><a>Show <%= nodes.length - 10 %> more <b class="caret"></b></a></th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tfoot>
 <% end %>
 </table>
 


### PR DESCRIPTION
This fixes issue #2356

Notably, this change renders the "Show # more" button with different styling than the table rows. @publiclab/reviewers , if the styling is meant to be maintained, I'd be happy to be make that change in this PR, but I would need some guidance regarding the preferred styling method. (For example, making changes within css or bootstrap.)

Here's the original button styling at the bottom:
<img width="628" alt="screen shot 2018-02-26 at 10 37 56 pm" src="https://user-images.githubusercontent.com/30608004/36712395-d439bc72-1b45-11e8-8fe5-a1d7ae017741.png">

Here's how the button looks in this PR:
<img width="571" alt="screen shot 2018-02-26 at 10 38 15 pm" src="https://user-images.githubusercontent.com/30608004/36712421-f5b9d1c0-1b45-11e8-8b8d-dcb09d8b211c.png">

Also, in working on this issue, I was thinking that it might make sense to hide the button once it's been clicked.  Pending feedback, I'd be happy to create an issue for it.

Cheers!
Adrian

-------------------------------
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
