### PR TITLE
Caching impressions

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -130,7 +130,9 @@ class Node < ActiveRecord::Base
   def totalviews
     # disabled as impressionist is not currently updating counter_cache; see above
     # self.views + self.legacy_views
-    impressionist_count(filter: :ip_address) + legacy_views
+    cache("totalviews-#{self.id}", expires_in: 60.minutes, skip_digest: true) do
+      impressionist_count(filter: :ip_address) + legacy_views
+    end
   end
 
   def self.weekly_tallies(type = 'note', span = 52, time = Time.now)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -130,7 +130,7 @@ class Node < ActiveRecord::Base
   def totalviews
     # disabled as impressionist is not currently updating counter_cache; see above
     # self.views + self.legacy_views
-    cache("totalviews-#{self.id}", expires_in: 60.minutes, skip_digest: true) do
+    Rails.cache("totalviews-#{self.id}", expires_in: 60.minutes, skip_digest: true) do
       impressionist_count(filter: :ip_address) + legacy_views
     end
   end


### PR DESCRIPTION
Fixes #2389 -- let's see if this works! It may break some tests if we test `node.totalcount` but we can adjust them or use TimeCop to trigger a cache refresh.