### PR TITLE
Offset deeplinks on headers by floating navbar width

### DIFF
--- a/app/assets/javascripts/wikis.js
+++ b/app/assets/javascripts/wikis.js
@@ -55,7 +55,7 @@ function postProcessContent(element) {
 /* add "link" icon to headers for example.com#Hash deep links */
 function addDeepLinks(element) {
   element.find("h1,h2,h3,h4").append(function(i, html) {
-    return " <small><a id='" + this.innerHTML.replace(/ /g, '+') + "' href='#" + this.innerHTML.replace(/ /g, '+') + "'><i class='icon fa fa-link'></i></a></small>";
+    return " <small><a href='#" + this.innerHTML.replace(/ /g, '+') + "'><i class='icon fa fa-link'></i></a><a class='navbar-offset' id='" + this.innerHTML.replace(/ /g, '+') + "'</a></small>";
   });
 }
 

--- a/app/assets/stylesheets/wiki.css
+++ b/app/assets/stylesheets/wiki.css
@@ -61,3 +61,10 @@
     opacity: 1;
   }
 }
+
+a.navbar-offset {
+    display: block;
+    position: relative;
+    top: -100px;
+    visibility: hidden;
+}


### PR DESCRIPTION
When following a deeplink to a specific wiki header, the header is obscured under the floating header/navbar. The tactic used in this PR -- separating linked "chain" icon from a separate invisible anchor that is vertically offset -- should fix it. (Unsure how this looks on different screen sizes.)

![screenshot of hidden header](https://user-images.githubusercontent.com/305339/37624374-4da55d56-2b9e-11e8-9ddb-05a50b591b12.png)

Sorry, untested except in browser inspector :)

Reference: [StackOverflow: offsetting an html anchor to adjust for fixed header](https://stackoverflow.com/questions/10732690/offsetting-an-html-anchor-to-adjust-for-fixed-header)