### PR TITLE
render_map changes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,8 +55,8 @@ module ApplicationHelper
     body
   end
 
-  def render_map(lat, lon, items)
-    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, items: items }
+  def render_map(lat, lon)
+    render partial: 'map/leaflet', locals: { lat: lat, lon: lon }
   end
 
   # returns the comment body which is to be shown in the comments section

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -80,9 +80,9 @@
     <br />
 
     <% if @node && @maps && @node.lat %>
-      <%= render_map(@node.lat, @node.lon, @maps) %>
+      <%= render_map(@node.lat, @node.lon) %>
     <% elsif @maps && @maps.first %>
-      <%= render_map(@maps.first.lat, @maps.first.lon, @maps) %>
+      <%= render_map(@maps.first.lat, @maps.first.lon) %>
     <% end %>
 
     <br style="clear:both;" />


### PR DESCRIPTION
First-timers-only issue for issue #2599 

Fixes #2599 by removing 'items' parameter from render_map function and removing third parameter from render_map function calls.

Relevant lines are 58 and 59 in:
`app/helpers/application_helper.rb`

And lines 83 and 85 in:
`app/views/sidebar/_related.html`

