### PR TITLE
Add token documentation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -57,3 +57,55 @@ And several tag-based JSON/XML listings are generated directly from controllers,
 
 https://github.com/publiclab/plots2/blob/master/app/controllers/tag_controller.rb#L97-L108
 
+## POST Comment with token via API
+<details>
+  <summary>1) Documentation and Example (click to expand) </summary>
+  Allows a logged user or bot to post comments via API with a token.
+
+  Successful responses include a JSON-structure describing the comment.
+
+* **URL**
+
+  `/comment/create/token/id.:format`
+
+* **Method:**
+
+  `POST`
+
+*  **URL Params**
+
+   **Required:**
+
+   `id=[integer]`
+   `username=[string]`
+
+* **Data Params**
+
+  `body=[json]`
+  `headers=[token]`
+
+* **Success Response:**
+
+  * **Code:** 200 <br />
+    **Content:** `{ id : 12, username : "janedoe", body : "This is a comment" }`
+
+* **Error Response:**
+
+  * **Code:** 400 BAD REQUEST <br />
+    **Content:** `{ error : "Bad Request" }`
+
+* **Sample Call:**
+
+  ```POST https://publiclab.org/comment/create/token/id.:format
+  Content-Type: application/json
+  Body:
+  {
+    "id": 1,
+    "body": "This is a comment made with a token",
+    "username": "stefannibrasil"
+  },
+  Headers: {
+    token: ""
+  }
+  ```
+</details>

--- a/doc/API.md
+++ b/doc/API.md
@@ -57,55 +57,46 @@ And several tag-based JSON/XML listings are generated directly from controllers,
 
 https://github.com/publiclab/plots2/blob/master/app/controllers/tag_controller.rb#L97-L108
 
-## POST Comment with token via API
-<details>
-  <summary>1) Documentation and Example (click to expand) </summary>
-  Allows a logged user or bot to post comments via API with a token.
-
-  Successful responses include a JSON-structure describing the comment.
-
-* **URL**
-
-  `/comment/create/token/id.:format`
-
-* **Method:**
-
-  `POST`
-
-*  **URL Params**
+## Token based API for creating comment
+Allows a logged user or bot to post comments via API with a token.
+* **URL**:  `/comment/create/token/id.:format`
+* **Method:**   `POST`
+* **URL Params** :-
 
    **Required:**
 
-   `id=[integer]`
-   `username=[string]`
+   `id=[integer]`: This value specifies the node for which comment is to be created
+   
+   `format=[string]` : Specifies response format 
+   
+   `username=[string]`: This string specifies username of user tends to create comment by this API post request
+ 
+   **Data Params:** 
+   
+    `body=[string]` : This is the actual content of the comment.
+ 
+   **Headers:** 
 
-* **Data Params**
-
-  `body=[json]`
-  `headers=[token]`
+   `TOKEN=[string]`: This string value specifies ``access_token`` of the user for authentication purpose.
 
 * **Success Response:**
-
-  * **Code:** 200 <br />
-    **Content:** `{ id : 12, username : "janedoe", body : "This is a comment" }`
+  * **Code:** 201 Created <br>
+    **Content:** None
 
 * **Error Response:**
-
-  * **Code:** 400 BAD REQUEST <br />
-    **Content:** `{ error : "Bad Request" }`
+  * **Code:** 400 BAD REQUEST <br>
+    **Content:** None
 
 * **Sample Call:**
-
-  ```POST https://publiclab.org/comment/create/token/id.:format
-  Content-Type: application/json
+  ```
+  POST https://publiclab.org/comment/create/token/id.:format
+  
+  Headers:- 
+  "HTTP_TOKEN": "7a969e3d-cfe1-4da5-9b4c-71a42c9eef88"
+  
   Body:
   {
-    "id": 1,
-    "body": "This is a comment made with a token",
-    "username": "stefannibrasil"
-  },
-  Headers: {
-    token: ""
+    "username": "user",
+    "body": "This is a comment made with a token"
   }
   ```
-</details>


### PR DESCRIPTION
This PR adds the token documentation discussed in #2018 about people or bots commenting via API using the token system
