### PR TITLE
Updated functional test in tag_controller_test.rb to replace deprecated assert_tag with assert_select

### DIFF
--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -39,8 +39,7 @@ class TagControllerTest < ActionController::TestCase
         id: 'question:*'
 
     assert_template :contributors
-    assert_tag tag: 'p',
-               child: /No contributors for that tag/
+    assert_select 'p', text: "No contributors for that tag; try searching for 'question:*':"
   end
 
   test "won't add invalid tags" do


### PR DESCRIPTION
Updated functional test in tag_controller_test.rb to replace deprecated assert_tag with assert_select

Fixes #2610 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
