### PR TITLE
test revision spam flows

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -190,6 +190,14 @@ class AdminController < ApplicationController
 
   def mark_spam_revision
     @revision = Revision.find_by(vid: params[:vid])
+    @node = Node.find_by(nid: @revision.nid)
+
+    if(@node.drupal_node_revisions_count == 1)
+      flash[:warning] = "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
+      redirect_to @node.path
+      return
+    end
+    
     if current_user && (current_user.role == 'moderator' || current_user.role == 'admin')
       if @revision.status == 1
         @revision.spam

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -192,12 +192,12 @@ class AdminController < ApplicationController
     @revision = Revision.find_by(vid: params[:vid])
     @node = Node.find_by(nid: @revision.nid)
 
-    if(@node.drupal_node_revisions_count == 1)
+    if(@node.revisions.length <= 1)
       flash[:warning] = "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
       redirect_to @node.path
       return
     end
-    
+
     if current_user && (current_user.role == 'moderator' || current_user.role == 'admin')
       if @revision.status == 1
         @revision.spam

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -37,7 +37,8 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
-   # assert_select ".alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
+    assert_select "div.alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
+
     get '/dashboard'
     assert_response :success
 

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -35,7 +35,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
     get '/moderate/revision/spam/' + revision.vid.to_s
 
     follow_redirect!
-    
+
     assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
 
     get '/dashboard'

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -37,7 +37,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
-    assert_select ".alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
+   # assert_select ".alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
     get '/dashboard'
     assert_response :success
 

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -11,7 +11,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
 
     assert revision.parent.revisions.length > 1
 
-    get '/moderate/revision/spam/' + revision.vid
+    get '/moderate/revision/spam/' + revision.vid.to_s
 
     follow_redirect!
 
@@ -32,7 +32,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, revision.parent.revisions.length
 
-    get '/moderate/revision/spam/' + revision.vid
+    get '/moderate/revision/spam/' + revision.vid.to_s
 
     follow_redirect!
     

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -9,6 +9,8 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
 
     revision = revisions(:about_rev_2)
 
+    assert revision.parent.revisions.length > 1
+
     get '/moderate/revision/spam/' + revision.vid
 
     follow_redirect!
@@ -28,9 +30,13 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
 
     revision = revisions(:wiki_page)
 
+    assert_equal 1, revision.parent.revisions.length
+
     get '/moderate/revision/spam/' + revision.vid
 
     follow_redirect!
+    
+    assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
 
     get '/dashboard'
     assert_response :success

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -37,7 +37,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
-    assert_select "div.alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
+   # assert_select ".alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
 
     get '/dashboard'
     assert_response :success

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -37,7 +37,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
-
+    assert_select ".alert.alert-warning" , "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
     get '/dashboard'
     assert_response :success
 

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -37,7 +37,7 @@ class RevisionSpamTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_equal "You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.", flash[:warning]
-    assert_select ".alert.alert-warning" , "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
+    assert_select ".alert.alert-warning" ,:text => "× You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance."
     get '/dashboard'
     assert_response :success
 

--- a/test/integration/revision_spam_test.rb
+++ b/test/integration/revision_spam_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class RevisionSpamTest < ActionDispatch::IntegrationTest
+  test 'mark a wiki revision as spam' do
+    post '/user_sessions', user_session: {
+      username: users(:admin).username,
+      password: 'secretive'
+    }
+
+    revision = revisions(:about_rev_2)
+
+    get '/moderate/revision/spam/' + revision.vid
+
+    follow_redirect!
+
+    get '/dashboard'
+    assert_response :success
+
+    get '/home'
+    assert_response :success
+  end
+
+  test 'disallow marking a wiki revision as spam when its the only revision' do
+    post '/user_sessions', user_session: {
+      username: users(:admin).username,
+      password: 'secretive'
+    }
+
+    revision = revisions(:wiki_page)
+
+    get '/moderate/revision/spam/' + revision.vid
+
+    follow_redirect!
+
+    get '/dashboard'
+    assert_response :success
+
+    get '/home'
+    assert_response :success
+  end
+end


### PR DESCRIPTION
This should fail for the same reason as #2647 -- spamming the sole revision of a wiki page! 

Looking for, to resolve this:

redirect to the Revisions view with a notice that: 

`You can't delete the last remaining revision of a page; try deleting the wiki page itself (if you're an admin) or contacting moderators@publiclab.org for assistance.`