### PR TITLE
Added whenever gem for easily writing and deploying cron jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV PHANTOMJS_VERSION 2.1.1
 #    > /etc/apt/sources.list
 
 # Install dependencies
-RUN apt-get update -qq && apt-get install -y bundler libmysqlclient-dev ruby-rmagick libfreeimage3 nodejs-legacy npm wget procps
+RUN apt-get update -qq && apt-get install -y bundler libmysqlclient-dev ruby-rmagick libfreeimage3 nodejs-legacy npm wget procps cron
 RUN wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; tar -xvf /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C /opt ; cp /opt/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin/* /usr/local/bin/
 RUN npm install -g bower
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'responders', '~> 2.0' # for Rails 4.2
 
 gem 'turbolinks'
 
+# Whenever provides a clear syntax for writing and deploying cron jobs
+gem 'whenever', require: false
 
 # run with `bundle install --without production` or `bundle install --without mysql` to exclude this
 group :mysql, :production do

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Please read and abide by our [Code of Conduct](https://publiclab.org/conduct); o
 12. Wheeeee! You're up and running! Log in with test usernames "user", "moderator", or "admin", and password "password".
 13. Run `rake test` to confirm that your install is working properly. For some setups, you may see warnings even if test pass; [see this issue](https://github.com/publiclab/plots2/issues/440) we're working to resolve.
 
+## How to start and modify cron jobs
+
+1. We are using whenever gem to schedule cron jobs [Whenever](https://github.com/javan/whenever)
+2. All the cron jobs are written in easy ruby syntax using this gem and can be found in config/schedule.rb.
+2. Go to the config/schedule.rb file to create and modify the cron jobs.
+3. [Click here](https://github.com/javan/whenever) to know about how to write cron jobs.
+4. After updating config/schedule.rb file run the command `whenever --update-crontab` to update the cron jobs.
+5. To see the installed list of cron jobs use command `crontab -l`
+6. For more details about this gem, visit the official repository of whenever gem.
+
 ### Bundle exec
 
 For some, it will be necessary to prepend your gem-related commands with `bundle exec`, for example, `bundle exec passenger start`; adding `bundle exec` ensures you're using the version of passenger you just installed with Bundler. `bundle exec rake db: setup`, `bundle exec rake db: seed` are other examples of where this might be necessary.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever


### PR DESCRIPTION
Added whenever gem for easily writing and deploying cron jobs
Sub-project part of Periodic Email Digests in #2104 
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
