### PR TITLE
Update node.rb with .deliver_now fixes

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -50,7 +50,7 @@ class SubscriptionMailer < ActionMailer::Base
     mail(
       to: "do-not-reply@#{ActionMailer::Base.default_url_options[:host]}",
       bcc: recipients,
-      subject: "#{node.title} ()"
+      subject: "#{node.title} (#{@tag.name})"
       )
   end
 end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -11,7 +11,7 @@ class SubscriptionMailer < ActionMailer::Base
       @node = node
       @tags = val[:tags]
       @footer = feature('email-footer')
-      mail(to: val[:user].email, subject: subject)
+      mail(to: val[:user].email, subject: subject).deliver_now
     end
   end
 
@@ -41,7 +41,7 @@ class SubscriptionMailer < ActionMailer::Base
     final_users_to_email.each do |user|
       @user = user
       unless user.id == current_user.id 
-        mail(to: user.email, subject: "Added: #{node.title}")
+        mail(to: user.email, subject: "Added: #{node.title}").deliver_now
       end
     end
     @footer = feature('email-footer')

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -6,13 +6,15 @@ class SubscriptionMailer < ActionMailer::Base
   def notify_node_creation(node)
     subject = '[PublicLab] ' + (node.has_power_tag('question') ? 'Question: ' : '') +
               node.title
-    Tag.subscribers(node.tags).each do |_key, val|
-      @user = val[:user]
-      @node = node
-      @tags = val[:tags]
-      @footer = feature('email-footer')
-      mail(to: val[:user].email, subject: subject).deliver_now
-    end
+    @node = node
+    @tags = node.tags.collect(&:name).join(',')
+    @footer = feature('email-footer')
+    recipients = Tag.subscribers(node.tags).values.map{ |obj| obj[:user] }.collect(&:email)
+    mail(
+      to: "do-not-reply@#{ActionMailer::Base.default_url_options[:host]}",
+      bcc: recipients,
+      subject: subject
+    )
   end
 
   def notify_note_liked(node, user)
@@ -24,26 +26,31 @@ class SubscriptionMailer < ActionMailer::Base
     mail(to: node.author.email, subject: subject)
   end
 
- def notify_tag_added(node, tag, current_user)
+ def notify_tag_added(node, tag, tagging_user)
     @tag = tag
     @node = node
-    @current_user = current_user
+    @tagging_user = tagging_user
     given_tags = node.tags.reject { |t| t == tag} 
     users_to_email = tag.followers_who_dont_follow_tags(given_tags)
     users_with_everything_tag = Tag.followers('everything')
     final_users_ids = nil 
-    if(!users_to_email.nil? && !users_with_everything_tag.nil?)
+    if (!users_to_email.nil? && !users_with_everything_tag.nil?)
       final_users_ids = users_to_email.collect(&:id) - users_with_everything_tag.collect(&:uid)
-    elsif(!users_to_email.nil?) 
+    elsif (!users_to_email.nil?) 
       final_users_ids = users_to_email.collect(&:id)
     end
-    final_users_to_email = User.find(final_users_ids) 
+    final_users_to_email = User.find(final_users_ids)
+    recipients = []
     final_users_to_email.each do |user|
-      @user = user
-      unless user.id == current_user.id 
-        mail(to: user.email, subject: "Added: #{node.title}").deliver_now
+      unless user.id == tagging_user.id
+        recipients << user.email
       end
     end
     @footer = feature('email-footer')
+    mail(
+      to: "do-not-reply@#{ActionMailer::Base.default_url_options[:host]}",
+      bcc: recipients,
+      subject: "#{node.title} ()"
+      )
   end
 end

--- a/app/views/subscription_mailer/notify_node_creation.html.erb
+++ b/app/views/subscription_mailer/notify_node_creation.html.erb
@@ -16,7 +16,7 @@
 
 <div style="color:#aaa;">
 
-<p>You received this email because you are subscribed to the following tags: <%= @tags.to_a.collect(&:name).join(",") %>.</p>
+<p>You received this email because you are subscribed to some or all of the following tags: <%= @tags %>.</p>
 
 <p>To change your preferences, please visit https://<%= ActionMailer::Base.default_url_options[:host] %>/subscriptions.</p>
 

--- a/app/views/subscription_mailer/notify_node_creation.html.erb
+++ b/app/views/subscription_mailer/notify_node_creation.html.erb
@@ -1,5 +1,3 @@
-<p>Dear <%= @user.username %>,</p>
-
 <p>Public Lab contributor <a href='https://<%= ActionMailer::Base.default_url_options[:host] %>/profile/<%= @node.author.name %>'><%= @node.author.name %></a> just <% if @node.has_power_tag('question') %>asked a question<% else %>posted a new research note<% end %> entitled '<b><%= @node.title %></b>':</p>
 
 <% if @node.has_power_tag('question') %>
@@ -15,8 +13,6 @@
 <%= raw auto_link(@node.latest.render_body_email(ActionMailer::Base.default_url_options[:host]), :sanitize => false) %>
 
 <hr /> 
-
-<% if @user.role == "admin" || @user.role == "moderator" %>Does this look like spam? <a class="btn btn-sm" href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= @node.id %>">Spam</a><% end %>
 
 <div style="color:#aaa;">
 

--- a/app/views/subscription_mailer/notify_tag_added.html.erb
+++ b/app/views/subscription_mailer/notify_tag_added.html.erb
@@ -3,16 +3,14 @@
 
   was tagged with <i><a href='https://<%= ActionMailer::Base.default_url_options[:host] %>/tag/<%= @tag.name %>'>#<%= @tag.name %></a></i> 
 
-  by <a href='https://<%= ActionMailer::Base.default_url_options[:host] %>/profile/<%= @current_user.username %>'><%= @current_user.username %></a>
+  by <a href='https://<%= ActionMailer::Base.default_url_options[:host] %>/profile/<%= @tagging_user.username %>'><%= @tagging_user.username %></a>
 </p>
 
 <p>Read and respond to the post here: https://<%= ActionMailer::Base.default_url_options[:host] %><%= @node.path %></p>
 
-<% if @user.role == "admin" || @user.role == "moderator" %>Does this look like spam? <a class="btn btn-sm" href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= @node.id %>">Spam</a><% end %>
-
 <div style="color:#aaa;">
 
-<p>You received this email because you are subscribed to the following tag: <%= @tag.name %>.</p>
+<p>You received this email because it was tagged with: <%= @tag.name %>.</p>
 
 <p>To change your preferences, please visit https://<%= ActionMailer::Base.default_url_options[:host] %>/subscriptions.</p>
 

--- a/test/unit/subscription_mailer_test.rb
+++ b/test/unit/subscription_mailer_test.rb
@@ -80,7 +80,7 @@ class SubscriptionMailerTest < ActionMailer::TestCase
     assert_equal ["do-not-reply@#{request_host}"], email.from
     assert_equal ["do-not-reply@#{request_host}"], email.to
     assert email.bcc.include?(users_to_email.last.email)
-    assert_equal "Added: #{node.title}", email.subject
+    assert_equal "#{node.title} (#{new_tag.name})", email.subject
     assert email.body.include?("was tagged with")
   end
 end

--- a/test/unit/subscription_mailer_test.rb
+++ b/test/unit/subscription_mailer_test.rb
@@ -79,7 +79,7 @@ class SubscriptionMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ["do-not-reply@#{request_host}"], email.from
     assert_equal ["do-not-reply@#{request_host}"], email.to
-    assert_equal email.bcc.include?(users_to_email.last.email)
+    assert email.bcc.include?(users_to_email.last.email)
     assert_equal "Added: #{node.title}", email.subject
     assert email.body.include?("was tagged with")
   end

--- a/test/unit/subscription_mailer_test.rb
+++ b/test/unit/subscription_mailer_test.rb
@@ -12,7 +12,7 @@ class SubscriptionMailerTest < ActionMailer::TestCase
 
     email = ActionMailer::Base.deliveries.last
     assert_equal ["do-not-reply@#{request_host}"], email.from
-    assert_equal [subscribers.values.last[:user].email], email.to
+    assert_equal ["do-not-reply@#{request_host}"], email.to
     assert_equal '[PublicLab] ' + node.title, email.subject
     assert email.body.include?("Public Lab contributor <a href='https://#{request_host}/profile/#{node.author.name}'>#{node.author.name}</a> just posted a new research note")
   end
@@ -27,7 +27,7 @@ class SubscriptionMailerTest < ActionMailer::TestCase
 
     email = ActionMailer::Base.deliveries.last
     assert_equal ["do-not-reply@#{request_host}"], email.from
-    assert_equal [subscribers.values.last[:user].email], email.to
+    assert_equal ["do-not-reply@#{request_host}"], email.to
     assert_equal '[PublicLab] Question: ' + node.title, email.subject
     assert email.body.include?("Public Lab contributor <a href='https://#{request_host}/profile/#{node.author.name}'>#{node.author.name}</a> just asked a question")
   end
@@ -78,8 +78,8 @@ class SubscriptionMailerTest < ActionMailer::TestCase
     assert !ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
     assert_equal ["do-not-reply@#{request_host}"], email.from
-    assert_equal [users_to_email.last.email], email.to
-    assert_not_equal [user.email], email.to
+    assert_equal ["do-not-reply@#{request_host}"], email.to
+    assert_equal email.bcc.include?(users_to_email.last.email)
     assert_equal "Added: #{node.title}", email.subject
     assert email.body.include?("was tagged with")
   end


### PR DESCRIPTION
This isn't right -- http://edgeapi.rubyonrails.org/classes/ActionMailer/MessageDelivery.html

But why aren't initial emails being sent? I suspected this line:

https://github.com/publiclab/plots2/blob/cbda70898ddacb78e154fb6576f6e1c61644fa1f/app/models/node.rb#L203

Maybe we have to refactor this to have a single `mail()` 

Actually, i see the logs showing that the mails are being rendered:

```
Started POST "/notes/create?rich=true" for XX.XX.XX.XX at 2018-05-22 13:37:07 +0000
Processing by NotesController#create as */*
  Parameters: {"title"=>"Last coal plant in Chicago shut down ", "body"=>"_lead image from http://lve
jo.org/_\n\nNews from February 2018: \n\nAfter an 11 year struggle, Little Village community and part
ners have succeeded in bringing enough pressure to shut down the last coal plant in Chicago. \n\nhttp
://www.chicagotribune.com/business/columnists/ori/ct-biz-crawford-station-redevelopment-ryan-ori-2018
0205-story.html\n\nRelated initiatives in the community include getting a new high school with commun
ity-controlled curriculum built after other area schools had been closed. Towards this goal, parents 
went on hunger strike. ", "authenticity_token"=>"XXXXXXXX==", "tags"=>"chicago,  coal", "has_main_image"=>"true", "main_imag
e"=>"25009", "node_images"=>"", "image"=>{"photo"=>""}, "rich"=>"true"}
  Rendered subscription_mailer/notify_node_creation.html.erb (50.7ms)
  Rendered subscription_mailer/notify_node_creation.html.erb (38.0ms)
  Rendered subscription_mailer/notify_node_creation.html.erb (18.9ms)
...
  Rendered subscription_mailer/notify_node_creation.html.erb (20.6ms)
  Rendered subscription_mailer/notify_node_creation.html.erb (11.8ms)
```

They're just not being actually sent, according to the logs. 