### PR TITLE
make descriptive tag links move to bottom of page- issue #2768

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -3,7 +3,7 @@
 <%= render :partial => "sidebar/related" %>
 
 <div class="col-md-9 note-show<% if @node.status == 4 || @node.status == 0 %> moderated<% end %>">
-  <% if current_user && @node.tags.length == 0 %><div class="alert alert-warning"><%= raw t('notes.show.note_no_tags') %></div><% end %>
+  <% if current_user && @node.tags.length == 0 %><div class="alert alert-warning"><%= raw t('notes.show.note_no_tags', url: 'javascript: $(".tag-input").focus();') %></div><% end %>
   <% if @node.has_power_tag('status:candidate') %><div class="alert alert-info">This was marked as a candidate activity -- <a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity" >read about how to adapt its content</a> into a fully-fledged, step-by-step activity that can be easily replicated.</div><% end %>
   <% if @node.has_power_tag('replication') %><div class="alert alert-info"><%= raw t('notes.show.replication') %> <a href="/n/<%= @node.power_tag('replication') %>"><%= raw t('notes.show.replication_link') %></a>.</div><% end %>
   <% if @node.has_power_tag('series') %><div class="alert alert-info"><%= raw t('notes.show.series') %> <a href="/tag/series:<%= @node.power_tag('series') %>"><%= @node.power_tag('series') %></a>.</div><% end %>

--- a/config/locales/views/notes/show/en.yml
+++ b/config/locales/views/notes/show/en.yml
@@ -3,7 +3,7 @@
 en:
   notes:
     show:
-      note_no_tags: "This note has no tags yet; help connect it to other content by <a onClick=\"$('#taginput').focus()\">adding descriptive tags below</a>."
+      note_no_tags: "This note has no tags yet; help connect it to other content by <a href='%{url}'>adding descriptive tags below</a>."
       replication: "This is an attempt to replicate "
       series: "This is part of a series on "
       replication_link: "an activity"


### PR DESCRIPTION
Fixes #2768

This PR fixes the 'add descriptive tag below' links that are currently not working.  With these changes, clicking the links moves to the bottom of the page and focuses on the input box.

![descriptive-tag](https://user-images.githubusercontent.com/19399698/40995449-afee23b8-68c4-11e8-88d6-49bf933a47e2.gif)
