### PR TITLE
Delete route for notes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Plots2::Application.routes.draw do
   get 'notes/popular' => 'notes#popular'
   get 'notes/liked' => 'notes#liked'
   get 'notes/image/:id' => 'notes#image'
+  get 'notes/delete/:id' => 'notes#delete'
   post 'notes/delete/:id' => 'notes#delete'
   post 'notes/update/:id' => 'notes#update'
   post 'notes/create' => 'notes#create'


### PR DESCRIPTION
Note deletion was a GET so i'm doing this quickly to re-enable that feature. We should probably set `method="post"` if we can to the delete button.