### PR TITLE
Change like count to avoid flickering to fix issue #2656

### DIFF
--- a/app/controllers/like_controller.rb
+++ b/app/controllers/like_controller.rb
@@ -11,7 +11,7 @@ class LikeController < ApplicationController
   # return a count of likes for a given node
   # This does not support non-nodes very well
   def show
-    render json: Node.find(params[:id]).cached_likes
+    render json: Node.find(params[:id]).likers.length
   end
 
   # for the current user, return whether is presently liked or not

--- a/app/controllers/like_controller.rb
+++ b/app/controllers/like_controller.rb
@@ -11,7 +11,7 @@ class LikeController < ApplicationController
   # return a count of likes for a given node
   # This does not support non-nodes very well
   def show
-    render json: Node.find(params[:id]).likers.length
+    render json: Node.find(params[:id]).likers.count
   end
 
   # for the current user, return whether is presently liked or not

--- a/test/functional/like_controller_test.rb
+++ b/test/functional/like_controller_test.rb
@@ -83,7 +83,7 @@ class LikeControllerTest < ActionController::TestCase
     UserSession.create(User.find(2))
     note = Node.where(type: 'note', status: 1).first
 
-    get :create, id: note.id #first liked
+    get :create, params: { id: note.id } #first liked
 
     note = Node.find note.id
 
@@ -91,19 +91,19 @@ class LikeControllerTest < ActionController::TestCase
     drupal_current_user.moderate    #moderated user
 
     note = Node.find note.id
-    assert_equal note.likers.length, note.cached_likes - 1
+    assert_equal note.likers.count, note.cached_likes - 1
   end
 
   # using likers will exclude moderated and banned users on the likes count
   test 'moderated not included' do
     UserSession.create(User.find(2))
     note = Node.where(type: 'note', status: 1).first
-    likers_length =  note.likers.length
+    likers_length =  note.likers.count
 
-    get :create, id: note.id #first liked
+    get :create, params: { id: note.id } #first liked
 
     note = Node.find note.id
-    assert_equal  likers_length + 1 , note.likers.length
+    assert_equal  likers_length + 1 , note.likers.count
   end
 
 end

--- a/test/functional/like_controller_test.rb
+++ b/test/functional/like_controller_test.rb
@@ -78,4 +78,32 @@ class LikeControllerTest < ActionController::TestCase
     assert_equal cached_likes-1 , note.cached_likes
   end
 
+  # cached likes includes moderated users, whereas likers do not
+  test 'moderated likes' do
+    UserSession.create(User.find(2))
+    note = Node.where(type: 'note', status: 1).first
+
+    get :create, id: note.id #first liked
+
+    note = Node.find note.id
+
+    drupal_current_user = DrupalUser.find 2
+    drupal_current_user.moderate    #moderated user
+
+    note = Node.find note.id
+    assert_equal note.likers.length, note.cached_likes - 1
+  end
+
+  # using likers will exclude moderated and banned users on the likes count
+  test 'moderated not included' do
+    UserSession.create(User.find(2))
+    note = Node.where(type: 'note', status: 1).first
+    likers_length =  note.likers.length
+
+    get :create, id: note.id #first liked
+
+    note = Node.find note.id
+    assert_equal  likers_length + 1 , note.likers.length
+  end
+
 end


### PR DESCRIPTION
This fixes #2656 by changing the like count method `show` on the [like](https://github.com/etalamante/plots2/blob/fixing_issue_2656/app/controllers/like_controller.rb) controller to exclude banned/moderated users.

Also, I added two tests on the [like_controller_test](https://github.com/etalamante/plots2/blob/fixing_issue_2656/test/functional/like_controller_test.rb) file to replicate the bug and to show the like count is working.

With those fixes, the like count would not flick after the page reloads and the number of likes will correspond to the number of users shown on the expanded view.

