### PR TITLE
resolves issue 2799 - Open ID flash notice appears on wrong page

### DIFF
--- a/app/controllers/openid_controller.rb
+++ b/app/controllers/openid_controller.rb
@@ -118,7 +118,7 @@ class OpenidController < ApplicationController
     session[:last_oidreq] = oidreq
     @oidreq = oidreq
 
-    flash[:notice] = message if message
+    flash.now[:notice] = message if message
 
     render template: 'openid/decide'
   end


### PR DESCRIPTION
changed openid_controller.rb line 121 from Flash to Flash.now

Fixes #2799

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x ] code is in uniquely-named feature branch and has no merge conflicts
* [x ] PR is descriptively titled
* [x ] PR body includes `fixes #0000`-style reference to original issue #
* [x ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
