### PR TITLE
resolves issues 2662 - add spam flag to wikis

### DIFF
--- a/app/views/like/_like.html.erb
+++ b/app/views/like/_like.html.erb
@@ -7,6 +7,9 @@
                 </a>
             <% end %>
         <% end %>
+    <a rel="tooltip" title="Flag as spam" class="btn btn-sm btn-default btn-flag-spam-<%= node.id %>" href="mailto:moderators@publiclab.org?subject=Reporting+spam+on+Public+Lab&body=Hi,+I+found+this+item+that+looks+like+spam+or+needs+to+be+moderated:+<%= node.title.gsub(/ /,'+') %>+https://publiclab.org/n/<%= node.id %>+by+https://publiclab.org/profile/<%= node.author.username %>+Thanks!">
+      <i class="fa fa-flag"></i>
+    </a>
     <li class="btn btn-default btn-sm" data-html="true" rel="popover" data-content="<%= "No tags" if tagnames.nil? || tagnames.length == 0 %><% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-default btn-mini'><%= tagname %></a></p><% end %><% end %><hr /><a class='btn btn-sm'><i class='fa fa-user'></i> <%= node.author.name %></a>" title="Follow by tag or author" data-placement="left">
       <i class="fa fa-eye"></i>
       <span class="hidden-xs hidden-sm"> Follow</span>


### PR DESCRIPTION
Fixes #2662

This should pass all tests.  adds a spam notification button to app/views/like/_like.html.erb parital

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x ] code is in uniquely-named feature branch and has no merge conflicts
* [x ] PR is descriptively titled
* [x ] PR body includes `fixes #0000`-style reference to original issue #
* [x ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
