### PR TITLE
Implement API tagging location

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -115,23 +115,24 @@ module Srch
         sresult
       end
 
-      # Request URL should be /api/srch/locations?srchString=QRY[&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
+      # Request URL should be /api/srch/taglocations?srchString=QRY[&tagName=awesome&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
       # Note: Query(QRY as above) must have latitude and longitude as srchString=lat,lon
-      desc 'Perform a search of documents having nearby latitude and longitude tag values',
+      desc 'Perform a search of documents having nearby latitude, longitude and tag values',
         hidden: false,
         is_array: false,
-        nickname: 'srchGetLocations'
+        nickname: 'srchGetTagLocations'
       params do
         requires :srchString, type: String, documentation: { example: 'Spec' }
+        optional :tagName, type: String, documentation: { example: 'awesome' }
         optional :seq, type: Integer, documentation: { example: 995 }
         optional :showCount, type: Integer, documentation: { example: 3 }
         optional :pageNum, type: Integer, documentation: { example: 0 }
       end
-      get :locations do
+      get :taglocations do
         sresult = DocList.new
         unless params[:srchString].nil? || params[:srchString] == 0 || !(params[:srchString].include? ",")
           sservice = SearchService.new
-          sresult = sservice.nearbyNodes(params[:srchString])
+          sresult = sservice.tagNearbyNodes(params[:srchString], params[:tag])
         end
         sparms = SearchRequest.fromRequest(params)
         sresult.srchParams = sparms

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -132,7 +132,7 @@ module Srch
         sresult = DocList.new
         unless params[:srchString].nil? || params[:srchString] == 0 || !(params[:srchString].include? ",")
           sservice = SearchService.new
-          sresult = sservice.tagNearbyNodes(params[:srchString], params[:tag])
+          sresult = sservice.tagNearbyNodes(params[:srchString], params[:tagName])
         end
         sparms = SearchRequest.fromRequest(params)
         sresult.srchParams = sparms
@@ -155,7 +155,7 @@ module Srch
       end
       get :peoplelocations do
         sresult = DocList.new
-        unless params[:srchString].nil? || params[:srchString] == 0 
+        unless params[:srchString].nil? || params[:srchString] == 0
           sservice = SearchService.new
           sresult = sservice.recentPeople(params[:srchString], params[:tagName])
         end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -196,12 +196,15 @@ class SearchService
     sresult
   end
 
-  # Search nearby nodes with respect to given latitude and longitude
-  def nearbyNodes(srchString)
+  # Search nearby nodes with respect to given latitude, longitute and tags
+  def tagNearbyNodes(srchString, tag)
     sresult = DocList.new
     coordinates = srchString.split(",")
     lat = coordinates[0]
     lon = coordinates[1]
+
+    tagList = textSearch_tags(tag)
+    sresult.addAll(tagList.items)
 
     nids = NodeTag.joins(:tag)
       .where('name LIKE ?', 'lat:' + lat[0..lat.length - 2] + '%')

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -205,10 +205,12 @@ class SearchService
       .where('name LIKE ?', 'lat:' + lat[0..lat.length - 2] + '%')
 
     if tagName.present?
-      nodes_scope = nodes_scope.where('name LIKE ?', tagName)
+      nodes_scope = NodeTag.joins(:tag)
+                           .where('name LIKE ?', tagName)
+                           .where(nid: nodes_scope.select(:nid))
     end
 
-    nids = nodes_scope.collect(&:nid) || []
+    nids = nodes_scope.collect(&:nid).uniq || []
 
     items = Node.includes(:tag)
       .references(:node, :term_data)

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -23,7 +23,7 @@ class SearchApiTest < ActiveSupport::TestCase
 
      json = JSON.parse(last_response.body)
 
-     assert_equal nodes(:blog).path,  json['items'][0]['docUrl']
+     assert_equal nodes(:blog).path, json['items'][0]['docUrl']
      assert_equal "Blog post",       json['items'][0]['docTitle']
      assert_equal 13,                json['items'][0]['docId']
 
@@ -49,7 +49,7 @@ class SearchApiTest < ActiveSupport::TestCase
 
      assert_equal "/profile/jeff", json['items'][0]['docUrl']
      assert_equal "jeff",          json['items'][0]['docTitle']
-     assert_equal "user",               json['items'][0]['docType']
+     assert_equal "user",          json['items'][0]['docType']
 
      assert matcher =~ json
 
@@ -119,16 +119,17 @@ class SearchApiTest < ActiveSupport::TestCase
      json = JSON.parse(last_response.body)
      assert matcher =~ json
 
-    end
+  end
 
-  test 'search nearby nodes functionality' do
-    get '/api/srch/locations?srchString=71.00,52.00'
+  test 'search Tag Nearby Nodes functionality' do
+    get '/api/srch/taglocations?srchString=71.00,52.00&tagName=awesome'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
             srchString: '71.00,52.00',
+            tagName: 'awesome',
             seq: nil,
         }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -136,11 +137,6 @@ class SearchApiTest < ActiveSupport::TestCase
     matcher = JsonExpressions::Matcher.new(pattern)
 
     json = JSON.parse(last_response.body)
-
-    assert_equal nodes(:blog).path, json['items'][0]['docUrl']
-    assert_equal "Blog post",       json['items'][0]['docTitle']
-    assert_equal 13,                json['items'][0]['docId']
-
     assert matcher =~ json
 
   end
@@ -162,8 +158,8 @@ class SearchApiTest < ActiveSupport::TestCase
     json = JSON.parse(last_response.body)
 
     assert_equal users(:bob).username, json['items'][0]['docTitle']
-    assert_equal "people_coordinates",       json['items'][0]['docType']
-    assert_equal 1,                json['items'][0]['docId']
+    assert_equal "people_coordinates", json['items'][0]['docType']
+    assert_equal 1,                    json['items'][0]['docId']
 
     assert matcher =~ json
 
@@ -187,8 +183,8 @@ class SearchApiTest < ActiveSupport::TestCase
     json = JSON.parse(last_response.body)
 
     assert_equal users(:bob).username, json['items'][0]['docTitle']
-    assert_equal "people_coordinates",       json['items'][0]['docType']
-    assert_equal 1,                json['items'][0]['docId']
+    assert_equal "people_coordinates", json['items'][0]['docType']
+    assert_equal 1,                    json['items'][0]['docId']
 
     assert matcher =~ json
 

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -138,32 +138,6 @@ class SearchApiTest < ActiveSupport::TestCase
 
     json = JSON.parse(last_response.body)
 
-    assert_equal "coordinates",        json['items'][0]['docType']
-    assert_equal 13,                   json['items'][0]['docId']
-
-    assert matcher =~ json
-
-  end
-
-  test 'search Tag Nearby Nodes functionality without tagName' do
-    get '/api/srch/taglocations?srchString=71.00,52.00'
-    assert last_response.ok?
-
-    # Expected search pattern
-    pattern = {
-        srchParams: {
-            srchString: '71.00,52.00',
-            seq: nil,
-        }.ignore_extra_keys!
-    }.ignore_extra_keys!
-
-    matcher = JsonExpressions::Matcher.new(pattern)
-
-    json = JSON.parse(last_response.body)
-
-    assert_equal "coordinates",        json['items'][0]['docType']
-    assert_equal 13,                   json['items'][0]['docId']
-
     assert matcher =~ json
 
   end

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -137,6 +137,33 @@ class SearchApiTest < ActiveSupport::TestCase
     matcher = JsonExpressions::Matcher.new(pattern)
 
     json = JSON.parse(last_response.body)
+
+    assert_equal "coordinates",        json['items'][0]['docType']
+    assert_equal 13,                   json['items'][0]['docId']
+
+    assert matcher =~ json
+
+  end
+
+  test 'search Tag Nearby Nodes functionality without tagName' do
+    get '/api/srch/taglocations?srchString=71.00,52.00'
+    assert last_response.ok?
+
+    # Expected search pattern
+    pattern = {
+        srchParams: {
+            srchString: '71.00,52.00',
+            seq: nil,
+        }.ignore_extra_keys!
+    }.ignore_extra_keys!
+
+    matcher = JsonExpressions::Matcher.new(pattern)
+
+    json = JSON.parse(last_response.body)
+
+    assert_equal "coordinates",        json['items'][0]['docType']
+    assert_equal 13,                   json['items'][0]['docId']
+
     assert matcher =~ json
 
   end


### PR DESCRIPTION
Improve API location search (#1934 ) to also include tags on the request URL.

Fix #2790 and  #2254 

* [ ✔️] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [✔️ ] code is in uniquely-named feature branch and has no merge conflicts
* [✔️ ] PR is descriptively titled
* [✔️ ] PR body includes `fixes #0000`-style reference to original issue #
* [✔️ ] ask `@publiclab/reviewers` for help, in a comment below



