### PR TITLE
Add OmniAuth Configuration to initializer for Github

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,8 @@
+#this file is used to store the variable needed for omniauth login and signup
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, ENV["google_app_key"],ENV["google_app_secret"] , skip_jwt: true
-  provider :facebook, ENV["APP_ID"],ENV["APP_SECRET"] , skip_jwt: true
+  #the provider is google_oauth2 and the app-key of google developers app is stored in OAUTH_GOOGLE_APP_KEY
+  #the app-secret of google developers app is stored in variable OAUTH_GOOGLE_APP_SECRET
+  provider :google_oauth2, ENV["OAUTH_GOOGLE_APP_KEY"],ENV["OAUTH_GOOGLE_APP_SECRET"] , skip_jwt: true
+  #For provider github, app_id is stored in
+  provider :github, ENV["OAUTH_GITHUB_APP_KEY"], ENV["OAUTH_GITHUB_APP_SECRET"], { scope: 'user:email' }
 end


### PR DESCRIPTION
Fixes ``Github`` Provider's ``Add OmniAuth Configuration to the initializer`` listed in the checklist #2676