### PR TITLE
Update 'learn more' link near draft checkbox (#2904)

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -189,7 +189,7 @@
     <span class="ple-help pull-right">
       <% if controller.action_name != "edit" && !current_user.first_time_poster %>
         <span id="newOpts" style="display: inline-block;">
-          <span id="text" style="display: none; color:red;">Others won't be able to see this until you're ready <a href="#" >Learn more</a>&nbsp; &nbsp;</span>
+        <span id="text" style="display: none; color:red;">Others won't be able to see this until you're ready <a href="https://publiclab.org/wiki/draft-feature" targrt="_blank">Learn more</a>&nbsp; &nbsp;</span>
           <span><input type="checkbox" id="myCheck" onclick="draftCheck()">Save as draft&nbsp; | &nbsp;</span>
           <span class="ple-steps-left">2</span>
           <span class="hidden-xs"> steps left</span>


### PR DESCRIPTION
Fixes #2904 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
