### PR TITLE
Don't allow new users to use '/wiki/new'

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -118,6 +118,11 @@ class WikiController < ApplicationController
   end
 
   def new
+    if current_user && current_user.first_time_poster
+      flash[:notice] = "Please post a question or other content before editing the wiki. Click <a href='https://publiclab.org/notes/tester/04-23-2016/new-moderation-system-for-first-time-posters'>here</a> to learn why."
+      redirect_to '/'
+      return
+    end
     @node = Node.new
     if params[:n] && !params[:body] # use another node body as a template
       node = Node.find(params[:n])

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -118,7 +118,7 @@ class WikiController < ApplicationController
   end
 
   def new
-    if current_user && current_user.first_time_poster
+    if current_user &.first_time_poster
       flash[:notice] = "Please post a question or other content before editing the wiki. Click <a href='https://publiclab.org/notes/tester/04-23-2016/new-moderation-system-for-first-time-posters'>here</a> to learn why."
       redirect_to '/'
       return

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -39,7 +39,7 @@ class WikiControllerTest < ActionController::TestCase
   end
 
   test "should use existing node body as template in post form based on param 'n'" do
-    UserSession.create(users(:bob))
+    UserSession.create(users(:test_user))
 
     get :new,
         params: { 
@@ -576,8 +576,9 @@ class WikiControllerTest < ActionController::TestCase
   end
 
   test "Invalid date tags aren't added" do
+    @user = UserSession.create(users(:jeff))
     @node = nodes(:wiki_page)
-    @node.add_tag('date:bad', users(:jeff))
+    @node.add_tag('date:bad', @user)
 
     assert_equal false, @node.has_power_tag('date')
     # assert_equal "anything goes", DateTime.strptime(@node.power_tag('date'),'%m- %d-%Y').to_date.to_s(:long)


### PR DESCRIPTION
Fixes #2889

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [✔️] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [✔️] code is in uniquely-named feature branch and has no merge conflicts
* [✔️] PR is descriptively titled
* [✔️] PR body includes `fixes #0000`-style reference to original issue #
* [✔️] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
