### PR TITLE
#2761 added redirect_to '/dashboard' + '?_=' + Time.now.to_i.to_s in user-c…           

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -111,7 +111,7 @@ class AdminController < ApplicationController
         @node.author.ban
         AdminMailer.notify_moderators_of_spam(@node, current_user).deliver_now
         flash[:notice] = "Item marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>."
-        redirect_to '/dashboard'
+        redirect_to '/dashboard' + '?_=' + Time.now.to_i.to_s
       else
         flash[:notice] = "Item already marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>."
         redirect_to '/dashboard'
@@ -138,7 +138,7 @@ class AdminController < ApplicationController
     else
       flash[:error] = 'Only moderators can moderate comments.'
     end
-    redirect_to '/dashboard'
+    redirect_to '/dashboard' + '?_=' + Time.now.to_i.to_s
   end
 
   def publish_comment

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -187,7 +187,7 @@ class AdminControllerTest < ActionController::TestCase
     node = assigns(:node)
     assert_equal 0, node.status
     assert_equal 0, node.author.status
-    assert_redirected_to '/dashboard'
+    assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
 
     email = ActionMailer::Base.deliveries.last
     assert_not_nil email.to
@@ -205,7 +205,7 @@ class AdminControllerTest < ActionController::TestCase
 
     assert_equal "Item already marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>.", flash[:notice]
     assert_equal 0, nodes(:spam).status
-    assert_redirected_to '/dashboard'
+    assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
   end
 
   test 'normal user should not be able to unspam a note' do
@@ -423,7 +423,7 @@ class AdminControllerTest < ActionController::TestCase
     comment = assigns(:comment)
     assert_equal 0, comment.status
     assert_equal "Comment has been marked as spam.", flash[:notice]
-    assert_redirected_to '/dashboard'
+    assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
   end
 
   test 'should mark comment as spam if admin' do


### PR DESCRIPTION
…ontroller

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
