### PR TITLE
Move sidebar to right side of research note and wiki pages #3091

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,7 +1,5 @@
 <script src="/assets/notes.js" type="text/javascript"></script>
 
-<%= render :partial => "sidebar/related" %>
-
 <div class="col-md-9 note-show<% if @node.status == 4 || @node.status == 0 %> moderated<% end %>">
   <% if current_user && @node.tags.length == 0 %><div class="alert alert-warning"><%= raw t('notes.show.note_no_tags', url: 'javascript: $(".tag-input").focus();') %></div><% end %>
   <% if @node.has_power_tag('status:candidate') %><div class="alert alert-info">This was marked as a candidate activity -- <a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity" >read about how to adapt its content</a> into a fully-fledged, step-by-step activity that can be easily replicated.</div><% end %>
@@ -119,3 +117,5 @@
   </div>
 
 </div><!--/span-->
+
+<%= render :partial => "sidebar/related" %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -4,8 +4,6 @@
 <script> var comments_length = <%= @node.comments.length %>; </script>
 <%= javascript_include_tag('question') %>
 
-<%= render :partial => "sidebar/question" %>
-
 <div class="col-md-9 note-show question-show">
 
    <% if @node.main_image %>
@@ -73,3 +71,5 @@
   <%= render :partial => "questions/answers" %>
 
 </div>
+
+<%= render :partial => "sidebar/question" %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -26,19 +26,11 @@
 <% end %>
 
 <% if @node.has_tag('sidebar:none') %>
-  <div class="col-md-2"></div>
-
   <div class="col-md-8">
-<% else %>  
-  <% if (@wikis.nil? && @notes.nil?) || @node.has_tag('sidebar:featured') %>
-    <%= render :partial => "sidebar/featured" %>
-  <% else %>
-    <%= render :partial => "sidebar/related" %>
-  <% end %>
-    
+<% else %>
   <div class="col-md-9">
 <% end %>
-    
+
   <%= render :partial => "wiki/header" %>
 
   <div class="tab-content">
@@ -97,6 +89,12 @@
   </div>
 
 </div>
+
+<% if (@wikis.nil? && @notes.nil?) || @node.has_tag('sidebar:featured') %>
+  <%= render :partial => "sidebar/featured" %>
+<% else %>
+  <%= render :partial => "sidebar/related" %>
+<% end %>
 
 <script>
 (function(){

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -90,10 +90,12 @@
 
 </div>
 
-<% if (@wikis.nil? && @notes.nil?) || @node.has_tag('sidebar:featured') %>
-  <%= render :partial => "sidebar/featured" %>
-<% else %>
-  <%= render :partial => "sidebar/related" %>
+<% unless @node.has_tag('sidebar:none') %>
+  <% if (@wikis.nil? && @notes.nil?) || @node.has_tag('sidebar:featured') %>
+    <%= render :partial => "sidebar/featured" %>
+  <% else %>
+    <%= render :partial => "sidebar/related" %>
+  <% end %>
 <% end %>
 
 <script>


### PR DESCRIPTION
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
-------

This PR fixes #3091, which is about moving the sidebar on research notes, questions, and wiki pages.