### PR TITLE
Refactor typeahead service

### DIFF
--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -14,5 +14,10 @@ module Srch
     params :additional do
       optional :tagName, type: String, documentation: { example: 'awesome' }
     end
+
+    params :commontypeahead do
+      requires :srchString, type: String, documentation: { example: 'Spec' }
+      optional :seq, type: Integer, documentation: { example: 995 }
+    end
   end
 end

--- a/app/services/execute_typeahead.rb
+++ b/app/services/execute_typeahead.rb
@@ -1,0 +1,28 @@
+class ExecuteTypeahead
+  def by(type, search_criteria, limit)
+    execute(type, search_criteria, limit)
+  end
+
+  private
+
+  def execute(type, search_criteria, limit)
+    sservice = TypeaheadService.new
+    sresult = TagList.new
+    case type
+      when :all
+        sresult = sservice.search_all(search_criteria.query, limit)
+      when :profiles
+        sresult = sservice.search_profiles(search_criteria.query, limit)
+      when :notes
+        sresult = sservice.search_notes(search_criteria.query, limit)
+      when :questions
+        sresult = sservice.search_questions(search_criteria.query, limit)
+      when :tags
+        sresult = sservice.search_tags(search_criteria.query, limit)
+      when :comments
+        sresult = sservice.search_comments(search_criteria.query, limit)
+      else
+        sresult = []
+      end
+    end
+end

--- a/app/services/execute_typeahead.rb
+++ b/app/services/execute_typeahead.rb
@@ -8,21 +8,21 @@ class ExecuteTypeahead
   def execute(type, search_criteria, limit)
     sservice = TypeaheadService.new
     sresult = TagList.new
-    case type
+    result = case type
       when :all
-        sresult = sservice.search_all(search_criteria.query, limit)
+        sservice.search_all(search_criteria.query, limit)
       when :profiles
-        sresult = sservice.search_profiles(search_criteria.query, limit)
+        sservice.search_profiles(search_criteria.query, limit)
       when :notes
-        sresult = sservice.search_notes(search_criteria.query, limit)
+        sservice.search_notes(search_criteria.query, limit)
       when :questions
-        sresult = sservice.search_questions(search_criteria.query, limit)
+        sservice.search_questions(search_criteria.query, limit)
       when :tags
-        sresult = sservice.search_tags(search_criteria.query, limit)
+        sservice.search_tags(search_criteria.query, limit)
       when :comments
-        sresult = sservice.search_comments(search_criteria.query, limit)
+        sservice.search_comments(search_criteria.query, limit)
       else
-        sresult = []
+        []
       end
     end
 end

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -71,7 +71,6 @@ class SearchApiTest < ActiveSupport::TestCase
        matcher = JsonExpressions::Matcher.new(pattern)
 
        json = JSON.parse(last_response.body)
-       puts json.inspect
        assert matcher =~ json
 
      end

--- a/test/functional/typeahead_api_test.rb
+++ b/test/functional/typeahead_api_test.rb
@@ -1,9 +1,5 @@
 require 'test_helper'
 
-# TODO:  Rework to get better inclusion of JsonExpressions pattern matching
-# TODO:  Add tests for negative matches--check echo of search parameters and null result
-# HACK:  Parameterize the 'get' URLs to make passing and changing test values easier
-
 class TypeaheadApiTest < ActiveSupport::TestCase
   include Rack::Test::Methods
 
@@ -11,128 +7,117 @@ class TypeaheadApiTest < ActiveSupport::TestCase
     Rails.application
   end
 
-  def setup
-    @stxt = 'lat'
-    @sprofile = 'adm'
-    @stags = 'everything'
-    @sseq = 7
-    @scom = 'comm'
-  end
-
   test 'typeahead all functionality' do
-    get '/api/typeahead/all?srchString=lat&seq=7'
+    get '/api/typeahead/all?srchString=Blog'
     assert last_response.ok?
 
     # Expected typeahead pattern
     pattern = {
-      # TODO:  Need more/better understanding and data for the test database
-      # return will be nil for now
-      # items: nil,
       srchParams: {
-        srchString: @stxt,
-        seq: @sseq
+        srchString: 'Blog',
+        seq: nil
       }.ignore_extra_keys!
     }.ignore_extra_keys!
 
     matcher = JsonExpressions::Matcher.new(pattern)
 
-    assert matcher =~ JSON.parse(last_response.body)
+    json = JSON.parse(last_response.body)
+
+    assert matcher =~ json
   end
 
   test 'typeahead profile functionality' do
-    get '/api/typeahead/profiles?srchString=adm&seq=7'
+    get '/api/typeahead/profiles?srchString=Jeff'
     assert last_response.ok?
 
     # Expected profile response pattern
     pattern = {
-      # TODO:  Need more/better understanding and data for the test database
-      # return will be nil for now
-      # items: nil,
       srchParams: {
-        srchString: @sprofile,
-        seq: @sseq
+        srchString: 'Jeff',
+        seq: nil
       }.ignore_extra_keys!
     }.ignore_extra_keys!
 
     matcher = JsonExpressions::Matcher.new(pattern)
 
-    assert matcher =~ JSON.parse(last_response.body)
+    json = JSON.parse(last_response.body)
+
+    assert matcher =~ json
   end
 
   test 'typeahead notes functionality' do
-    get '/api/typeahead/notes?srchString=lat&seq=7'
+    get '/api/typeahead/notes?srchString=Blog'
     assert last_response.ok?
 
     # Expected notes pattern
     pattern = {
-      # TODO:  Need more/better understanding and data for the test database
-      # return will be nil for now
-      # items: nil,
       srchParams: {
-        srchString: @stxt,
-        seq: @sseq
+        srchString: 'Blog',
+        seq: nil
       }.ignore_extra_keys!
     }.ignore_extra_keys!
 
     matcher = JsonExpressions::Matcher.new(pattern)
 
-    assert matcher =~ JSON.parse(last_response.body)
+    json = JSON.parse(last_response.body)
+
+    assert matcher =~ json
   end
 
   test 'typeahead questions functionality' do
-    get '/api/typeahead/questions?srchString=lat&seq=7'
+    get '/api/typeahead/questions?srchString=Question'
     assert last_response.ok?
 
     # Expected question pattern
-    #  Returns null right now for test--need to set a better search sequence on demo seed data
     pattern = {
-      # TODO:  Need more/better understanding and data for the test database
-      # return will be nil for now
-      # items: nil,
       srchParams: {
-        srchString: @stxt,
-        seq: @sseq
-      }.ignore_extra_keys!
-    }.ignore_extra_keys!
+        srchString: 'Question',
+        seq: nil,
+       }.ignore_extra_keys!
+     }.ignore_extra_keys!
 
-    matcher = JsonExpressions::Matcher.new(pattern)
+     matcher = JsonExpressions::Matcher.new(pattern)
 
-    assert matcher =~ JSON.parse(last_response.body)
+     json = JSON.parse(last_response.body)
+
+     assert matcher =~ json
   end
 
   test 'typeahead tags functionality' do
-    get '/api/typeahead/tags?srchString=everything&seq=7'
+    get '/api/typeahead/tags?srchString=everything'
     assert last_response.ok?
 
     # Expected tag pattern
     pattern = {
-      # TODO:  Need more/better understanding and data for the test database
-      # return will be nil for now
-      # items: nil,
       srchParams: {
-        srchString: @stags,
-        seq: @sseq
+        srchString: 'everything',
+        seq: nil
       }.ignore_extra_keys!
     }.ignore_extra_keys!
 
     matcher = JsonExpressions::Matcher.new(pattern)
 
-    assert matcher =~ JSON.parse(last_response.body)
+    json = JSON.parse(last_response.body)
+
+    assert matcher =~ json
   end
 
   test 'typeahead comments functionality' do
-    get '/api/typeahead/comments?srchString=comm&seq=7'
+    get '/api/typeahead/comments?srchString=comment'
     assert last_response.ok?
 
     # Expected comment pattern
     pattern = {
       srchParams: {
-        srchString: @scom,
-        seq: @sseq
+        srchString: 'comment',
+        seq: nil
       }.ignore_extra_keys!
-    }.ignore_extra_keys! 
+    }.ignore_extra_keys!
+
     matcher = JsonExpressions::Matcher.new(pattern)
 
-    assert matcher =~ JSON.parse(last_response.body)    
+    json = JSON.parse(last_response.body)
+
+    assert matcher =~ json
   end
 end


### PR DESCRIPTION
As part of #3070 (Refactor Search API) we are opening this PR to remove API Typeahead endpoints duplication. The changes are prety similar to what we did here, but this time we worked on Typeahead endpoints.

Again, we decided to first try to remove some duplications/refactor the code and later improve the searches.

We would like some feedback about our work here, please! :)

@publiclab/reviewers @publiclab/soc @jywarren