### PR TITLE
Search endpoint most recently people

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -34,6 +34,18 @@ module Srch
         Search.execute(:profiles, params)
       end
 
+      # Request URL should be /api/srch/recentprofiles?srchString=QRY[&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
+      desc 'Perform a search of profiles', hidden: false,
+                                           is_array: false,
+                                           nickname: 'srchGetRecentProfiles'
+
+      params do
+        use :common
+      end
+      get :recentprofiles do
+        Search.execute(:recentprofiles, params)
+      end
+
       # Request URL should be /api/srch/notes?srchString=QRY[&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
       # Basic implementation from classic plots2 SearchController
       desc 'Perform a search of research notes', hidden: false,

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -13,6 +13,8 @@ class ExecuteSearch
        sresult = sservice.textSearch_all(search_criteria.query)
      when :profiles
        sresult = sservice.textSearch_profiles(search_criteria.query)
+     when :recentprofiles
+       sresult = sservice.textSearch_recentProfiles(search_criteria.query)
      when :notes
        sresult = sservice.textSearch_notes(search_criteria.query)
      when :questions

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -131,7 +131,6 @@ class SearchService
     sresult
   end
 
-  #####################################################################################
   # Search for more recently updated profiles for matching text
   def textSearch_recentProfiles(srchString)
     sresult = DocList.new
@@ -155,7 +154,6 @@ class SearchService
 
     sresult
   end
-  #####################################################################################
 
   # Search notes for matching strings
   def textSearch_notes(srchString)
@@ -280,7 +278,7 @@ class SearchService
       end
     end
     users = users.uniq
-    count = 0 # TODO: fazer de maneira mais bonita em Ruby
+    count = 0
     users.each do |user|
       next unless user.has_power_tag("lat") && user.has_power_tag("lon")
       blurred = false

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -131,6 +131,32 @@ class SearchService
     sresult
   end
 
+  #####################################################################################
+  # Search for more recently updated profiles for matching text
+  def textSearch_recentProfiles(srchString)
+    sresult = DocList.new
+
+    nodes = Node.all.order("changed DESC").limit(100).distinct
+    users = []
+    nodes.each do |node|
+      next unless node.author.status != 0
+      if node.author.name.downcase.include? srchString.downcase
+        users << node.author.user
+      end
+    end
+
+    users = users.uniq
+
+    # User profiles
+    users.each do |match|
+      doc = DocResult.fromSearch(0, 'user', '/profile/' + match.name, match.name, '', 0)
+      sresult.addDoc(doc)
+    end
+
+    sresult
+  end
+  #####################################################################################
+
   # Search notes for matching strings
   def textSearch_notes(srchString)
     sresult = DocList.new
@@ -242,7 +268,7 @@ class SearchService
   def recentPeople(srchString, tagName = nil)
     sresult = DocList.new
 
-    nodes = Node.all.order("changed DESC").limit(srchString).distinct
+    nodes = Node.all.order("changed DESC").limit(100).distinct
     users = []
     nodes.each do |node|
       if node.author.status != 0
@@ -254,6 +280,7 @@ class SearchService
       end
     end
     users = users.uniq
+    count = 0 # TODO: fazer de maneira mais bonita em Ruby
     users.each do |user|
       next unless user.has_power_tag("lat") && user.has_power_tag("lon")
       blurred = false
@@ -262,6 +289,10 @@ class SearchService
       end
       doc = DocResult.fromLocationSearch(user.id, 'people_coordinates', user.path, user.username, 0, 0, user.lat, user.lon, blurred)
       sresult.addDoc(doc)
+      count += 1
+      if count == srchString.to_i
+        break
+      end
     end
 
     sresult

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -99,6 +99,30 @@ class SearchApiTest < ActiveSupport::TestCase
 
    end
 
+   test 'search recent profiles functionality' do
+     get '/api/srch/recentprofiles?srchString=Jeff'
+     assert last_response.ok?
+
+     # Expected search pattern
+     pattern = {
+       srchParams: {
+         srchString: 'Jeff',
+         seq: nil,
+       }.ignore_extra_keys!
+     }.ignore_extra_keys!
+
+     matcher = JsonExpressions::Matcher.new(pattern)
+
+     json = JSON.parse(last_response.body)
+
+     assert_equal "/profile/jeff", json['items'][0]['docUrl']
+     assert_equal "jeff",          json['items'][0]['docTitle']
+     assert_equal "user",          json['items'][0]['docType']
+
+     assert matcher =~ json
+
+   end
+
   test 'search notes functionality' do
       get '/api/srch/notes?srchString=Blog'
       assert last_response.ok?


### PR DESCRIPTION
Hey everyone!

We are opening this request to fix the issue #3069. 

1. We created a new endpoint `recentprofiles` that returns the profiles with most recent activity.
2. We fixed `recentPeople` method. In one of our latest PR (#3045) we did the following change that was not correct. Because in this part of the code the limit is for the node search. So we undid this change and added a count to control the number of profiles returned ([line 290](https://github.com/publiclab/plots2/pull/3126/files#diff-9546dd6074cdca7a128c2bf04fa5367aR290)).

>nodes = Node.all.order("changed DESC").limit(100).distinct -> nodes = Node.all.order("changed DESC").limit(srchString).distinct

3. We don't think the name of the `recentPeople` method is appropriate for the `peopleLocations` endpoint, since the method returns the location of people with most recent activity with a specific tag. Can we change it to `peopleLocations`? So maybe we can use `recentPeople` for our new method.

We would like some feedback about our strategy here, thank you! :)

fixes #3069 
@publiclab/reviewers @publiclab/soc @jywarren