### PR TITLE
#3121 Moved tagging system to sidebar in notes, questions, wikis

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -229,8 +229,13 @@ body { padding-top: 70px; }
 
 #tags .label {
   line-height: 2em;
-  font-size: 13px;
-  margin-right: 4px;
+  font-size: 16px;
+  margin: 0px;
+}
+
+#tags li {
+  margin: 0px;
+  padding: 0px;
 }
 
 /* Styles for specific areas of the site */

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -108,9 +108,6 @@
 
     <%= render :partial => "home/social" %>
 
-    <hr />
-
-    <%= render :partial => "tag/tagging" %>
     <div>
       <%= render :partial => "notes/comments" %>
     </div>
@@ -118,4 +115,4 @@
 
 </div><!--/span-->
 
-<%= render :partial => "sidebar/related" %>
+<%= render :partial => "sidebar/related", :locals => {:include_tagging => true} %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -48,10 +48,6 @@
 
   <hr />
 
-  <%= render :partial => "tag/tagging" %>
-
-  <hr />
-
   <h3><span id="answer-0-comment-count"><%= @node.comments.length %></span> Comments</h3>
     <% @node.comments.order("timestamp ASC").each do |comment| %>
       <%= render :partial => "notes/comment", :locals => {:comment => comment} %>

--- a/app/views/sidebar/_featured.html.erb
+++ b/app/views/sidebar/_featured.html.erb
@@ -1,3 +1,5 @@
+<%include_tagging = local_assigns.fetch :include_tagging, false #not all things using this sidebar uses tagging%>
+
 <div class="col-md-3">
 
   <% if params[:controller] != "home" && params[:action] != "home" %>
@@ -6,6 +8,10 @@
 
   <% cache('feature_sidebar-feature', skip_digest: true) do %>
     <%= feature('sidebar-feature') %>
+  <% end %>
+
+  <% if include_tagging %>
+    <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
   <% end %>
 
 </div>

--- a/app/views/sidebar/_none.html.erb
+++ b/app/views/sidebar/_none.html.erb
@@ -1,0 +1,3 @@
+<div class="col-md-3 hidden-print">
+  <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
+</div>

--- a/app/views/sidebar/_question.html.erb
+++ b/app/views/sidebar/_question.html.erb
@@ -3,8 +3,6 @@
   <a style="margin-top:-16px;margin-bottom:0;" class="btn btn-mini btn-block btn-link visible-xs visible-sm" href="javascript:void()" onClick="toggle_sidebar()"><i class="fa fa-chevron-down"></i></a>
 
   <div id="sidebar" class="hidden-xs hidden-sm">
-  
-    <a style="margin-bottom:6px;" rel="tooltip" title="Ask a question to the community" data-placement="bottom" href="/post?tags=question:question&template=question&redirect=question" class="btn btn-primary btn-lg btn-block hidden-sm"><i class="fa fa-question-circle fa-white"></i> Ask a Question</a>
 
     <a rel="tooltip" title="Ask question<% if @tagnames %> about <%= (@tagnames.uniq.collect {|x| x.gsub(/[\w-]+:/, '') }).join(',') %><% end %>" data-placement="bottom" href="/post<%= '?tags=' + @tagnames.uniq.join(',') if @tagnames %>&template=question&redirect=question" class="btn btn-primary btn-lg btn-block"><i class="fa fa-question-circle fa-white"></i> Ask related question &raquo;</a>
 

--- a/app/views/sidebar/_question.html.erb
+++ b/app/views/sidebar/_question.html.erb
@@ -27,5 +27,7 @@
     <%= render partial: 'sidebar/notes', locals: { notes: @notes, title: "Related Questions", node: @node } %>
 
   </div>
+
+  <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
 </div>
 <%= javascript_include_tag 'sidebar' %>

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -1,3 +1,5 @@
+<%include_tagging = local_assigns.fetch :include_tagging, false #not all things using this sidebar uses tagging%>
+
 <div class="col-md-3 hidden-print">
 
   <a style="margin-top:-16px;margin-bottom:0;" class="btn btn-mini btn-block btn-link visible-xs visible-sm" href="javascript:void()" onClick="toggle_sidebar()"><i class="fa fa-chevron-down"></i></a>
@@ -102,7 +104,9 @@
 
   <% end %>
 
-  <hr style="margin-bottom:6px;" />
+  <% if include_tagging %>
+    <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
+  <% end %>
 
   </div>
 </div>

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -1,15 +1,20 @@
 <%sidebar_tagging = local_assigns.fetch :sidebar_tagging, false #preserves user, map tagging orientation %>
 
+<% if sidebar_tagging %>
+  <h1>Tags</h1>
+  <em class="italics">Tags help organize our knowledge base. Click to find more on a topic.</em>
+<% end %>
+
 <% if @node %>
   <%= render partial: 'tag/replication' %>
 
   <span id="tags">
-  <%= render partial: 'tag/tags', locals: { power_tag: true, label_name: 'label-default', tags: @node.node_tags, sidebar_tagging: sidebar_tagging } %>
-  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @node.node_tags, sidebar_tagging: sidebar_tagging } %>
+  <%= render partial: 'tag/tags', locals: { power_tag: true, label_name: 'label-default', tags: @node.node_tags } %>
+  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @node.node_tags } %>
   </span>
 <% else %>
   <span id="tags">
-  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @user.user_tags, sidebar_tagging: sidebar_tagging } %>
+  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @user.user_tags } %>
   </span>
 <% end %>
 

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -1,13 +1,15 @@
+<%sidebar_tagging = local_assigns.fetch :sidebar_tagging, false #preserves user, map tagging orientation %>
+
 <% if @node %>
   <%= render partial: 'tag/replication' %>
 
   <span id="tags">
-  <%= render partial: 'tag/tags', locals: { power_tag: true, label_name: 'label-default', tags: @node.node_tags } %>
-  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @node.node_tags } %>
+  <%= render partial: 'tag/tags', locals: { power_tag: true, label_name: 'label-default', tags: @node.node_tags, sidebar_tagging: sidebar_tagging } %>
+  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @node.node_tags, sidebar_tagging: sidebar_tagging } %>
   </span>
 <% else %>
   <span id="tags">
-  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @user.user_tags } %>
+  <%= render partial: 'tag/tags', locals: { power_tag: false, label_name: 'label-primary', tags: @user.user_tags, sidebar_tagging: sidebar_tagging } %>
   </span>
 <% end %>
 
@@ -43,7 +45,7 @@ $(".label").on("click", function(e){
 <form id="tagform" class="form" data-remote="true" action="<%= url %>">
   <div class="control-group">
     <input name="remote" type="hidden" value="true" />
-    <div class="input-group col-md-6">
+    <div class="<%= sidebar_tagging ? 'input-group' : 'input-group col-md-6' =%>">
       <span class="input-group-addon"><i class="fa fa-tags"></i></span>
       <input autocomplete="off" class="tag-input form-control" name="name" type="text" placeholder="<%= t('tag._tagging.enter_tags') %>" data-provide="typeahead" />
       <div class="input-group-btn">

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,6 +1,4 @@
-<%sidebar_tagging = local_assigns.fetch :sidebar_tagging, false #preserves user, map tagging orientation %>
-
-<ul class="<%= sidebar_tagging ? 'list-unstyled' : 'list-inline' =%>">
+<ul class= "list-inline">
   <% tags.each do |tag| %>
     <% if tag.class == NodeTag %>
 

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,9 +1,11 @@
-<p>
+<%sidebar_tagging = local_assigns.fetch :sidebar_tagging, false #preserves user, map tagging orientation %>
+
+<ul class="<%= sidebar_tagging ? 'list-unstyled' : 'list-inline' =%>">
   <% tags.each do |tag| %>
     <% if tag.class == NodeTag %>
 
       <% if power_tag ^ tag.name.include?(':') # XOR operator??? %>
-        <span id="tag_<%= tag.tid %>" class="label <%= label_name %>" style="cursor:pointer" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p> <div style='text-align:center;'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
+        <li><span id="tag_<%= tag.tid %>" class="label <%= label_name %>" style="cursor:pointer" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p> <div style='text-align:center;'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
           <%= tag.name %>
           <% if current_user && ( current_user.uid ==  @node.uid || current_user.uid == tag.uid  || current_user.role == "admin" || current_user.role == "moderator") %>
             <% if tag.name.include? ':' %>
@@ -12,12 +14,12 @@
               <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete">x</a>
             <% end %>
           <% end %>
-        </span>
+        </span></li>
       <% end %>
 
     <% elsif tag.class == UserTag && (tag.name[0..4] != "oauth" || (current_user && (current_user.uid == tag.uid || current_user.role == "admin"))) %>
 
-        <span id="tag_<%= tag.id %>" class="label <%= label_name %>" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
+        <li><span id="tag_<%= tag.id %>" class="label <%= label_name %>" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
           <% if tag.name[0..4] != "oauth" %>
             <%= tag.name %>
           <% else %>
@@ -26,9 +28,9 @@
           <% if current_user && ( current_user.uid == tag.uid  || current_user.role == "admin" || current_user.role == "moderator") %>
             <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= @user.id %>?name=<%= tag.name %>" data-method="delete">x</a>
           <% end %>
-        </span>
+        </span></li>
 
     <% end %>
 
   <% end %>
-</p>
+</ul>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -25,11 +25,7 @@
   <div class="alert alert-info" role="alert">This wiki page hasn't been edited for a while. If you see anything that needs updating, please help out!</div>
 <% end %>
 
-<% if @node.has_tag('sidebar:none') %>
-  <div class="col-md-8">
-<% else %>
-  <div class="col-md-9">
-<% end %>
+<div class="col-md-9">
 
   <%= render :partial => "wiki/header" %>
 
@@ -83,18 +79,18 @@
   <hr />
 
   <div class="hidden-print">
-    <%= render :partial => "tag/tagging" %>
-    <hr />
     <%= render :partial => "home/social" %>
   </div>
 
 </div>
 
-<% unless @node.has_tag('sidebar:none') %>
+<% if @node.has_tag('sidebar:none') %>
+  <%= render :partial => "sidebar/none" %>
+<% else %>
   <% if (@wikis.nil? && @notes.nil?) || @node.has_tag('sidebar:featured') %>
-    <%= render :partial => "sidebar/featured" %>
+    <%= render :partial => "sidebar/featured", :locals => {:include_tagging => true} %>
   <% else %>
-    <%= render :partial => "sidebar/related" %>
+    <%= render :partial => "sidebar/related", :locals => {:include_tagging => true} %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Fixes #3121 

Moved tagging to the right sidebar for notes, questions, and wikis. Users and Maps tagging functionality should be unaffected.
![blog-sidebar-tagging](https://user-images.githubusercontent.com/40677825/43041845-d9a83c84-8d31-11e8-8048-4b0c22deb4e5.png)

The tagging system appears in the sidebar even if the powertag for sidebar:none is selected.
![wiki-sidebar-tagging](https://user-images.githubusercontent.com/40677825/43041847-ee1b3e00-8d31-11e8-83e7-9865e6aaa799.png)



Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
