### PR TITLE
Improve textSearch_profiles result

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -21,7 +21,7 @@ module Srch
         Search.execute(:all, params)
       end
 
-      # Request URL should be /api/srch/profiles?srchString=QRY[&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
+      # Request URL should be /api/srch/profiles?srchString=QRY[&order=RECENTDESC&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
       # Basic implementation from classic plots2 SearchController
       desc 'Perform a search of profiles', hidden: false,
                                            is_array: false,

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -21,14 +21,14 @@ module Srch
         Search.execute(:all, params)
       end
 
-      # Request URL should be /api/srch/profiles?srchString=QRY[&order=RECENTDESC&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
+      # Request URL should be /api/srch/profiles?srchString=QRY[&order_by=recent&sort_direction=desc&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
       # Basic implementation from classic plots2 SearchController
       desc 'Perform a search of profiles', hidden: false,
                                            is_array: false,
                                            nickname: 'srchGetProfiles'
 
       params do
-        use :common, :sortorder
+        use :common, :sorting, :ordering
       end
       get :profiles do
         Search.execute(:profiles, params)
@@ -105,9 +105,10 @@ module Srch
       sresult = DocList.new
       search_query = params[:srchString]
       tag_query = params[:tagName]
-      order_query = params[:order]
+      order_query = params[:order_by]
+      sort_query = params[:sort_direction]
       search_type = endpoint
-      search_criteria = SearchCriteria.new(search_query, tag_query, order_query)
+      search_criteria = SearchCriteria.new(search_query, tag: tag_query, order_by: order_query, sort_direction: sort_query)
 
       if search_criteria.valid?
         sresult = ExecuteSearch.new.by(search_type, search_criteria)

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -28,7 +28,7 @@ module Srch
                                            nickname: 'srchGetProfiles'
 
       params do
-        use :common
+        use :common, :sortorder
       end
       get :profiles do
         Search.execute(:profiles, params)
@@ -105,8 +105,9 @@ module Srch
       sresult = DocList.new
       search_query = params[:srchString]
       tag_query = params[:tagName]
+      order_query = params[:order]
       search_type = endpoint
-      search_criteria = SearchCriteria.new(search_query, tag_query)
+      search_criteria = SearchCriteria.new(search_query, tag_query, order_query)
 
       if search_criteria.valid?
         sresult = ExecuteSearch.new.by(search_type, search_criteria)

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -21,7 +21,7 @@ module Srch
         Search.execute(:all, params)
       end
 
-      # Request URL should be /api/srch/profiles?srchString=QRY[&order_by=recent&sort_direction=desc&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
+      # Request URL should be /api/srch/profiles?srchString=QRY[&sort_by=recent&order_direction=desc&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
       # Basic implementation from classic plots2 SearchController
       desc 'Perform a search of profiles', hidden: false,
                                            is_array: false,
@@ -105,14 +105,15 @@ module Srch
       sresult = DocList.new
       search_query = params[:srchString]
       tag_query = params[:tagName]
-      order_query = params[:order_by]
-      sort_query = params[:sort_direction]
+      order_query = params[:order_direction]
+      sort_query = params[:sort_by]
       search_type = endpoint
-      search_criteria = SearchCriteria.new(search_query, tag: tag_query, order_by: order_query, sort_direction: sort_query)
+      search_criteria = SearchCriteria.new(search_query, tag: tag_query, sort_by: sort_query, order_direction: order_query)
 
       if search_criteria.valid?
         sresult = ExecuteSearch.new.by(search_type, search_criteria)
       end
+
       sparms = SearchRequest.fromRequest(params)
       sresult.srchParams = sparms
       sresult

--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -15,6 +15,10 @@ module Srch
       optional :tagName, type: String, documentation: { example: 'awesome' }
     end
 
+    params :sortorder do
+      optional :order, type: String, documentation: { example: 'recentdesc' }
+    end
+
     params :commontypeahead do
       requires :srchString, type: String, documentation: { example: 'Spec' }
       optional :seq, type: Integer, documentation: { example: 995 }

--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -15,8 +15,12 @@ module Srch
       optional :tagName, type: String, documentation: { example: 'awesome' }
     end
 
-    params :sortorder do
-      optional :order, type: String, documentation: { example: 'recentdesc' }
+    params :ordering do
+      optional :order_direction, type: String, documentation: { example: 'desc' }
+    end
+
+    params :sorting do
+      optional :sort_by, type: String, documentation: { example: 'recent' }
     end
 
     params :commontypeahead do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ActiveRecord::Base
   has_many :following_users, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :likes
+  has_many :revisions, through: :node
 
   validates_with UniqueUsernameValidator, on: :create
   validates_format_of :username, with: /\A[A-Za-z\d_\-]+\z/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
   after_destroy :destroy_drupal_user
 
   def self.search(query)
-    User.where('MATCH(username, bio) AGAINST(?)', query)
+    User.where('MATCH(username, bio) AGAINST (?)', query)
   end
 
   def new_contributor

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
   after_destroy :destroy_drupal_user
 
   def self.search(query)
-    User.where('MATCH(username, bio) AGAINST (?)', query)
+    User.where('MATCH(username) AGAINST((?) IN BOOLEAN MODE)', query + '*')
   end
 
   def new_contributor

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
   before_save :set_token
   after_destroy :destroy_drupal_user
 
-  def self.search(query)
+  def self.search_by_username(query)
     User.where('MATCH(username) AGAINST((?) IN BOOLEAN MODE)', query + '*')
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,8 @@ class User < ActiveRecord::Base
   before_save :set_token
   after_destroy :destroy_drupal_user
 
-  def self.search_by_username(query)
-    User.where('MATCH(username) AGAINST((?) IN BOOLEAN MODE)', query + '*')
+  def self.search(query)
+    User.where('MATCH(bio, username) AGAINST(? IN BOOLEAN MODE)', query + '*')
   end
 
   def new_contributor

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -10,9 +10,9 @@ class ExecuteSearch
     sresult = DocList.new
     case type
      when :all
-       sresult = sservice.textSearch_all(search_criteria.query)
+       sresult = sservice.textSearch_all(search_criteria)
      when :profiles
-       sresult = sservice.textSearch_profiles(search_criteria.query, search_criteria.order)
+       sresult = sservice.textSearch_profiles(search_criteria)
      when :notes
        sresult = sservice.textSearch_notes(search_criteria.query)
      when :questions

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -12,7 +12,7 @@ class ExecuteSearch
      when :all
        sresult = sservice.textSearch_all(search_criteria.query)
      when :profiles
-       sresult = sservice.textSearch_profiles(search_criteria.query)
+       sresult = sservice.textSearch_profiles(search_criteria.query, search_criteria.order)
      when :notes
        sresult = sservice.textSearch_notes(search_criteria.query)
      when :questions

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -12,7 +12,7 @@ class ExecuteSearch
      when :all
        sresult = sservice.textSearch_all(search_criteria)
      when :profiles
-       sresult = sservice.textSearch_profiles(search_criteria)
+       sresult = sservice.profiles(search_criteria)
      when :notes
        sresult = sservice.textSearch_notes(search_criteria.query)
      when :questions

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -1,19 +1,19 @@
 class SearchCriteria
-  attr_reader :query, :tag, :order_by
+  attr_reader :query, :tag, :sort_by
 
-  def initialize(query, tag: nil, order_by: nil, sort_direction: "DESC")
+  def initialize(query, tag: nil, sort_by: nil, order_direction: "DESC")
     @query = query
     @tag = tag
-    @order_by = order_by
-    @sort_direction = sort_direction
+    @sort_by = sort_by
+    @order_direction = order_direction
   end
 
   def valid?
     !query.nil? && query != 0
   end
 
-  def sort_direction
-    sanitize_direction(@sort_direction)
+  def order_direction
+    sanitize_direction(@order_direction)
   end
 
   private

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -1,13 +1,30 @@
 class SearchCriteria
-  attr_reader :query, :tag, :order
+  attr_reader :query, :tag, :order_by
 
-  def initialize(query, tag = nil, order = nil)
+  def initialize(query, tag: nil, order_by: nil, sort_direction: "DESC")
     @query = query
     @tag = tag
-    @order = order
+    @order_by = order_by
+    @sort_direction = sort_direction
   end
 
   def valid?
     !query.nil? && query != 0
+  end
+
+  def sort_direction
+    sanitize_direction(@sort_direction)
+  end
+
+  private
+
+  def sanitize_direction(direction)
+    if direction.present?
+      direction = direction.upcase
+      options = %w(DESC ASC)
+      options.include?(direction) ? direction : "DESC"
+    else
+      "DESC"
+    end
   end
 end

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -1,9 +1,10 @@
 class SearchCriteria
-  attr_reader :query, :tag
+  attr_reader :query, :tag, :order
 
-  def initialize(query, tag = nil)
+  def initialize(query, tag = nil, order = nil)
     @query = query
     @tag = tag
+    @order = order
   end
 
   def valid?

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -54,9 +54,9 @@ class SearchService
                           .reorder('')
 
     user_scope =
-      if search_criteria.order_by == "recent"
-        user_scope.left_outer_joins(:revisions)
-                  .order("node_revisions.timestamp #{search_criteria.sort_direction}")
+      if search_criteria.sort_by == "recent"
+        user_scope.joins(:revisions)
+                  .order("node_revisions.timestamp #{search_criteria.order_direction}")
                   .distinct # do we need unique/distinct on user id ?
 
       else

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -44,7 +44,7 @@ class SearchService
   end
 
   # Search profiles for matching text and package up as a DocResult
-  # If order == "recentdesc", search for more recently updated profiles for matching text.
+  # If order == "recentdesc", search for more recently updated profiles for matching name.
   # Otherwise, show profiles without any ordering
   def textSearch_profiles(srchString, order = nil)
     sresult = DocList.new

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -202,10 +202,8 @@ class SearchService
     nodes = Node.all.order("changed DESC").limit(100).distinct
     users = []
     nodes.each do |node|
-      next unless node.author.status != 0
-      if node.author.name.downcase.include? srchString.downcase
-        users << node.author.user
-      end
+      next unless (node.author.status != 0) and (node.author.name.downcase.include? srchString.downcase)
+      users << node.author.user
     end
 
     users = users.uniq

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -202,7 +202,7 @@ class SearchService
     nodes = Node.all.order("changed DESC").limit(100).distinct
     users = []
     nodes.each do |node|
-      next unless (node.author.status != 0) and (node.author.name.downcase.include? srchString.downcase)
+      next unless (node.author.status != 0) && (node.author.name.downcase.include? srchString.downcase)
       users << node.author.user
     end
 
@@ -219,8 +219,8 @@ class SearchService
       if node.author.status != 0
         if tagName.blank?
           users << node.author.user
-        else
-          users << node.author.user if node.author.user.has_tag(tagName)
+        elsif node.author.user.has_tag(tagName)
+          users << node.author.user
         end
       end
     end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -50,8 +50,7 @@ class SearchService
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
   def textSearch_profiles(search_criteria)
-    user_scope = SrchScope.find_users(search_criteria.query, limit = nil)
-                          .reorder('')
+    user_scope = User.where('username LIKE ? AND rusers.status = 1', '%' + search_criteria.query + '%')
 
     user_scope =
       if search_criteria.sort_by == "recent"

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -215,14 +215,10 @@ class SearchService
   def getRecentProfilesTag(tagName = nil)
     nodes = Node.all.order("changed DESC").limit(100).distinct
     users = []
+
     nodes.each do |node|
-      if node.author.status != 0
-        if tagName.blank?
-          users << node.author.user
-        elsif node.author.user.has_tag(tagName)
-          users << node.author.user
-        end
-      end
+      next unless node.author.status != 0 && ((tagName && node.author.user.has_tag(tagName)) || tagName.nil?)
+      users << node.author.user
     end
 
     users = users.uniq

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -27,7 +27,7 @@ class SearchService
       sresult.addDoc(doc)
     end
     # User profiles
-    userList = textSearch_profiles(search_criteria)
+    userList = profiles(search_criteria)
     sresult.addAll(userList.items)
 
     # Tags
@@ -49,7 +49,7 @@ class SearchService
 
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
-  def textSearch_profiles(search_criteria)
+  def profiles(search_criteria)
     user_scope = SrchScope.find_users(search_criteria.query, limit = 10)
 
     user_scope =

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -50,19 +50,19 @@ class SearchService
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
   def textSearch_profiles(search_criteria)
-    user_scope = User.where('username LIKE ? AND rusers.status = 1', '%' + search_criteria.query + '%')
+    user_scope = SrchScope.find_users(search_criteria.query, limit = 10)
+                          .reorder('')
 
     user_scope =
       if search_criteria.sort_by == "recent"
         user_scope.joins(:revisions)
                   .order("node_revisions.timestamp #{search_criteria.order_direction}")
-                  .distinct # do we need unique/distinct on user id ?
-
+                  .distinct
       else
-        user_scope.order(id: :desc) # order by what when order_by is not present? id? username?
+        user_scope.order(id: :desc)
       end
 
-    users = user_scope.limit(10) # verify limit?
+    users = user_scope.limit(10)
 
     sresult = DocList.new
     users.each do |match|

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -51,13 +51,13 @@ class SearchService
   # a recent activity may be a node creation or a node revision
   def textSearch_profiles(search_criteria)
     user_scope = SrchScope.find_users(search_criteria.query, limit = 10)
-                          .reorder('')
 
     user_scope =
       if search_criteria.sort_by == "recent"
         user_scope.joins(:revisions)
                   .order("node_revisions.timestamp #{search_criteria.order_direction}")
                   .distinct
+
       else
         user_scope.order(id: :desc)
       end

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -3,12 +3,12 @@ class SrchScope
   def self.find_users(input, limit)
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
       User.search(input)
-          .order('id DESC')
-          .where(status: 1)
+          .order('id DESC') # do we need this line?
+          .where('rusers.status = ?', 1)
           .limit(limit)
     else
       User.order('id DESC')
-          .where('username LIKE ? AND status = 1', '%' + input + '%')
+          .where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
           .limit(limit)
     end
   end

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -3,12 +3,12 @@ class SrchScope
   def self.find_users(input, limit)
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
       User.search(input)
-          .order('id DESC') # do we need this line?
-          .where('rusers.status = ?', 1)
+          .order('id DESC')
+          .where(status: 1)
           .limit(limit)
     else
-      User.order('id DESC')
-          .where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
+      User.where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
+          .order('id DESC')
           .limit(limit)
     end
   end

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -2,7 +2,7 @@
 class SrchScope
   def self.find_users(query, limit)
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      User.search_by_username(query)
+      User.search(query)
           .where('rusers.status = ?', 1)
           .limit(limit)
     else

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -3,12 +3,10 @@ class SrchScope
   def self.find_users(input, limit)
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
       User.search(input)
-          .order('id DESC')
-          .where(status: 1)
+          .where('rusers.status = ?', 1)
           .limit(limit)
     else
       User.where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
-          .order('id DESC')
           .limit(limit)
     end
   end

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -1,8 +1,8 @@
 # This class provides common methods that Typehead and Search services use
 class SrchScope
-  def self.find_users(input, limit)
+  def self.find_users(query, limit)
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      User.search(input)
+      User.search_by_username(query)
           .where('rusers.status = ?', 1)
           .limit(limit)
     else

--- a/db/migrate/20120101000000_drupal_schema.rb
+++ b/db/migrate/20120101000000_drupal_schema.rb
@@ -467,7 +467,7 @@ class DrupalSchema < ActiveRecord::Migration[5.1]
     unless index_exists? "url_alias", [:dst, :language, :pid], name: "dst_language_pid"
       add_index "url_alias", ["dst", "language", "pid"], :name => "dst_language_pid"
     end
-    
+
     unless index_exists? "url_alias", [:src, :language, :pid], name: "src_language_pid"
       add_index "url_alias", ["src", "language", "pid"], :name => "src_language_pid"
     end

--- a/db/migrate/20180804042601_add_full_text_index_on_username.rb
+++ b/db/migrate/20180804042601_add_full_text_index_on_username.rb
@@ -1,0 +1,13 @@
+class AddFullTextIndexOnUsername < ActiveRecord::Migration[5.2]
+  def up
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      add_index :rusers, :username, type: :fulltext, name: 'rusers_username_fulltext_idx'
+    end
+  end
+
+  def down
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      remove_index :rusers, name: 'rusers_username_fulltext_idx'
+    end
+  end
+end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,332 +12,313 @@
 
 ActiveRecord::Schema.define(version: 2018_08_04_215454) do
 
-  create_table "answer_selections", force: true do |t|
+  create_table "answer_selections", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "aid"
-    t.boolean "liking",    default: false
+    t.boolean "liking", default: false
     t.boolean "following", default: false
+    t.index ["user_id", "aid"], name: "index_answer_selections_on_user_id_and_aid"
   end
 
-  add_index "answer_selections", ["user_id", "aid"], name: "index_answer_selections_on_user_id_and_aid", using: :btree
-
-  create_table "answers", force: true do |t|
-    t.integer  "uid",                             default: 0,     null: false
-    t.integer  "nid",                             default: 0,     null: false
-    t.text     "content",      limit: 2147483647,                 null: false
-    t.integer  "cached_likes",                    default: 0
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.boolean  "accepted",                        default: false
+  create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "uid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.text "content", limit: 4294967295, null: false
+    t.integer "cached_likes", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "accepted", default: false
+    t.index ["uid", "nid"], name: "index_answers_on_uid_and_nid"
   end
 
-  add_index "answers", ["uid", "nid"], name: "index_answers_on_uid_and_nid", using: :btree
-
-  create_table "comments", primary_key: "cid", force: true do |t|
-    t.integer "pid",                          default: 0,  null: false
-    t.integer "nid",                          default: 0,  null: false
-    t.integer "uid",                          default: 0,  null: false
-    t.string  "subject",   limit: 64,         default: "", null: false
-    t.text    "comment",   limit: 2147483647,              null: false
-    t.string  "hostname",  limit: 128,        default: "", null: false
-    t.integer "timestamp",                    default: 0,  null: false
-    t.integer "status",                       default: 1,  null: false
-    t.integer "format",    limit: 2,          default: 0,  null: false
-    t.string  "thread"
-    t.string  "name",      limit: 60
-    t.string  "mail",      limit: 64
-    t.string  "homepage"
-    t.integer "aid",                          default: 0,  null: false
-    t.integer "comment_via", limit: 4,          default: 0
-    t.string  "message_id",  limit: 255
+  create_table "comments", primary_key: "cid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "pid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.integer "uid", default: 0, null: false
+    t.string "subject", limit: 64, default: "", null: false
+    t.text "comment", limit: 4294967295, null: false
+    t.string "hostname", limit: 128, default: "", null: false
+    t.integer "timestamp", default: 0, null: false
+    t.integer "status", default: 1, null: false
+    t.integer "format", limit: 2, default: 0, null: false
+    t.string "thread"
+    t.string "name", limit: 60
+    t.string "mail", limit: 64
+    t.string "homepage"
+    t.integer "aid", default: 0, null: false
+    t.integer "comment_via", default: 0
+    t.string "message_id"
+    t.index ["comment"], name: "index_comments_on_comment", type: :fulltext
+    t.index ["nid"], name: "index_comments_nid"
+    t.index ["pid"], name: "index_comments_pid"
+    t.index ["status"], name: "index_comments_status"
   end
 
-  add_index "comments", ["comment"], name: "index_comments_on_comment", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-  add_index "comments", ["nid"], name: "index_comments_nid", using: :btree
-  add_index "comments", ["pid"], name: "index_comments_pid", using: :btree
-  add_index "comments", ["status"], name: "index_comments_status", using: :btree
-
-  create_table "community_tags", id: false, force: true do |t|
-    t.integer "tid",  default: 0, null: false
-    t.integer "nid",  default: 0, null: false
-    t.integer "uid",  default: 0, null: false
+  create_table "community_tags", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "tid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.integer "uid", default: 0, null: false
     t.integer "date", default: 0, null: false
+    t.index ["nid"], name: "index_community_tags_nid"
+    t.index ["tid", "nid"], name: "tid_nid"
+    t.index ["tid"], name: "index_community_tags_tid"
+    t.index ["uid"], name: "index_community_tags_uid"
   end
 
-  add_index "community_tags", ["nid"], name: "index_community_tags_nid", using: :btree
-  add_index "community_tags", ["tid", "nid"], name: "tid_nid", using: :btree
-  add_index "community_tags", ["tid"], name: "index_community_tags_tid", using: :btree
-  add_index "community_tags", ["uid"], name: "index_community_tags_uid", using: :btree
-
-  create_table "content_field_image_gallery", id: false, force: true do |t|
-    t.integer "vid",                                default: 0, null: false
-    t.integer "nid",                                default: 0, null: false
-    t.integer "delta",                              default: 0, null: false
+  create_table "content_field_image_gallery", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "vid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.integer "delta", default: 0, null: false
     t.integer "field_image_gallery_fid"
     t.integer "field_image_gallery_list", limit: 1
-    t.text    "field_image_gallery_data"
+    t.text "field_image_gallery_data"
+    t.index ["nid"], name: "index_content_field_image_gallery_nid"
   end
 
-  add_index "content_field_image_gallery", ["nid"], name: "index_content_field_image_gallery_nid", using: :btree
-
-  create_table "content_field_main_image", primary_key: "vid", force: true do |t|
-    t.integer "nid",                             default: 0, null: false
+  create_table "content_field_main_image", primary_key: "vid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "nid", default: 0, null: false
     t.integer "field_main_image_fid"
     t.integer "field_main_image_list", limit: 1
-    t.text    "field_main_image_data"
+    t.text "field_main_image_data"
+    t.index ["nid"], name: "index_content_field_main_image_nid"
   end
 
-  add_index "content_field_main_image", ["nid"], name: "index_content_field_main_image_nid", using: :btree
-
-  create_table "content_field_map_editor", id: false, force: true do |t|
-    t.integer "vid",                                       default: 0, null: false
-    t.integer "nid",                                       default: 0, null: false
-    t.integer "delta",                                     default: 0, null: false
-    t.text    "field_map_editor_value", limit: 2147483647
+  create_table "content_field_map_editor", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "vid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.integer "delta", default: 0, null: false
+    t.text "field_map_editor_value", limit: 4294967295
+    t.index ["nid"], name: "index_content_field_map_editor_nid"
   end
 
-  add_index "content_field_map_editor", ["nid"], name: "index_content_field_map_editor_nid", using: :btree
-
-  create_table "content_field_mappers", id: false, force: true do |t|
-    t.integer "vid",                                    default: 0, null: false
-    t.integer "nid",                                    default: 0, null: false
-    t.integer "delta",                                  default: 0, null: false
-    t.text    "field_mappers_value", limit: 2147483647
+  create_table "content_field_mappers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "vid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.integer "delta", default: 0, null: false
+    t.text "field_mappers_value", limit: 4294967295
+    t.index ["nid"], name: "index_content_field_mappers_nid"
   end
 
-  add_index "content_field_mappers", ["nid"], name: "index_content_field_mappers_nid", using: :btree
-
-  create_table "content_type_map", primary_key: "vid", force: true do |t|
-    t.integer "nid",                                                                         default: 0, null: false
-    t.string  "field_publication_date_value",    limit: 20
-    t.string  "field_capture_date_value",        limit: 20
-    t.text    "field_geotiff_url_value",         limit: 2147483647
-    t.text    "field_google_maps_url_value",     limit: 2147483647
-    t.text    "field_openlayers_url_value",      limit: 2147483647
-    t.text    "field_tms_url_value",             limit: 2147483647
-    t.text    "field_jpg_url_value",             limit: 2147483647
-    t.text    "field_license_value",             limit: 2147483647
-    t.text    "field_raw_images_value",          limit: 2147483647
-    t.text    "field_cartographer_notes_value",  limit: 2147483647
+  create_table "content_type_map", primary_key: "vid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "nid", default: 0, null: false
+    t.string "field_publication_date_value", limit: 20
+    t.string "field_capture_date_value", limit: 20
+    t.text "field_geotiff_url_value", limit: 4294967295
+    t.text "field_google_maps_url_value", limit: 4294967295
+    t.text "field_openlayers_url_value", limit: 4294967295
+    t.text "field_tms_url_value", limit: 4294967295
+    t.text "field_jpg_url_value", limit: 4294967295
+    t.text "field_license_value", limit: 4294967295
+    t.text "field_raw_images_value", limit: 4294967295
+    t.text "field_cartographer_notes_value", limit: 4294967295
     t.integer "field_cartographer_notes_format"
-    t.text    "field_notes_value",               limit: 2147483647
+    t.text "field_notes_value", limit: 4294967295
     t.integer "field_notes_format"
-    t.text    "field_mbtiles_url_value",         limit: 2147483647
+    t.text "field_mbtiles_url_value", limit: 4294967295
     t.integer "field_zoom_min_value"
-    t.decimal "field_ground_resolution_value",                      precision: 10, scale: 2
-    t.decimal "field_geotiff_filesize_value",                       precision: 10, scale: 1
-    t.decimal "field_jpg_filesize_value",                           precision: 10, scale: 1
-    t.decimal "field_raw_images_filesize_value",                    precision: 10, scale: 1
-    t.text    "field_tms_tile_type_value",       limit: 2147483647
+    t.decimal "field_ground_resolution_value", precision: 10, scale: 2
+    t.decimal "field_geotiff_filesize_value", precision: 10, scale: 1
+    t.decimal "field_jpg_filesize_value", precision: 10, scale: 1
+    t.decimal "field_raw_images_filesize_value", precision: 10, scale: 1
+    t.text "field_tms_tile_type_value", limit: 4294967295
     t.integer "field_zoom_max_value"
-    t.string  "authorship"
+    t.string "authorship"
+    t.index ["nid"], name: "index_content_type_map_nid"
   end
 
-  add_index "content_type_map", ["nid"], name: "index_content_type_map_nid", using: :btree
-
-  create_table "files", primary_key: "fid", force: true do |t|
-    t.integer "uid",       default: 0,  null: false
-    t.string  "filename",  default: "", null: false
-    t.string  "filepath",  default: "", null: false
-    t.string  "filemime",  default: "", null: false
-    t.integer "filesize",  default: 0,  null: false
-    t.integer "status",    default: 0,  null: false
-    t.integer "timestamp", default: 0,  null: false
+  create_table "files", primary_key: "fid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "uid", default: 0, null: false
+    t.string "filename", default: "", null: false
+    t.string "filepath", default: "", null: false
+    t.string "filemime", default: "", null: false
+    t.integer "filesize", default: 0, null: false
+    t.integer "status", default: 0, null: false
+    t.integer "timestamp", default: 0, null: false
+    t.index ["status"], name: "index_files_status"
+    t.index ["timestamp"], name: "index_files_timestamp"
+    t.index ["uid"], name: "index_files_uid"
   end
 
-  add_index "files", ["status"], name: "index_files_status", using: :btree
-  add_index "files", ["timestamp"], name: "index_files_timestamp", using: :btree
-  add_index "files", ["uid"], name: "index_files_uid", using: :btree
-
-  create_table "friendly_id_slugs", force: true do |t|
-    t.string   "slug",                      null: false
-    t.integer  "sluggable_id",              null: false
-    t.string   "sluggable_type", limit: 40
+  create_table "friendly_id_slugs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 40
     t.datetime "created_at"
   end
 
-  create_table "images", force: true do |t|
-    t.string   "title"
-    t.integer  "uid"
-    t.integer  "nid"
-    t.string   "notes"
-    t.integer  "version",            default: 0
-    t.string   "photo_file_name"
-    t.string   "photo_content_type"
-    t.string   "photo_file_size"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.string   "remote_url"
-    t.integer  "vid",                default: 0
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.integer "uid"
+    t.integer "nid"
+    t.string "notes"
+    t.integer "version", default: 0
+    t.string "photo_file_name"
+    t.string "photo_content_type"
+    t.string "photo_file_size"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "remote_url"
+    t.integer "vid", default: 0
   end
 
-  create_table "impressions", force: true do |t|
-    t.string   "impressionable_type"
-    t.integer  "impressionable_id"
-    t.integer  "user_id"
-    t.string   "controller_name"
-    t.string   "action_name"
-    t.string   "view_name"
-    t.string   "request_hash"
-    t.string   "ip_address"
-    t.string   "session_hash"
-    t.text     "message"
-    t.text     "referrer"
-    t.text     "params"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+  create_table "impressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "impressionable_type"
+    t.integer "impressionable_id"
+    t.integer "user_id"
+    t.string "controller_name"
+    t.string "action_name"
+    t.string "view_name"
+    t.string "request_hash"
+    t.string "ip_address"
+    t.string "session_hash"
+    t.text "message"
+    t.text "referrer"
+    t.text "params"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
+    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
+    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
+    t.index ["impressionable_id"], name: "index_impressions_on_impressionable_id"
+    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
+    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index", length: { params: 255 }
+    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
+    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
+    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index", length: { message: 255 }
+    t.index ["impressionable_type"], name: "index_impressions_on_impressionable_type"
+    t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
-  add_index "impressions", ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index", using: :btree
-  add_index "impressions", ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index", using: :btree
-  add_index "impressions", ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index", using: :btree
-  add_index "impressions", ["impressionable_id"], name: "index_impressions_on_impressionable_id", using: :btree
-  add_index "impressions", ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index", using: :btree
-  add_index "impressions", ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index", length: {"impressionable_type"=>nil, "impressionable_id"=>nil, "params"=>255}, using: :btree
-  add_index "impressions", ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index", using: :btree
-  add_index "impressions", ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index", using: :btree
-  add_index "impressions", ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index", length: {"impressionable_type"=>nil, "message"=>255, "impressionable_id"=>nil}, using: :btree
-  add_index "impressions", ["impressionable_type"], name: "index_impressions_on_impressionable_type", using: :btree
-  add_index "impressions", ["user_id"], name: "index_impressions_on_user_id", using: :btree
-
-  create_table "likes", force: true do |t|
-    t.integer  "likeable_id"
-    t.integer  "user_id"
-    t.string   "likeable_type"
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "likeable_id"
+    t.integer "user_id"
+    t.string "likeable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "emoji_type"
+    t.string "emoji_type"
   end
 
-  create_table "node", primary_key: "nid", force: true do |t|
-    t.integer "vid",                                    default: 0,  null: false
-    t.string  "type",                        limit: 32, default: "", null: false
-    t.string  "language",                    limit: 12, default: "", null: false
-    t.string  "title",                                  default: "", null: false
-    t.integer "uid",                                    default: 0,  null: false
-    t.integer "status",                                 default: 1,  null: false
-    t.integer "created",                                default: 0,  null: false
-    t.integer "changed",                                default: 0,  null: false
-    t.integer "comment",                                default: 0,  null: false
-    t.integer "promote",                                default: 0,  null: false
-    t.integer "moderate",                               default: 0,  null: false
-    t.integer "sticky",                                 default: 0,  null: false
-    t.integer "tnid",                                   default: 0,  null: false
-    t.integer "translate",                              default: 0,  null: false
-    t.integer "cached_likes",                           default: 0
-    t.integer "comments_count",                         default: 0
-    t.integer "drupal_node_revisions_count",            default: 0
-    t.string  "path"
+  create_table "node", primary_key: "nid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "vid", default: 0, null: false
+    t.string "type", limit: 32, default: "", null: false
+    t.string "language", limit: 12, default: "", null: false
+    t.string "title", default: "", null: false
+    t.integer "uid", default: 0, null: false
+    t.integer "status", default: 1, null: false
+    t.integer "created", default: 0, null: false
+    t.integer "changed", default: 0, null: false
+    t.integer "comment", default: 0, null: false
+    t.integer "promote", default: 0, null: false
+    t.integer "moderate", default: 0, null: false
+    t.integer "sticky", default: 0, null: false
+    t.integer "tnid", default: 0, null: false
+    t.integer "translate", default: 0, null: false
+    t.integer "cached_likes", default: 0
+    t.integer "comments_count", default: 0
+    t.integer "drupal_node_revisions_count", default: 0
+    t.string "path"
     t.integer "main_image_id"
-    t.string  "slug"
-    t.integer "legacy_views",                           default: 0
-    t.integer "views",                                  default: 0
+    t.string "slug"
+    t.integer "legacy_views", default: 0
+    t.integer "views", default: 0
+    t.index ["changed"], name: "node_changed"
+    t.index ["created"], name: "node_created"
+    t.index ["moderate"], name: "node_moderate"
+    t.index ["promote", "status"], name: "node_promote_status"
+    t.index ["slug"], name: "index_node_on_slug"
+    t.index ["status", "type", "nid"], name: "node_status_type"
+    t.index ["title", "type"], name: "node_title_type"
+    t.index ["tnid"], name: "index_node_tnid"
+    t.index ["translate"], name: "index_node_translate"
+    t.index ["type"], name: "node_type"
+    t.index ["uid"], name: "index_node_uid"
+    t.index ["vid"], name: "index_node_vid"
   end
 
-  add_index "node", ["changed"], name: "node_changed", using: :btree
-  add_index "node", ["created"], name: "node_created", using: :btree
-  add_index "node", ["moderate"], name: "node_moderate", using: :btree
-  add_index "node", ["promote", "status"], name: "node_promote_status", using: :btree
-  add_index "node", ["slug"], name: "index_node_on_slug", using: :btree
-  add_index "node", ["status", "type", "nid"], name: "node_status_type", using: :btree
-  add_index "node", ["title", "type"], name: "node_title_type", using: :btree
-  add_index "node", ["tnid"], name: "index_node_tnid", using: :btree
-  add_index "node", ["translate"], name: "index_node_translate", using: :btree
-  add_index "node", ["type"], name: "node_type", using: :btree
-  add_index "node", ["uid"], name: "index_node_uid", using: :btree
-  add_index "node", ["vid"], name: "index_node_vid", using: :btree
-
-  create_table "node_access", id: false, force: true do |t|
-    t.integer "nid",                    default: 0,  null: false
-    t.integer "gid",                    default: 0,  null: false
-    t.string  "realm",                  default: "", null: false
-    t.integer "grant_view",   limit: 1, default: 0,  null: false
-    t.integer "grant_update", limit: 1, default: 0,  null: false
-    t.integer "grant_delete", limit: 1, default: 0,  null: false
+  create_table "node_access", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "nid", default: 0, null: false
+    t.integer "gid", default: 0, null: false
+    t.string "realm", default: "", null: false
+    t.integer "grant_view", limit: 1, default: 0, null: false
+    t.integer "grant_update", limit: 1, default: 0, null: false
+    t.integer "grant_delete", limit: 1, default: 0, null: false
   end
 
-  create_table "node_revisions", primary_key: "vid", force: true do |t|
-    t.integer "nid",                          default: 0,  null: false
-    t.integer "uid",                          default: 0,  null: false
-    t.string  "title",                        default: "", null: false
-    t.text    "body",      limit: 2147483647,              null: false
-    t.text    "teaser"
-    t.text    "log"
-    t.integer "timestamp",                    default: 0,  null: false
-    t.integer "format",                       default: 0,  null: false
-    t.integer "status",                       default: 1
+  create_table "node_revisions", primary_key: "vid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "nid", default: 0, null: false
+    t.integer "uid", default: 0, null: false
+    t.string "title", default: "", null: false
+    t.text "body", limit: 4294967295, null: false
+    t.text "teaser"
+    t.text "log"
+    t.integer "timestamp", default: 0, null: false
+    t.integer "format", default: 0, null: false
+    t.integer "status", default: 1
+    t.index ["body", "title"], name: "index_node_revisions_on_body_and_title", type: :fulltext
+    t.index ["nid"], name: "index_node_revisions_nid"
+    t.index ["timestamp"], name: "index_node_revisions_timestamp"
+    t.index ["uid"], name: "index_node_revisions_uid"
   end
 
-   add_index "node_revisions", ["body", "title"], name: "index_node_revisions_on_body_and_title", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-  add_index "node_revisions", ["nid"], name: "index_node_revisions_nid", using: :btree
-  add_index "node_revisions", ["timestamp"], name: "index_node_revisions_timestamp", using: :btree
-  add_index "node_revisions", ["uid"], name: "index_node_revisions_uid", using: :btree
-
-  create_table "node_selections", id: false, force: true do |t|
+  create_table "node_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "nid"
     t.boolean "following", default: true
     t.boolean "liking",    default: false
   end
 
-  add_index "node_selections", ["user_id", "nid"], name: "index_node_selections_on_user_id_and_nid", unique: true, using: :btree
-
-  create_table "profile_fields", primary_key: "fid", force: true do |t|
-    t.string  "title"
-    t.string  "name",         limit: 128, default: "", null: false
-    t.text    "explanation"
-    t.string  "category"
-    t.string  "page"
-    t.string  "type",         limit: 128
-    t.integer "weight",       limit: 1,   default: 0,  null: false
-    t.integer "required",     limit: 1,   default: 0,  null: false
-    t.integer "register",     limit: 1,   default: 0,  null: false
-    t.integer "visibility",   limit: 1,   default: 0,  null: false
-    t.integer "autocomplete", limit: 1,   default: 0,  null: false
-    t.text    "options"
+  create_table "profile_fields", primary_key: "fid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.string "name", limit: 128, default: "", null: false
+    t.text "explanation"
+    t.string "category"
+    t.string "page"
+    t.string "type", limit: 128
+    t.integer "weight", limit: 1, default: 0, null: false
+    t.integer "required", limit: 1, default: 0, null: false
+    t.integer "register", limit: 1, default: 0, null: false
+    t.integer "visibility", limit: 1, default: 0, null: false
+    t.integer "autocomplete", limit: 1, default: 0, null: false
+    t.text "options"
+    t.index ["category"], name: "index_profile_fields_category"
+    t.index ["name"], name: "index_profile_fields_name"
   end
 
-  add_index "profile_fields", ["category"], name: "index_profile_fields_category", using: :btree
-  add_index "profile_fields", ["name"], name: "index_profile_fields_name", using: :btree
-
-  create_table "profile_values", id: false, force: true do |t|
-    t.integer "fid",   default: 0, null: false
-    t.integer "uid",   default: 0, null: false
-    t.text    "value"
+  create_table "profile_values", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "fid", default: 0, null: false
+    t.integer "uid", default: 0, null: false
+    t.text "value"
+    t.index ["fid"], name: "index_profile_values_fid"
+    t.index ["uid"], name: "index_profile_values_on_uid"
   end
 
-  add_index "profile_values", ["fid"], name: "index_profile_values_fid", using: :btree
-  add_index "profile_values", ["uid"], name: "index_profile_values_on_uid", using: :btree
-
-  create_table "relationships", force: true do |t|
-    t.integer  "follower_id"
-    t.integer  "followed_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
-
-  add_index "relationships", ["followed_id"], name: "index_relationships_on_followed_id", using: :btree
-  add_index "relationships", ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true, using: :btree
-  add_index "relationships", ["follower_id"], name: "index_relationships_on_follower_id", using: :btree
-
-  create_table "rsessions", force: true do |t|
-    t.string   "session_id", null: false
-    t.text     "data"
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
-  add_index "rsessions", ["session_id"], name: "index_rsessions_on_session_id", using: :btree
-  add_index "rsessions", ["updated_at"], name: "index_rsessions_on_updated_at", using: :btree
+  create_table "rsessions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_rsessions_on_session_id"
+    t.index ["updated_at"], name: "index_rsessions_on_updated_at"
+  end
 
-  create_table "rusers", force: true do |t|
-    t.string   "username"
-    t.string   "email"
-    t.string   "crypted_password"
-    t.string   "password_salt"
-    t.string   "persistence_token"
-    t.integer  "login_count",                           default: 0,       null: false
-    t.integer  "failed_login_count",                    default: 0,       null: false
+  create_table "rusers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "username"
+    t.string "email"
+    t.string "crypted_password"
+    t.string "password_salt"
+    t.string "persistence_token"
+    t.integer "login_count", default: 0, null: false
+    t.integer "failed_login_count", default: 0, null: false
     t.datetime "last_request_at"
     t.datetime "current_login_at"
     t.datetime "last_login_at"
@@ -356,69 +336,58 @@ ActiveRecord::Schema.define(version: 2018_08_04_215454) do
     t.string   "token"
     t.integer  "status",                                default: 0
     t.integer "password_checker", default: 0
+    t.index ["username"], name: "rusers_username_fulltext_idx", type: :fulltext
   end
 
-  add_index "rusers", ["created_at"], name: "index_rusers_created_at", using: :btree
-  add_index "rusers", ["email"], name: "index_rusers_on_email", using: :btree
-  add_index "rusers", ["persistence_token"], name: "index_rusers_on_persistence_token", using: :btree
-  add_index "rusers", ["status"], name: "index_rusers_on_status", using: :btree
-  add_index "rusers", ["username", "bio"], name: "index_rusers_on_username_and_bio", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-  add_index "rusers", ["username"], name: "index_rusers_on_username", using: :btree
-
-  create_table "tag_selections", id: false, force: true do |t|
+  create_table "tag_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "tid"
     t.boolean "following", default: false
+    t.index ["user_id", "tid"], name: "index_tag_selections_on_user_id_and_tid", unique: true
   end
 
-  add_index "tag_selections", ["user_id", "tid"], name: "index_tag_selections_on_user_id_and_tid", unique: true, using: :btree
-
-  create_table "term_data", primary_key: "tid", force: true do |t|
-    t.integer "vid",                            default: 0,  null: false
-    t.string  "name",                           default: "", null: false
-    t.text    "description", limit: 2147483647
-    t.integer "weight",      limit: 1,          default: 0,  null: false
+  create_table "term_data", primary_key: "tid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "vid", default: 0, null: false
+    t.string "name", default: "", null: false
+    t.text "description", limit: 4294967295
+    t.integer "weight", limit: 1, default: 0, null: false
     t.integer "count"
-    t.string  "parent"
+    t.string "parent"
+    t.index ["name"], name: "index_term_data_on_name"
+    t.index ["parent"], name: "index_term_data_on_parent"
+    t.index ["vid", "name"], name: "index_term_data_vid_name"
+    t.index ["vid", "weight", "name"], name: "index_vid_weight_name"
   end
 
-  add_index "term_data", ["name"], name: "index_term_data_on_name", using: :btree
-  add_index "term_data", ["parent"], name: "index_term_data_on_parent", using: :btree
-  add_index "term_data", ["vid", "name"], name: "index_term_data_vid_name", using: :btree
-  add_index "term_data", ["vid", "weight", "name"], name: "index_vid_weight_name", using: :btree
-
-  create_table "term_node", id: false, force: true do |t|
+  create_table "term_node", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "nid", default: 0, null: false
     t.integer "vid", default: 0, null: false
     t.integer "tid", default: 0, null: false
+    t.index ["nid"], name: "index_term_node_nid"
+    t.index ["vid"], name: "index_term_node_vid"
   end
 
-  add_index "term_node", ["nid"], name: "index_term_node_nid", using: :btree
-  add_index "term_node", ["vid"], name: "index_term_node_vid", using: :btree
-
-  create_table "upload", id: false, force: true do |t|
-    t.integer "fid",                   default: 0,  null: false
-    t.integer "nid",                   default: 0,  null: false
-    t.integer "vid",                   default: 0,  null: false
-    t.string  "description",           default: "", null: false
-    t.integer "list",        limit: 1, default: 0,  null: false
-    t.integer "weight",      limit: 1, default: 0,  null: false
+  create_table "upload", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "fid", default: 0, null: false
+    t.integer "nid", default: 0, null: false
+    t.integer "vid", default: 0, null: false
+    t.string "description", default: "", null: false
+    t.integer "list", limit: 1, default: 0, null: false
+    t.integer "weight", limit: 1, default: 0, null: false
+    t.index ["fid"], name: "index_upload_fid"
+    t.index ["nid"], name: "index_upload_nid"
   end
 
-  add_index "upload", ["fid"], name: "index_upload_fid", using: :btree
-  add_index "upload", ["nid"], name: "index_upload_nid", using: :btree
-
-  create_table "user_selections", id: false, force: true do |t|
+  create_table "user_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "self_id"
     t.integer "other_id"
     t.boolean "following", default: false
+    t.index ["self_id", "other_id"], name: "index_user_selections_on_self_id_and_other_id", unique: true
   end
 
-  add_index "user_selections", ["self_id", "other_id"], name: "index_user_selections_on_self_id_and_other_id", unique: true, using: :btree
-
-  create_table "user_tags", force: true do |t|
-    t.integer  "uid"
-    t.string   "value"
+  create_table "user_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "uid"
+    t.string "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "data"
@@ -454,5 +423,4 @@ ActiveRecord::Schema.define(version: 2018_08_04_215454) do
   add_index "users", ["mail"], name: "index_users_mail", using: :btree
   add_index "users", ["name"], name: "index_users_name", using: :btree
   add_index "users", ["uid"], name: "index_users_uid", using: :btree
-
 end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -336,7 +336,8 @@ ActiveRecord::Schema.define(version: 2018_08_04_215454) do
     t.string   "token"
     t.integer  "status",                                default: 0
     t.integer "password_checker", default: 0
-    t.index ["username"], name: "rusers_username_fulltext_idx", type: :fulltext
+    t.index ["username", "bio"], name: "index_rusers_on_username_and_bio", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+    t.index ["username"], name: "rusers_username_fulltext_idx", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
   end
 
   create_table "tag_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/test/fixtures/drupal_users.yml
+++ b/test/fixtures/drupal_users.yml
@@ -95,3 +95,24 @@ jeffrey:
   mail: jeff@publiclab.org
   uid: 14
   created: <%= Time.now.to_i %>
+
+steff1:
+  name: steff1
+  status: 1
+  mail: steff1@pxlshp.com
+  uid: 15
+  created: <%= Time.now.to_i %>
+
+steff2:
+  name: steff2
+  status: 1
+  mail: steff2@pxlshp.com
+  uid: 16
+  created: <%= Time.now.to_i %>
+
+steff3:
+  name: steff3
+  status: 1
+  mail: steff3@pxlshp.com
+  uid: 17
+  created: <%= Time.now.to_i %>

--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -258,3 +258,39 @@ welcome_feature:
   status: 1
   type: "feature"
   cached_likes: 0
+
+post_test1:
+  nid: 23
+  uid: 15
+  title: "Post Test 1"
+  path: "/notes/user1/<%= DateTime.new(2018,8,1).strftime("%m-%d-%Y") %>/post-test1"
+  created: <%= DateTime.new(2018,8,1).to_i %>
+  changed: <%= DateTime.new(2018,8,1).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: user1-<%= DateTime.new(2018,8,1).strftime("%m-%d-%Y") %>-post-test1
+
+post_test2:
+  nid: 24
+  uid: 16
+  title: "Post Test 2"
+  path: "/notes/user2/<%= DateTime.new(2018,8,8).strftime("%m-%d-%Y") %>/post-test2"
+  created: <%= DateTime.new(2018,8,8).to_i %>
+  changed: <%= DateTime.new(2018,8,8).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: user2-<%= DateTime.new(2018,8,8).strftime("%m-%d-%Y") %>-post-test2
+
+post_test3:
+  nid: 25
+  uid: 17
+  title: "Post Test 3"
+  path: "/notes/user3/<%= DateTime.new(2018,8,15).strftime("%m-%d-%Y") %>/post-test3"
+  created: <%= DateTime.new(2018,8,15).to_i %>
+  changed: <%= DateTime.new(2018,8,15).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: user3-<%= DateTime.new(2018,8,15).strftime("%m-%d-%Y") %>-post-test3

--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -273,7 +273,7 @@ post_test1:
 
 post_test2:
   nid: 24
-  uid: 16
+  uid: 17
   title: "Post Test 2"
   path: "/notes/user2/<%= DateTime.new(2018,8,8).strftime("%m-%d-%Y") %>/post-test2"
   created: <%= DateTime.new(2018,8,8).to_i %>
@@ -285,7 +285,7 @@ post_test2:
 
 post_test3:
   nid: 25
-  uid: 17
+  uid: 16
   title: "Post Test 3"
   path: "/notes/user3/<%= DateTime.new(2018,8,15).strftime("%m-%d-%Y") %>/post-test3"
   created: <%= DateTime.new(2018,8,15).to_i %>

--- a/test/fixtures/revisions.yml
+++ b/test/fixtures/revisions.yml
@@ -269,7 +269,7 @@ checkbox_two:
   body: |+
     # Heading 1
     List of things
-    * [x] 
+    * [x]
 
 email_body:
   nid: 22
@@ -277,3 +277,24 @@ email_body:
   title: "welcome-email-body"
   body: Welcome to Public Lab
   timestamp: <%= (Time.now - 1.week).to_i %>
+
+post_test1:
+  nid: 23
+  uid: 15
+  title: Post test review 1
+  body: Post test review 1
+  timestamp: <%= DateTime.new(2018,8,1).to_i %>
+
+post_test2:
+  nid: 24
+  uid: 16
+  title: Post test review 2
+  body: Post test review 2
+  timestamp: <%= DateTime.new(2018,8,8).to_i %>
+
+post_test3:
+  nid: 25
+  uid: 17
+  title: Post test review 2
+  body: Post test review 2
+  timestamp: <%= DateTime.new(2018,8,15).to_i %>

--- a/test/fixtures/revisions.yml
+++ b/test/fixtures/revisions.yml
@@ -287,14 +287,14 @@ post_test1:
 
 post_test2:
   nid: 24
-  uid: 16
+  uid: 17
   title: Post test review 2
   body: Post test review 2
   timestamp: <%= DateTime.new(2018,8,8).to_i %>
 
 post_test3:
   nid: 25
-  uid: 17
+  uid: 16
   title: Post test review 2
   body: Post test review 2
   timestamp: <%= DateTime.new(2018,8,15).to_i %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -171,3 +171,42 @@ jeffrey:
   bio: 'Here is something really interesting about Jeff.'
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+steff1:
+  username: steff1
+  status: 1
+  email: steff1@pxlshp.com
+  id: 15
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  last_request_at: <%= Time.now %>
+  bio: ''
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+steff2:
+  username: steff2
+  status: 1
+  email: steff2@pxlshp.com
+  id: 16
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  last_request_at: <%= Time.now %>
+  bio: ''
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+steff3:
+  username: steff3
+  status: 1
+  email: steff3@pxlshp.com
+  id: 17
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  last_request_at: <%= Time.now %>
+  bio: ''
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -313,7 +313,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal selector.size, 17
+    assert_equal selector.size, 20
     assert_select "div p", 'Pending approval by community moderators. Please be patient!'
   end
 
@@ -342,7 +342,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal selector.size, 17
+    assert_equal selector.size, 20
     assert_select "p", "Moderate first-time post: \n              Approve\n              Spam"
   end
 
@@ -554,7 +554,7 @@ class NotesControllerTest < ActionController::TestCase
     assert_redirected_to note.path(:question) + '?_=' + Time.now.to_i.to_s
   end
 
-  
+
   test 'should render a text/plain when the note is edited through xhr' do
     user = UserSession.create(users(:jeff))
     note = nodes(:one)
@@ -648,7 +648,7 @@ class NotesControllerTest < ActionController::TestCase
       old_controller = @controller
       @controller = SettingsController.new
 
-      get :change_locale, params: { locale: lang.to_s } 
+      get :change_locale, params: { locale: lang.to_s }
 
       @controller = old_controller
 

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -75,14 +75,15 @@ class SearchApiTest < ActiveSupport::TestCase
 
      end
 
-   test 'search profiles functionality' do
-     get '/api/srch/profiles?srchString=Jeff'
+   # returns users by id when order_by is not provided and sorted direction default DESC
+   test 'search profiles without order_by and default sort_direction' do
+     get '/api/srch/profiles?srchString=steff'
      assert last_response.ok?
 
      # Expected search pattern
      pattern = {
        srchParams: {
-         srchString: 'Jeff',
+         srchString: 'steff',
          seq: nil,
        }.ignore_extra_keys!
      }.ignore_extra_keys!
@@ -91,23 +92,24 @@ class SearchApiTest < ActiveSupport::TestCase
 
      json = JSON.parse(last_response.body)
 
-     assert_equal "/profile/jeff", json['items'][1]['docUrl']
-     assert_equal "jeff",          json['items'][1]['docTitle']
-     assert_equal "user",          json['items'][1]['docType']
+     assert_equal "/profile/steff3",   json['items'][0]['docUrl']
+     assert_equal "/profile/steff2",   json['items'][1]['docUrl']
+     assert_equal "/profile/steff1",   json['items'][2]['docUrl']
 
      assert matcher =~ json
 
    end
 
-   test 'search recent profiles functionality' do
-     get '/api/srch/profiles?srchString=Jeff&order=recentdesc'
+   # returns users ordered by recent activity and sorted direction default DESC
+   test 'search recent profiles with order_by=recent present' do
+     get '/api/srch/profiles?srchString=steff&order_by=recent'
      assert last_response.ok?
 
      # Expected search pattern
      pattern = {
        srchParams: {
-         srchString: 'Jeff',
-         seq: nil,
+         srchString: 'steff',
+         seq: nil
        }.ignore_extra_keys!
      }.ignore_extra_keys!
 
@@ -115,13 +117,40 @@ class SearchApiTest < ActiveSupport::TestCase
 
      json = JSON.parse(last_response.body)
 
-     assert_equal "/profile/jeff", json['items'][0]['docUrl']
-     assert_equal "jeff",          json['items'][0]['docTitle']
-     assert_equal "user",          json['items'][0]['docType']
+     assert_equal "/profile/steff3",     json['items'][0]['docUrl']
+     assert_equal "/profile/steff2",     json['items'][1]['docUrl']
+     assert_equal "/profile/steff1",     json['items'][2]['docUrl']
+     assert_equal "user",               json['items'][0]['docType']
+     assert_equal "user",               json['items'][1]['docType']
 
      assert matcher =~ json
-
    end
+
+   # returns users ordered by recent activity and sorted by ASC direction
+   test 'search recent profiles with order_by=recent present and sort_direction ASC' do
+     get '/api/srch/profiles?srchString=steff&order_by=recent&sort_direction=ASC'
+     assert last_response.ok?
+
+     # Expected search pattern
+     pattern = {
+       srchParams: {
+         srchString: 'steff',
+         seq: nil
+       }.ignore_extra_keys!
+     }.ignore_extra_keys!
+
+     matcher = JsonExpressions::Matcher.new(pattern)
+
+     json = JSON.parse(last_response.body)
+
+     assert_equal "/profile/steff1",     json['items'][0]['docUrl']
+     assert_equal "/profile/steff2",     json['items'][1]['docUrl']
+     assert_equal "/profile/steff3",     json['items'][2]['docUrl']
+     assert_equal "user",               json['items'][0]['docType']
+     assert_equal "user",               json['items'][1]['docType']
+
+     assert matcher =~ json
+  end
 
   test 'search notes functionality' do
       get '/api/srch/notes?srchString=Blog'

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -99,6 +99,30 @@ class SearchApiTest < ActiveSupport::TestCase
 
    end
 
+   test 'search recent profiles functionality' do
+     get '/api/srch/profiles?srchString=Jeff&order=recentdesc'
+     assert last_response.ok?
+
+     # Expected search pattern
+     pattern = {
+       srchParams: {
+         srchString: 'Jeff',
+         seq: nil,
+       }.ignore_extra_keys!
+     }.ignore_extra_keys!
+
+     matcher = JsonExpressions::Matcher.new(pattern)
+
+     json = JSON.parse(last_response.body)
+
+     assert_equal "/profile/jeff", json['items'][0]['docUrl']
+     assert_equal "jeff",          json['items'][0]['docTitle']
+     assert_equal "user",          json['items'][0]['docType']
+
+     assert matcher =~ json
+
+   end
+
   test 'search notes functionality' do
       get '/api/srch/notes?srchString=Blog'
       assert last_response.ok?

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -100,9 +100,9 @@ class SearchApiTest < ActiveSupport::TestCase
 
    end
 
-   # returns users ordered by recent activity and sorted direction default DESC
-   test 'search recent profiles with order_by=recent present' do
-     get '/api/srch/profiles?srchString=steff&order_by=recent'
+   # returns users sorteded by recent activity and order direction default DESC
+   test 'search recent profiles with sort_by=recent present' do
+     get '/api/srch/profiles?srchString=steff&sort_by=recent'
      assert last_response.ok?
 
      # Expected search pattern
@@ -117,18 +117,16 @@ class SearchApiTest < ActiveSupport::TestCase
 
      json = JSON.parse(last_response.body)
 
-     assert_equal "/profile/steff3",     json['items'][0]['docUrl']
-     assert_equal "/profile/steff2",     json['items'][1]['docUrl']
-     assert_equal "/profile/steff1",     json['items'][2]['docUrl']
-     assert_equal "user",               json['items'][0]['docType']
-     assert_equal "user",               json['items'][1]['docType']
+     assert_equal "steff3",     json['items'][0]['docTitle']
+     assert_equal "steff2",     json['items'][1]['docTitle']
+     assert_equal "steff1",     json['items'][2]['docTitle']
 
      assert matcher =~ json
    end
 
    # returns users ordered by recent activity and sorted by ASC direction
-   test 'search recent profiles with order_by=recent present and sort_direction ASC' do
-     get '/api/srch/profiles?srchString=steff&order_by=recent&sort_direction=ASC'
+   test 'search recent profiles with sort_by=recent present and order_direction ASC' do
+     get '/api/srch/profiles?srchString=steff&sort_by=recent&order_direction=ASC'
      assert last_response.ok?
 
      # Expected search pattern
@@ -146,8 +144,6 @@ class SearchApiTest < ActiveSupport::TestCase
      assert_equal "/profile/steff1",     json['items'][0]['docUrl']
      assert_equal "/profile/steff2",     json['items'][1]['docUrl']
      assert_equal "/profile/steff3",     json['items'][2]['docUrl']
-     assert_equal "user",               json['items'][0]['docType']
-     assert_equal "user",               json['items'][1]['docType']
 
      assert matcher =~ json
   end

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -117,8 +117,8 @@ class SearchApiTest < ActiveSupport::TestCase
 
      json = JSON.parse(last_response.body)
 
-     assert_equal "steff3",     json['items'][0]['docTitle']
-     assert_equal "steff2",     json['items'][1]['docTitle']
+     assert_equal "steff2",     json['items'][0]['docTitle']
+     assert_equal "steff3",     json['items'][1]['docTitle']
      assert_equal "steff1",     json['items'][2]['docTitle']
 
      assert matcher =~ json
@@ -142,8 +142,8 @@ class SearchApiTest < ActiveSupport::TestCase
      json = JSON.parse(last_response.body)
 
      assert_equal "/profile/steff1",     json['items'][0]['docUrl']
-     assert_equal "/profile/steff2",     json['items'][1]['docUrl']
-     assert_equal "/profile/steff3",     json['items'][2]['docUrl']
+     assert_equal "/profile/steff3",     json['items'][1]['docUrl']
+     assert_equal "/profile/steff2",     json['items'][2]['docUrl']
 
      assert matcher =~ json
   end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -246,7 +246,9 @@ class NodeTest < ActiveSupport::TestCase
 
   test 'should find all research notes' do
     notes = Node.research_notes
-    expected = [nodes(:one), nodes(:spam), nodes(:first_timer_note), nodes(:blog), nodes(:moderated_user_note), nodes(:activity), nodes(:upgrade), nodes(:draft)]
+    expected = [nodes(:one), nodes(:spam), nodes(:first_timer_note), nodes(:blog),
+                nodes(:moderated_user_note), nodes(:activity), nodes(:upgrade),
+                nodes(:draft), nodes(:post_test1), nodes(:post_test2), nodes(:post_test3)]
     assert_equal expected, notes
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -43,6 +43,16 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'user mysql native fulltext search 2' do
+    assert User.count > 0
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      users = User.search('steff')
+      assert users.first.username 'steff'
+      assert_not_nil users
+      assert users.length > 0
+    end
+  end
+
   test 'user questions' do
     user = users(:jeff)
     assert !user.questions.empty?

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -43,16 +43,6 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test 'user mysql native fulltext search 2' do
-    assert User.count > 0
-    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      users = User.search('steff')
-      assert users.first.username 'steff'
-      assert_not_nil users
-      assert users.length > 0
-    end
-  end
-
   test 'user questions' do
     user = users(:jeff)
     assert !user.questions.empty?

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -37,7 +37,7 @@ class UserTest < ActiveSupport::TestCase
   test 'user mysql native fulltext search' do
     assert User.count > 0
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      users = User.search('really interesting')
+      users = User.search('jeff')
       assert_not_nil users
       assert users.length > 0
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -37,7 +37,7 @@ class UserTest < ActiveSupport::TestCase
   test 'user mysql native fulltext search' do
     assert User.count > 0
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      users = User.search('jeff')
+      users = User.search_by_username('jeff')
       assert_not_nil users
       assert users.length > 0
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -37,7 +37,7 @@ class UserTest < ActiveSupport::TestCase
   test 'user mysql native fulltext search' do
     assert User.count > 0
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      users = User.search_by_username('jeff')
+      users = User.search('jeff')
       assert_not_nil users
       assert users.length > 0
     end


### PR DESCRIPTION
Hey everyone!

We are opening this request to fix the issue #3069. 

1. We created a new endpoint `recentprofiles` that returns the profiles with most recent activity.
2. We fixed `recentPeople` method. In one of our latest PR (#3045) we did the following change that was not correct. Because in this part of the code the limit is for the node search. So we undid this change and added a count to control the number of profiles returned ([line 290](https://github.com/publiclab/plots2/pull/3126/files#diff-9546dd6074cdca7a128c2bf04fa5367aR290)).

>nodes = Node.all.order("changed DESC").limit(100).distinct -> nodes = Node.all.order("changed DESC").limit(srchString).distinct

3. We don't think the name of the `recentPeople` method is appropriate for the `peopleLocations` endpoint, since the method returns the location of people with most recent activity with a specific tag. Can we change it to `peopleLocations`? So maybe we can use `recentPeople` for our new method.

We would like some feedback about our strategy here, thank you! :)

fixes #3069 
@publiclab/reviewers @publiclab/soc @jywarren