### PR TITLE
#3142 moved all sidebar content to right, made tags visible on sm/xs

### DIFF
--- a/app/views/like/index.html.erb
+++ b/app/views/like/index.html.erb
@@ -1,5 +1,3 @@
-<%= render :partial => "sidebar/featured" %>
-
 <div class="col-md-9">
 <h1> <%= t('like.index.recent_likes') %> </h1>
 <% if current_user && (current_user.role == "admin" || current_user.role == "moderator") %>
@@ -49,3 +47,5 @@
 <%= will_paginate @likes, :renderer => BootstrapPagination::Rails if @paginated %>
 
 </div>
+
+<%= render :partial => "sidebar/featured" %>

--- a/app/views/map/show.html.erb
+++ b/app/views/map/show.html.erb
@@ -4,7 +4,6 @@
 <% end %>
 
 <div class="row">
-  <%= render :partial => "sidebar/related" %>
 
 <div class="col-md-9">
 
@@ -75,8 +74,7 @@
   <%= render :partial => "home/social" %>
   <hr />
 
-  <%= render :partial => "tag/tagging" %>
-
   <%= render :partial => "notes/comments" %>
 
 </div><!--/span-->
+<%= render partial: "sidebar/related" %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,10 +1,3 @@
-<% if params[:controller] == "tag" || params[:controller] == "search" %>
-  <%= render :partial => "sidebar/related" %>
-<% elsif params[:action] == "author" || params[:action] == "author_topic" %>
-  <%= render :partial => "sidebar/author" %>
-<% else %>
-  <%= render :partial => "sidebar/user" %>
-<% end %>
 <div class="col-md-9">
   <% if params[:controller] == "search" %>
     <h3><%= raw t('notes.index.search_results_for', :params => params[:id]) %> <small>(<a href="/search/advanced/<%= params[:id] %>"><%= t('notes.index.advanced_search') %></a>)</h3>
@@ -44,3 +37,11 @@
   <hr />
   
 </div>
+
+<% if params[:controller] == "tag" || params[:controller] == "search" %>
+  <%= render :partial => "sidebar/related" %>
+<% elsif params[:action] == "author" || params[:action] == "author_topic" %>
+  <%= render :partial => "sidebar/author" %>
+<% else %>
+  <%= render :partial => "sidebar/user" %>
+<% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -115,4 +115,4 @@
 
 </div><!--/span-->
 
-<%= render :partial => "sidebar/related", :locals => {:include_tagging => true} %>
+<%= render partial: "sidebar/related" %>

--- a/app/views/searches/dynamic.html.erb
+++ b/app/views/searches/dynamic.html.erb
@@ -1,7 +1,5 @@
 <% content_for (:head) { javascript_include_tag "dynamic_search" } %>
 
-<%= render :partial => "sidebar/related" %>
-
 <div class="col-md-9">
   <h3 style="margin-top:0;">Dynamic Search Page</h3>
 
@@ -81,3 +79,5 @@
     </div>
   </div>
 </div>
+
+<%= render :partial => "sidebar/related" %>

--- a/app/views/sidebar/_featured.html.erb
+++ b/app/views/sidebar/_featured.html.erb
@@ -1,17 +1,25 @@
-<%include_tagging = local_assigns.fetch :include_tagging, false #not all things using this sidebar uses tagging%>
+<div class="col-md-3 hidden-print">
 
-<div class="col-md-3">
+  <a style="margin-top:-16px;margin-bottom:0;" class="btn btn-mini btn-block btn-link visible-xs visible-sm" href="javascript:void()" onClick="toggle_sidebar()"><i class="fa fa-chevron-down"></i></a>
 
-  <% if params[:controller] != "home" && params[:action] != "home" %>
-    <%= render :partial => "sidebar/post_button" %>
-  <% end %>
+  <div id="sidebar" class="hidden-xs hidden-sm">
 
-  <% cache('feature_sidebar-feature', skip_digest: true) do %>
-    <%= feature('sidebar-feature') %>
-  <% end %>
+    <% if params[:controller] != "home" && params[:action] != "home" %>
+      <%= render :partial => "sidebar/post_button" %>
+    <% end %>
 
-  <% if include_tagging %>
-    <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
-  <% end %>
+    <% cache('feature_sidebar-feature', skip_digest: true) do %>
+      <%= feature('sidebar-feature') %>
+    <% end %>
 
+
+  </div>
+
+  <div id=sidebar-tags>
+    <% if @node %>
+      <%= render partial: 'tag/tagging' %>
+    <% end %>
+  </div>
+  
 </div>
+<%= javascript_include_tag 'sidebar' %>

--- a/app/views/sidebar/_question.html.erb
+++ b/app/views/sidebar/_question.html.erb
@@ -26,6 +26,9 @@
 
   </div>
 
-  <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
+  <div id=sidebar-tags>
+    <%= render partial: 'tag/tagging' %>
+  </div>
+  
 </div>
 <%= javascript_include_tag 'sidebar' %>

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -1,5 +1,3 @@
-<%include_tagging = local_assigns.fetch :include_tagging, false #not all things using this sidebar uses tagging%>
-
 <div class="col-md-3 hidden-print">
 
   <a style="margin-top:-16px;margin-bottom:0;" class="btn btn-mini btn-block btn-link visible-xs visible-sm" href="javascript:void()" onClick="toggle_sidebar()"><i class="fa fa-chevron-down"></i></a>
@@ -46,45 +44,6 @@
     <%= render partial: 'sidebar/notes', locals: { notes: @node.responses, title: I18n.t('sidebar._related.responses_to_note'), node: @node } %>
   <% end %>
 
-  <% if params[:action] != "contributors" %>
-    <% if @notes && @notes.length > 0 %>
-    <h4><%= t('sidebar._related.recent_topic_contributors') %></h4>
-    <% @notes.collect(&:author).collect(&:name).uniq.each do |author| %>
-      <p>
-        <i class="fa fa-user"></i>
-        <a href="/profile/<%= author %>"><%= author %></a>
-      </p>
-    <% end %>
-
-    <% if params[:controller] == "tag" || (@node && @node.type == "page") %><a href="/contributors/<%= params[:id] %>"><i class="fa fa-list"></i> <%= t('sidebar._related.contributors_for_this_topic') %> &raquo;</a><% end %>
-    <% end %>
-
-    <% if @users && @users.length > 0 %>
-    <h4><%= t('sidebar._related.contributors') %></h4>
-      <% @users.each do |author| %>
-      <p>
-        <i class="fa fa-user"></i>
-        <a href="/profile/<%= author.name %>"><%= author.name %></a>
-      </p>
-      <% end %>
-      <p><a href="/contributors/<%= params[:id] %>"><i class="fa fa-list"></i> <%= t('sidebar._related.contributors_for_this_topic') %> &raquo;</a></p>
-    <% end %>
-  <% end %>
-
-
-  <% if (params[:controller] != "tag") && @node && !@node.has_tag('tabbed:wikis') %>
-    <% if params[:controller] == "notes" && params[:action] == "index" %>
-      <%= render partial: 'sidebar/wikis', locals: { wikis: @wikis, title: I18n.t('sidebar._related.recent_wiki_edits'), node: @node } %>
-    <% else %>
-      <%= render partial: 'sidebar/wikis', locals: { wikis: @wikis, title: I18n.t('sidebar._related.recent_wiki_pages'), node: @node } %>
-    <% end %>
-  <% end %>
-
-
-  <% if params[:controller] != "tag" && params[:controller] != "search" %>
-    <%= render partial: 'sidebar/notes', locals: { notes: @notes, title: I18n.t('sidebar._related.related_research_notes'), node: @node } %>
-  <% end %>
-
   <% if @maps && @maps.length > 0 && params[:controller] != "search" %>
 
     <br />
@@ -97,17 +56,15 @@
 
     <br style="clear:both;" />
 
-
-    <% if params[:controller] != "tag" && params[:controller] != "search" %>
-      <%= render partial: 'sidebar/notes', locals: { notes: @maps, title: I18n.t('sidebar._related.related_maps'), node: @node } %>
-    <% end %>
-
-  <% end %>
-
-  <% if include_tagging %>
-    <%= render partial: 'tag/tagging', locals: { sidebar_tagging: true } %>
   <% end %>
 
   </div>
+
+  <% if @node %>
+    <div id=sidebar-tags>
+      <%= render partial: 'tag/tagging' %>
+    </div>
+  <% end %>
+  
 </div>
 <%= javascript_include_tag 'sidebar' %>

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -1,9 +1,5 @@
-<%sidebar_tagging = local_assigns.fetch :sidebar_tagging, false #preserves user, map tagging orientation %>
-
-<% if sidebar_tagging %>
-  <h1>Tags</h1>
-  <em class="italics">Tags help organize our knowledge base. Click to find more on a topic.</em>
-<% end %>
+<h1>Tags</h1>
+<em class="italics">Tags help organize our knowledge base. Click to find more on a topic.</em>
 
 <% if @node %>
   <%= render partial: 'tag/replication' %>
@@ -50,7 +46,7 @@ $(".label").on("click", function(e){
 <form id="tagform" class="form" data-remote="true" action="<%= url %>">
   <div class="control-group">
     <input name="remote" type="hidden" value="true" />
-    <div class="<%= sidebar_tagging ? 'input-group' : 'input-group col-md-6' =%>">
+    <div class="input-group">
       <span class="input-group-addon"><i class="fa fa-tags"></i></span>
       <input autocomplete="off" class="tag-input form-control" name="name" type="text" placeholder="<%= t('tag._tagging.enter_tags') %>" data-provide="typeahead" />
       <div class="input-group-btn">

--- a/app/views/tag/contributors-index.html.erb
+++ b/app/views/tag/contributors-index.html.erb
@@ -1,4 +1,3 @@
-<%= render :partial => "sidebar/featured" %>
 <div class="col-md-9">
   <% if !@tags.empty? %>
     <% @tags.each do |tag| %>
@@ -63,3 +62,5 @@
   <% end %>
 
 </div>
+
+<%= render partial: "sidebar/featured" %>

--- a/app/views/tag/contributors.html.erb
+++ b/app/views/tag/contributors.html.erb
@@ -1,4 +1,3 @@
-<%= render :partial => "sidebar/related" %>
 <div class="col-md-9">
   <% if @tag %>
     <div id="note-graph" style="height:100px;"></div>
@@ -67,3 +66,4 @@
   <%= render :partial => "tag/contributors" %>
 
 </div>
+<%= render :partial => "sidebar/related" %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,3 +1,122 @@
+<div class="col-md-9">
+
+  <div id = "note-graph" style = "overflow: auto; text-align:center; border: 1px solid #E5E5E5; margin-bottom: 10px;"></div>
+
+  <h3 style="margin-top:0;"><%= @user.name %> <%= @user.new_contributor %>
+    <small>
+      <%= @user.node_count %> <%= raw t('users.profile.notes_and_edits', :url1 => "/notes/author/"+@user.name) %>
+      <% if current_user && current_user.role == "admin" %> | <%= @user.email %><% end %>
+      <% if @user.role == "moderator" %> | <i class="fa fa-certificate"></i> <%= t('users.profile.moderator') %><% end %>
+      <% if @user.role == "admin" %> | <i class="fa fa-certificate"></i> <%= t('users.profile.admin') %><% end %>
+      <% if @user.status == 0 %> | <i class="fa fa-ban" style="color:#a00;"></i> <%= t('users.profile.banned') %><% end %>
+    </small>
+  </h3>
+
+  <p><small><%= raw auto_link(RDiscount.new(@profile_user.bio || '').to_html, :sanitize => false) %></small></p>
+
+  <hr />
+  <div class="row" id="highlight" style=" text-align: center;">
+    <h3 class="col-md-4 col-xs-12 col-sm-4"><a href = "/tag/question:*/author/<%= params[:id] %>"><%= Node.questions.where(status: 1, uid: @user.id).length %> questions asked </a><br><br> <%= Answer.where(uid: @profile_user.id).count %> answers posted</h3>
+    <h3 class="col-md-4 col-xs-12 col-sm-4"><a href = "/tag/activity:*/author/<%= params[:id] %>"><%= @count_activities_posted %> activities posted </a><br><br> <a href = "/tag/replication:*/author/<%= params[:id] %>"><%= @count_activities_attempted %> activities attempted</a></h3>
+     <% if !@map_lat.nil? && !@map_lon.nil? %>
+      <%= render :partial => "map/userLeaflet" , locals: {haslocation: true} %>
+    <% elsif !current_user.nil? && current_user.id == @user.id %>
+    <%= render :partial => "map/userLeaflet" , locals: {haslocation: false} %>
+    <% end %>
+  </div>
+  <hr />
+
+  <span style="float:right;"><small><%= raw t('users.profile.joined_time_ago', :time_ago => distance_of_time_in_words(@user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' })) %></small></span>
+  <br>
+
+  <ul class="nav nav-tabs">
+    <li class="active"><a href="#research" data-toggle="tab"><i class="fa fa-file"></i><span class="hidden-sm hidden-xs"> <%= t('users.profile.research') %></span><% if current_user && current_user.uid == @profile_user.uid %> <%= "(#{@notes.count + @coauthored.count + @drafts.count })" %><% else %><%= "(#{ @notes.count + @coauthored.count })" %><% end %></a></li>
+    <li><a href="#questions" data-toggle="tab"><i class="fa fa-question-circle"></i><span class="hidden-sm hidden-xs"> <%= t('users.profile.questions') %></span> (<%= Node.questions.where(status: 1, uid: @user.id).length %>)</a></li>
+    <li><a href="#comments" id="comments-tab" data-toggle="tab"><i class="fa fa-comment"></i><span class="hidden-sm hidden-xs"> Comments</span> (<%= @comment_count %>)</a></li>
+    <li><a href="#likes" data-toggle="tab"><i class="fa fa-star"></i><span class="hidden-sm hidden-xs"> <%= t('users.profile.liked') %></span> (<%= @user.like_count %>)</a></li>
+    <li><a href="#barnstars" data-toggle="tab"><i class="fa fa-certificate"></i><span class="hidden-sm hidden-xs"> Barnstars</span> (<%= @user.user.try(:barnstars).try(:length) %>)</a></li>
+  </ul>
+
+  <br />
+
+ <div class="tab-content">
+
+    <div class="tab-pane active" id="research">
+      <div class="btn-group text-center">
+        <a href="#notes" class="btn btn-default" data-toggle="tab">Authored <%= "(#{ @notes.count })" %></a>
+        <a href="#coauthored" class="btn btn-default" data-toggle="tab">Coauthored  <%= "(#{ @coauthored.count })" %></a>
+        <% if current_user && current_user.uid == @profile_user.uid %><a href="#draft" class="btn btn-default" data-toggle="tab">Drafts <%= "(#{ @drafts.count })" %></a><% end %>
+      </div>
+
+      <br />
+
+      <div class="tab-content">
+        <div class="tab-pane active" id="notes">
+          <%= render :partial => "notes/notes" %>
+        </div>
+
+        <div class="tab-pane" id="coauthored">
+          <%= render :partial => "notes/coauthored_notes" %>
+        </div>
+
+        <% if current_user && current_user.uid == @profile_user.uid %>
+            <div class="tab-pane" id="draft">
+              <%= render :partial => "notes/draft_notes" %>
+            </div>
+        <% end %>
+      </div>
+    </div>
+
+   <div class="tab-pane" id="questions">
+     <div class="btn-group text-center">
+       <a href="#asked" class="btn btn-default active" data-toggle="tab">Asked</a>
+       <a href="#answered" class="btn btn-default" data-toggle="tab">Answered</a>
+     </div>
+
+     <div class="tab-content">
+       <div class="tab-pane active" id="asked">
+         <%= render :partial => "questions/questions" %>
+       </div>
+
+       <div class="tab-pane" id="answered">
+         <%= render :partial => "users/answered" %>
+       </div>
+     </div>
+   </div>
+
+    <div class="tab-pane" id="maps">
+      <p><i><%= raw t('users.profile.view_these_maps', :url1 => "//mapknitter.org/profile/"+@user.name) %></i></p>
+      <table class="table">
+        <tr>
+          <th style="width:200px;"><%= t('users.profile.title') %></th>
+          <th style="width:200px;"><%= t('users.profile.creation_date') %></th>
+          <th><%= t('users.profile.image') %></th>
+        </tr>
+      </table>
+    </div>
+
+    <div class="tab-pane" id="comments">
+      <h2 style="text-align:center;"><i class="fa fa-spinner fa fa-spin"></i></h2>
+    </div>
+
+    <div class="tab-pane" id="likes">
+      <%= render :partial => "users/likes" %>
+    </div>
+
+    <div class="tab-pane" id="barnstars">
+      <% if @user.user %>
+      <% @user.user.barnstars.each do |tag| %>
+        <p style="color:#aaa;"><i style="color:#db4;" class="fa fa-large fa fa-star-o"></i> <i><%= raw t('users.profile.barnstar_awarded_to_by', :url1 => "/profile/"+tag.node.author.name, :author => tag.node.author.name, :url2 => "/wiki/barnstars#"+tag.name.split(':').last.split('-').each{|w| w.capitalize!}.join('+'), :barnstar => tag.name.split(':').last.split('-').each{|w| w.capitalize!}.join(' '), :url3 => "/profile/"+tag.author.username, :awarder => tag.author.username, :url4 => tag.node.path, :work => tag.node.title) %></i></p>
+        <hr />
+      <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <hr />
+
+</div>
+
 <div class="col-md-3">
   <% if @user.user %>
     <img class="hidden-xs hidden-sm img-rounded" id="profile-photo" style="width:100%;margin-bottom:10px;" src="<%= @user.user.profile_image %>" />
@@ -5,6 +124,7 @@
       <img class="img-circle" id="profile-photo" style="width:50%;margin-bottom:20px;" src="<%= @user.user.photo_path %>" />
     </div>
   <% end %>
+  <%= render :partial => "tag/tagging", locals: { url: "/profile/tags/create/#{ @user.id }", parent: :profile } %>
 
   <div class="profile_icons" style="text-align: center;">
   <% if @twitter.nil? == false %>
@@ -146,126 +266,6 @@
 
 </div>
 
-<div class="col-md-9">
-
-  <div id = "note-graph" style = "overflow: auto; text-align:center; border: 1px solid #E5E5E5; margin-bottom: 10px;"></div>
-
-  <h3 style="margin-top:0;"><%= @user.name %> <%= @user.new_contributor %>
-    <small>
-      <%= @user.node_count %> <%= raw t('users.profile.notes_and_edits', :url1 => "/notes/author/"+@user.name) %>
-      <% if current_user && current_user.role == "admin" %> | <%= @user.email %><% end %>
-      <% if @user.role == "moderator" %> | <i class="fa fa-certificate"></i> <%= t('users.profile.moderator') %><% end %>
-      <% if @user.role == "admin" %> | <i class="fa fa-certificate"></i> <%= t('users.profile.admin') %><% end %>
-      <% if @user.status == 0 %> | <i class="fa fa-ban" style="color:#a00;"></i> <%= t('users.profile.banned') %><% end %>
-    </small>
-  </h3>
-
-  <p><small><%= raw auto_link(RDiscount.new(@profile_user.bio || '').to_html, :sanitize => false) %></small></p>
-
-  <hr />
-  <div class="row" id="highlight" style=" text-align: center;">
-    <h3 class="col-md-4 col-xs-12 col-sm-4"><a href = "/tag/question:*/author/<%= params[:id] %>"><%= Node.questions.where(status: 1, uid: @user.id).length %> questions asked </a><br><br> <%= Answer.where(uid: @profile_user.id).count %> answers posted</h3>
-    <h3 class="col-md-4 col-xs-12 col-sm-4"><a href = "/tag/activity:*/author/<%= params[:id] %>"><%= @count_activities_posted %> activities posted </a><br><br> <a href = "/tag/replication:*/author/<%= params[:id] %>"><%= @count_activities_attempted %> activities attempted</a></h3>
-     <% if !@map_lat.nil? && !@map_lon.nil? %>
-      <%= render :partial => "map/userLeaflet" , locals: {haslocation: true} %>
-    <% elsif !current_user.nil? && current_user.id == @user.id %>
-    <%= render :partial => "map/userLeaflet" , locals: {haslocation: false} %>
-    <% end %>
-  </div>
-  <hr />
-
-  <span style="float:right;"><small><%= raw t('users.profile.joined_time_ago', :time_ago => distance_of_time_in_words(@user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' })) %></small></span>
-  <br>
-
-  <ul class="nav nav-tabs">
-    <li class="active"><a href="#research" data-toggle="tab"><i class="fa fa-file"></i><span class="hidden-sm hidden-xs"> <%= t('users.profile.research') %></span><% if current_user && current_user.uid == @profile_user.uid %> <%= "(#{@notes.count + @coauthored.count + @drafts.count })" %><% else %><%= "(#{ @notes.count + @coauthored.count })" %><% end %></a></li>
-    <li><a href="#questions" data-toggle="tab"><i class="fa fa-question-circle"></i><span class="hidden-sm hidden-xs"> <%= t('users.profile.questions') %></span> (<%= Node.questions.where(status: 1, uid: @user.id).length %>)</a></li>
-    <li><a href="#comments" id="comments-tab" data-toggle="tab"><i class="fa fa-comment"></i><span class="hidden-sm hidden-xs"> Comments</span> (<%= @comment_count %>)</a></li>
-    <li><a href="#likes" data-toggle="tab"><i class="fa fa-star"></i><span class="hidden-sm hidden-xs"> <%= t('users.profile.liked') %></span> (<%= @user.like_count %>)</a></li>
-    <li><a href="#barnstars" data-toggle="tab"><i class="fa fa-certificate"></i><span class="hidden-sm hidden-xs"> Barnstars</span> (<%= @user.user.try(:barnstars).try(:length) %>)</a></li>
-  </ul>
-
-  <br />
-
- <div class="tab-content">
-
-    <div class="tab-pane active" id="research">
-      <div class="btn-group text-center">
-        <a href="#notes" class="btn btn-default" data-toggle="tab">Authored <%= "(#{ @notes.count })" %></a>
-        <a href="#coauthored" class="btn btn-default" data-toggle="tab">Coauthored  <%= "(#{ @coauthored.count })" %></a>
-        <% if current_user && current_user.uid == @profile_user.uid %><a href="#draft" class="btn btn-default" data-toggle="tab">Drafts <%= "(#{ @drafts.count })" %></a><% end %>
-      </div>
-
-      <br />
-
-      <div class="tab-content">
-        <div class="tab-pane active" id="notes">
-          <%= render :partial => "notes/notes" %>
-        </div>
-
-        <div class="tab-pane" id="coauthored">
-          <%= render :partial => "notes/coauthored_notes" %>
-        </div>
-
-        <% if current_user && current_user.uid == @profile_user.uid %>
-            <div class="tab-pane" id="draft">
-              <%= render :partial => "notes/draft_notes" %>
-            </div>
-        <% end %>
-      </div>
-    </div>
-
-   <div class="tab-pane" id="questions">
-     <div class="btn-group text-center">
-       <a href="#asked" class="btn btn-default active" data-toggle="tab">Asked</a>
-       <a href="#answered" class="btn btn-default" data-toggle="tab">Answered</a>
-     </div>
-
-     <div class="tab-content">
-       <div class="tab-pane active" id="asked">
-         <%= render :partial => "questions/questions" %>
-       </div>
-
-       <div class="tab-pane" id="answered">
-         <%= render :partial => "users/answered" %>
-       </div>
-     </div>
-   </div>
-
-    <div class="tab-pane" id="maps">
-      <p><i><%= raw t('users.profile.view_these_maps', :url1 => "//mapknitter.org/profile/"+@user.name) %></i></p>
-      <table class="table">
-        <tr>
-          <th style="width:200px;"><%= t('users.profile.title') %></th>
-          <th style="width:200px;"><%= t('users.profile.creation_date') %></th>
-          <th><%= t('users.profile.image') %></th>
-        </tr>
-      </table>
-    </div>
-
-    <div class="tab-pane" id="comments">
-      <h2 style="text-align:center;"><i class="fa fa-spinner fa fa-spin"></i></h2>
-    </div>
-
-    <div class="tab-pane" id="likes">
-      <%= render :partial => "users/likes" %>
-    </div>
-
-    <div class="tab-pane" id="barnstars">
-      <% if @user.user %>
-      <% @user.user.barnstars.each do |tag| %>
-        <p style="color:#aaa;"><i style="color:#db4;" class="fa fa-large fa fa-star-o"></i> <i><%= raw t('users.profile.barnstar_awarded_to_by', :url1 => "/profile/"+tag.node.author.name, :author => tag.node.author.name, :url2 => "/wiki/barnstars#"+tag.name.split(':').last.split('-').each{|w| w.capitalize!}.join('+'), :barnstar => tag.name.split(':').last.split('-').each{|w| w.capitalize!}.join(' '), :url3 => "/profile/"+tag.author.username, :awarder => tag.author.username, :url4 => tag.node.path, :work => tag.node.title) %></i></p>
-        <hr />
-      <% end %>
-      <% end %>
-    </div>
-  </div>
-
-  <hr />
-
-  <%= render :partial => "tag/tagging", locals: { url: "/profile/tags/create/#{ @user.id }", parent: :profile } %>
-
-</div>
 <script src = "https://cdn.jsdelivr.net/npm/frappe-charts@0.0.8/dist/frappe-charts.min.iife.js"></script>
 
 <script type = "text/javascript">

--- a/app/views/wiki/index.html.erb
+++ b/app/views/wiki/index.html.erb
@@ -1,5 +1,3 @@
-<%= render :partial => "sidebar/featured" %>
-
 <div class="col-md-9">
 
   <% if params[:controller] == "tag" %>
@@ -29,4 +27,4 @@
   <hr />
 
 </div>
-
+<%= render partial: "sidebar/featured" %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -88,9 +88,9 @@
   <%= render :partial => "sidebar/none" %>
 <% else %>
   <% if (@wikis.nil? && @notes.nil?) || @node.has_tag('sidebar:featured') %>
-    <%= render :partial => "sidebar/featured", :locals => {:include_tagging => true} %>
+    <%= render :partial => "sidebar/featured" %>
   <% else %>
-    <%= render :partial => "sidebar/related", :locals => {:include_tagging => true} %>
+    <%= render :partial => "sidebar/related" %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Fixes #3142, I've moved all sidebar content to the right side site wide (including maps and users, various indexes), as well as made sidebar collapsible on sm/xs sizes, while keeping tags visible.
-----

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
