### PR TITLE
#3143 added related tags to tag page

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -142,6 +142,7 @@ class TagController < ApplicationController
     @tag = Tag.find_by(name: params[:id])
     @note_count = Tag.tagged_node_count(params[:id]) || 0
     @users = Tag.contributors(@tagnames[0])
+    @related_tags = Tag.related(@tagnames[0])
 
     respond_with(nodes) do |format|
       format.html { render 'tag/show' }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -303,14 +303,16 @@ class Tag < ApplicationRecord
 
   def self.related(tag_name)
     Rails.cache.fetch('related-tags/' + tag_name, expires_in: 1.weeks) do
-      nids = NodeTag.joins(:tag).where(Tag.table_name => {name: tag_name}).select(:nid)
+       nids = NodeTag.joins(:tag)
+                     .where(Tag.table_name => { name: tag_name })
+                     .select(:nid)
 
-      Tag.joins(:node_tag)
-         .where(NodeTag.table_name => {nid: nids})
+       Tag.joins(:node_tag)
+         .where(NodeTag.table_name => { nid: nids })
          .where.not(name: tag_name)
          .group(:tid)
          .order('COUNT(term_data.tid) DESC')
          .limit(5)
-     end
+    end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -300,4 +300,17 @@ class Tag < ApplicationRecord
         .where('term_data.name = ?', tag_name)
         .count
   end
+
+  def self.related(tag_name)
+    Rails.cache.fetch('related-tags/' + tag_name, expires_in: 1.weeks) do
+      nids = NodeTag.joins(:tag).where(Tag.table_name => {name: tag_name}).select(:nid)
+
+      Tag.joins(:node_tag)
+         .where(NodeTag.table_name => {nid: nids})
+         .where.not(name: tag_name)
+         .group(:tid)
+         .order('COUNT(term_data.tid) DESC')
+         .limit(5)
+     end
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -303,11 +303,11 @@ class Tag < ApplicationRecord
 
   def self.related(tag_name)
     Rails.cache.fetch('related-tags/' + tag_name, expires_in: 1.weeks) do
-       nids = NodeTag.joins(:tag)
+      nids = NodeTag.joins(:tag)
                      .where(Tag.table_name => { name: tag_name })
                      .select(:nid)
 
-       Tag.joins(:node_tag)
+      Tag.joins(:node_tag)
          .where(NodeTag.table_name => { nid: nids })
          .where.not(name: tag_name)
          .group(:tid)

--- a/app/views/tag/_related.html.erb
+++ b/app/views/tag/_related.html.erb
@@ -1,0 +1,8 @@
+<h2>Related Tags</h2>
+<ul class= "list-inline">
+  <% tags.each do |tag| %>
+      <li><span id="tag_<%= tag.tid %>" class="label label-default">
+        <%= tag.name %>
+      </span></li>
+  <% end %>
+</ul>

--- a/app/views/tag/_related.html.erb
+++ b/app/views/tag/_related.html.erb
@@ -1,8 +1,10 @@
-<h2>Related Tags</h2>
-<ul class= "list-inline">
-  <% tags.each do |tag| %>
-      <li><a href='/tag/<%= tag.name %>' id="tag_<%= tag.tid %>" class="label <%= tag.name.include?(":") ? 'label-primary' : 'label-default' %>">
-        <%= tag.name %>
-      </a></li>
-  <% end %>
-</ul>
+<div class="row">
+  <ul class= "list-inline col-md-10">
+    <li><strong>Related Tags:</strong></li>
+    <% tags.each do |tag| %>
+        <li><a href='/tag/<%= tag.name %>' id="tag_<%= tag.tid %>" class="label <%= tag.name.include?(":") ? 'label-primary' : 'label-default' %>">
+          <%= tag.name %>
+        </a></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/tag/_related.html.erb
+++ b/app/views/tag/_related.html.erb
@@ -1,8 +1,8 @@
 <h2>Related Tags</h2>
 <ul class= "list-inline">
   <% tags.each do |tag| %>
-      <li><span id="tag_<%= tag.tid %>" class="label label-default">
+      <li><a href='/tag/<%= tag.name %>' id="tag_<%= tag.tid %>" class="label <%= tag.name.include?(":") ? 'label-primary' : 'label-default' %>">
         <%= tag.name %>
-      </span></li>
+      </a></li>
   <% end %>
 </ul>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -71,6 +71,10 @@
 
   <% unless @wildcard %><p style="clear:both;padding-top:8px;"><a style="margin-bottom:6px;" class="btn btn-primary" href="/post?tags=question:<%= params[:id].gsub('question:', '') %>&template=question&redirect=question"><i class="fa fa-white icon-question-circle"></i> <%= raw t('tag.show.ask_question', :tag => params[:id].gsub('question:', '')) %></a> <%= raw t('tag.show.or_subscribe_to_answer', :url1 => "/subscribe/tag/question:"+params[:id].gsub('question:', '')) %></p><% end %>
 
+  <% if @related_tags %>
+      <%=  render :partial => "tag/related", :locals => {tags: @related_tags } %>
+  <% end %>
+
   <ul class="nav nav-tabs" style="margin-top:10px;">
     <% if params[:action] == "show" %>
       <% unless params[:id].match("question:") %><li<% if @node_type == "note" %> class="active"<% end %>><a href="/tag/<%= params[:id] %>"><i class="fa fa-file"></i> <%= raw t('tag.show.research_notes') %></a></li><% end %>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -72,7 +72,9 @@
   <% unless @wildcard %><p style="clear:both;padding-top:8px;"><a style="margin-bottom:6px;" class="btn btn-primary" href="/post?tags=question:<%= params[:id].gsub('question:', '') %>&template=question&redirect=question"><i class="fa fa-white icon-question-circle"></i> <%= raw t('tag.show.ask_question', :tag => params[:id].gsub('question:', '')) %></a> <%= raw t('tag.show.or_subscribe_to_answer', :url1 => "/subscribe/tag/question:"+params[:id].gsub('question:', '')) %></p><% end %>
 
   <% if @related_tags %>
-      <%=  render :partial => "tag/related", :locals => {tags: @related_tags } %>
+    <br/>
+    <%=  render :partial => "tag/related", :locals => {tags: @related_tags } %>
+    <br/>
   <% end %>
 
   <ul class="nav nav-tabs" style="margin-top:10px;">


### PR DESCRIPTION
Fixes #3143, adds related tags to tag pages. Right now it's just a list displayed on a tag detail page, but the query logic and caching should be sound.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
