### PR TITLE
update semver marks on leaflet-environmental-layers and leaflet-blurred-location

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,12 +24,12 @@
     "megamark": "~3.3.0",
     "i18n-js": "^2.1.2",
     "short-code-forms": "jywarren/short-code-forms#~0.0.1",
-    "leaflet-blurred-location": "publiclab/leaflet-blurred-location#master",
+    "leaflet-blurred-location": "publiclab/leaflet-blurred-location#^1.1.14",
     "chart.js": "v2.7.0",
     "typeahead.js-browserify": "Javier-Rotelli/typeahead.js-browserify#~1.0.7",
     "noty": "3.1.4",
     "jquery-confirm": "craftpip/jquery-confirm#3.3.2" , 
-    "leaflet-environmental-layers": "1.0.1" ,
+    "leaflet-environmental-layers": "^1.0.1" ,
     "leaflet-hash": "*" 
   },
   "resolutions": {


### PR DESCRIPTION
@mridulnagpal @sagarpreet-chadha https://semver.org and now that I'm looking at these docs:

https://github.com/npm/node-semver#x-ranges-12x-1x-12-

maybe we should use x-ranges to be more clear?