### PR TITLE
Adds user options to spam-like comments or messages.

### DIFF
--- a/app/views/comment_mailer/notify_note_author.html.erb
+++ b/app/views/comment_mailer/notify_note_author.html.erb
@@ -20,7 +20,7 @@ Do NOT reply to this email; click this link to respond:
 <hr />
 
 <p>Look like spam?
-  <% if @user.user.can_moderate? %>
+  <% if @user.role == "admin" || @user.role == "moderator" %>
     Mark this as <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/admin/mark_comment_spam/<%= @comment.id %>">Spam</a>
   <% else %>
     <a href="mailto:moderators@publiclab.org?subject=Reporting+spam+on+Public+Lab&body=Hi,+I+found+this+comment+that+looks+like+spam+or+needs+to+be+moderated:+https://publiclab.org/<%= @comment.parent.path %>#c<%= @comment.cid %>+by+https://publiclab.org/profile/<% if @comment.author %><%= @comment.author.name %><% end %>+Thanks!" title="Flag as spam" class="btn btn-sm btn-default btn-flag-spam-<%= @comment.id %>" >Flag this</a> for moderators

--- a/app/views/comment_mailer/notify_note_author.html.erb
+++ b/app/views/comment_mailer/notify_note_author.html.erb
@@ -19,6 +19,15 @@ Do NOT reply to this email; click this link to respond:
 
 <hr />
 
+<p>Look like spam?
+  <% if @user.can_moderate? %>
+    Mark this as <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/admin/mark_comment_spam/<%= @comment.id %>">Spam</a>
+  <% else %>
+    <a href="mailto:moderators@publiclab.org?subject=Reporting+spam+on+Public+Lab&body=Hi,+I+found+this+comment+that+looks+like+spam+or+needs+to+be+moderated:+https://publiclab.org/<%= @comment.parent.path %>#c<%= @comment.cid %>+by+https://publiclab.org/profile/<% if @comment.author %><%= @comment.author.name %><% end %>+Thanks!" title="Flag as spam" class="btn btn-sm btn-default btn-flag-spam-<%= @comment.id %>" >Flag this</a> for moderators
+  <% end%>
+</p>
+
+
 <div style="color:#aaa;">
 
 <% if @comment.parent.has_power_tag('question') %>


### PR DESCRIPTION
Fixes #3205 "Comment moderation link addition in notify_author_mailer".

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
