### PR TITLE
Improve peopleLocations endpoint: people_locations method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ActiveRecord::Base
   has_many :following_users, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :likes
+  has_many :revisions, through: :node
 
   validates_with UniqueUsernameValidator, on: :create
   validates_format_of :username, with: /\A[A-Za-z\d_\-]+\z/

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -20,7 +20,7 @@ class ExecuteSearch
      when :tags
        sresult = sservice.textSearch_tags(search_criteria.query)
      when :peoplelocations
-       sresult = sservice.recentPeople(search_criteria.query, search_criteria.tag)
+       sresult = sservice.people_locations(search_criteria.query, search_criteria.tag)
      when :taglocations
        if search_criteria.query.include? ","
          sresult = sservice.tagNearbyNodes(search_criteria.query, search_criteria.tag)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -173,31 +173,7 @@ class SearchService
   def people_locations(srchString, tagName = nil)
     sresult = DocList.new
 
-    user_scope =
-    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-         User.select('rusers.*, node_revisions.timestamp')
-             .where('rusers.status <> 0')\
-             .joins(:user_tags)\
-             .where('value LIKE "lat:%"')\
-             .joins(:revisions)\
-             .order("node_revisions.timestamp DESC")\
-             .distinct
-      else
-        User.where('rusers.status <> 0')\
-            .joins(:user_tags)\
-            .where('value LIKE "lat:%"')\
-            .joins(:revisions)\
-            .order("node_revisions.timestamp DESC")\
-            .distinct
-      end
-
-    if tagName.present?
-      user_scope = User.joins(:user_tags)\
-                       .where('user_tags.value LIKE ?', tagName)\
-                       .where(id: user_scope.select("rusers.id"))
-    end
-
-    user_scope = user_scope.limit(srchString.to_i)
+    user_scope = SrchScope.find_locations(srchString, tagName)
 
     user_scope.each do |user|
       blurred = user.has_power_tag("location") ? user.get_value_of_power_tag("location") : false

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -167,7 +167,7 @@ class SearchService
 
   # GET X number of latest people/contributors and package up as a DocResult
   # X = srchString
-  def recentPeople(srchString, tagName = nil)
+  def people_locations(srchString, tagName = nil)
     sresult = DocList.new
 
     user_scope = User.where('rusers.status <> 0')\

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -173,12 +173,23 @@ class SearchService
   def people_locations(srchString, tagName = nil)
     sresult = DocList.new
 
-    user_scope = User.where('rusers.status <> 0')\
-                     .joins(:user_tags)\
-                     .where('value LIKE "lat:%"')\
-                     .joins(:revisions)\
-                     .order("node_revisions.timestamp DESC")\
-                     .distinct
+    user_scope =
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+         User.select('rusers.*, node_revisions.timestamp')
+             .where('rusers.status <> 0')\
+             .joins(:user_tags)\
+             .where('value LIKE "lat:%"')\
+             .joins(:revisions)\
+             .order("node_revisions.timestamp DESC")\
+             .distinct
+      else
+        User.where('rusers.status <> 0')\
+            .joins(:user_tags)\
+            .where('value LIKE "lat:%"')\
+            .joins(:revisions)\
+            .order("node_revisions.timestamp DESC")\
+            .distinct
+      end
 
     if tagName.present?
       user_scope = User.joins(:user_tags)\

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -165,8 +165,11 @@ class SearchService
     sresult
   end
 
-  # GET X number of latest people/contributors and package up as a DocResult
-  # X = srchString
+  # Returns the location of people with most recent contributions.
+  # The method receives as parameter the number of results to be
+  # returned and as optional parameter a user tag. If the user tag
+  # is present, the method returns only the location of people
+  # with that specific user tag.
   def people_locations(srchString, tagName = nil)
     sresult = DocList.new
 
@@ -174,7 +177,8 @@ class SearchService
                      .joins(:user_tags)\
                      .where('value LIKE "lat:%"')\
                      .joins(:revisions)\
-                     .order("node_revisions.timestamp DESC")
+                     .order("node_revisions.timestamp DESC")\
+                     .distinct
 
     if tagName.present?
       user_scope = User.joins(:user_tags)\

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -69,7 +69,7 @@ class SrchScope
     user_locations = User.where('rusers.status <> 0')\
                          .joins(:user_tags)\
                          .where('value LIKE "lat:%"')\
-                         .joins(:revisions)\
+                         .includes(:revisions)\
                          .order("node_revisions.timestamp DESC")\
                          .distinct
     if user_tag.present?

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -66,23 +66,12 @@ class SrchScope
   end
 
   def self.find_locations(limit, user_tag = nil)
-    user_locations =
-      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-        User.select('rusers.*,node_revisions.timestamp')
-            .where('rusers.status <> 0')\
-            .joins(:user_tags)\
-            .where('value LIKE "lat:%"')\
-            .joins(:revisions)\
-            .order("node_revisions.timestamp DESC")\
-            .distinct
-      else
-        User.where('rusers.status <> 0')\
-            .joins(:user_tags)\
-            .where('value LIKE "lat:%"')\
-            .joins(:revisions)\
-            .order("node_revisions.timestamp DESC")\
-            .distinct
-      end
+    user_locations = User.where('rusers.status <> 0')\
+                         .joins(:user_tags)\
+                         .where('value LIKE "lat:%"')\
+                         .joins(:revisions)\
+                         .order("node_revisions.timestamp DESC")\
+                         .distinct
     if user_tag.present?
       user_locations = User.joins(:user_tags)\
                        .where('user_tags.value LIKE ?', user_tag)\

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -66,24 +66,12 @@ class SrchScope
   end
 
   def self.find_locations(limit, user_tag = nil)
-    user_locations =
-      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-        User.select('rusers.*, node_revisions.timestamp')
-            .where('rusers.status <> 0')\
-            .joins(:user_tags)\
-            .where('value LIKE "lat:%"')\
-            .joins(:revisions)\
-            .order("node_revisions.timestamp DESC")\
-            .distinct
-      else
-        User.where('rusers.status <> 0')\
-            .joins(:user_tags)\
-            .where('value LIKE "lat:%"')\
-            .joins(:revisions)\
-            .order("node_revisions.timestamp DESC")\
-            .distinct
-      end
-
+    user_locations = User.where('rusers.status <> 0')\
+                         .joins(:user_tags)\
+                         .where('value LIKE "lat:%"')\
+                         .joins(:revisions)\
+                         .order("node_revisions.timestamp DESC")\
+                         .distinct
     if user_tag.present?
       user_locations = User.joins(:user_tags)\
                        .where('user_tags.value LIKE ?', user_tag)\

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -66,12 +66,23 @@ class SrchScope
   end
 
   def self.find_locations(limit, user_tag = nil)
-    user_locations = User.where('rusers.status <> 0')\
-                         .joins(:user_tags)\
-                         .where('value LIKE "lat:%"')\
-                         .joins(:revisions)\
-                         .order("node_revisions.timestamp DESC")\
-                         .distinct
+    user_locations =
+      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+        User.select('rusers.*,node_revisions.timestamp')
+            .where('rusers.status <> 0')\
+            .joins(:user_tags)\
+            .where('value LIKE "lat:%"')\
+            .joins(:revisions)\
+            .order("node_revisions.timestamp DESC")\
+            .distinct
+      else
+        User.where('rusers.status <> 0')\
+            .joins(:user_tags)\
+            .where('value LIKE "lat:%"')\
+            .joins(:revisions)\
+            .order("node_revisions.timestamp DESC")\
+            .distinct
+      end
     if user_tag.present?
       user_locations = User.joins(:user_tags)\
                        .where('user_tags.value LIKE ?', user_tag)\

--- a/test/unit/helpers/search_helper_test.rb
+++ b/test/unit/helpers/search_helper_test.rb
@@ -4,7 +4,7 @@ class SearchHelperTest < ActionView::TestCase
 
 	test "search Recent People helper" do
 		sservice = SearchService.new
-		result = sservice.recentPeople(100)
+		result = sservice.people_locations(100)
 		assert_equal result.items.first.docType , "people_coordinates"
 		assert_equal result.items.first.docTitle , users(:bob).username
 		assert_equal result.items.first.docSummary , 0


### PR DESCRIPTION
Hey everybody!

We are opening this request to fix the issue #3196. Here we implemented a new version of `recentPeople` method. 

Now we first select the users that have lat/lon and then we join the users table with the revisions table to order them by most recent activities. We also change the name of the method from `recentPeople` to `people_locations`.

We would like some feedback, thanks! :)

fixes #3196
@publiclab/reviewers @publiclab/soc @jywarren