### PR TITLE
API Search profiles: adding parameter to search (only) by username 

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -103,13 +103,8 @@ module Srch
 
     def self.execute(endpoint, params)
       sresult = DocList.new
-      search_query = params[:srchString]
-      tag_query = params[:tagName]
-      order_query = params[:order_direction]
-      sort_query = params[:sort_by]
-      field_query = params[:field]
       search_type = endpoint
-      search_criteria = SearchCriteria.new(search_query, tag: tag_query, sort_by: sort_query, order_direction: order_query, field: field_query)
+      search_criteria = SearchCriteria.new(params)
 
       if search_criteria.valid?
         sresult = ExecuteSearch.new.by(search_type, search_criteria)

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -21,14 +21,14 @@ module Srch
         Search.execute(:all, params)
       end
 
-      # Request URL should be /api/srch/profiles?srchString=QRY[&sort_by=recent&order_direction=desc&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
+      # Request URL should be /api/srch/profiles?srchString=QRY[&sort_by=recent&order_direction=desc&field=username&seq=KEYCOUNT&showCount=NUM_ROWS&pageNum=PAGE_NUM]
       # Basic implementation from classic plots2 SearchController
       desc 'Perform a search of profiles', hidden: false,
                                            is_array: false,
                                            nickname: 'srchGetProfiles'
 
       params do
-        use :common, :sorting, :ordering
+        use :common, :sorting, :ordering, :field
       end
       get :profiles do
         Search.execute(:profiles, params)
@@ -107,8 +107,9 @@ module Srch
       tag_query = params[:tagName]
       order_query = params[:order_direction]
       sort_query = params[:sort_by]
+      field_query = params[:field]
       search_type = endpoint
-      search_criteria = SearchCriteria.new(search_query, tag: tag_query, sort_by: sort_query, order_direction: order_query)
+      search_criteria = SearchCriteria.new(search_query, tag: tag_query, sort_by: sort_query, order_direction: order_query, field: field_query)
 
       if search_criteria.valid?
         sresult = ExecuteSearch.new.by(search_type, search_criteria)

--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -25,6 +25,7 @@ module Srch
 
     params :field do
       optional :field, type: String, documentation: { example: 'username' }
+      optional :limit, type: Integer, documentation: { example: 0 }
     end
 
     params :commontypeahead do

--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -23,6 +23,10 @@ module Srch
       optional :sort_by, type: String, documentation: { example: 'recent' }
     end
 
+    params :field do
+      optional :field, type: String, documentation: { example: 'username' }
+    end
+
     params :commontypeahead do
       requires :srchString, type: String, documentation: { example: 'Spec' }
       optional :seq, type: Integer, documentation: { example: 995 }

--- a/app/api/srch/typeahead.rb
+++ b/app/api/srch/typeahead.rb
@@ -88,9 +88,8 @@ module Srch
 
     def self.execute(endpoint, params)
       sresult = TagList.new
-      search_query = params[:srchString]
       search_type = endpoint
-      search_criteria = SearchCriteria.new(search_query)
+      search_criteria = SearchCriteria.new(params)
 
       if search_criteria.valid?
         sresult = ExecuteTypeahead.new.by(search_type, search_criteria, TYPEAHEAD_LIMIT)

--- a/app/assets/javascripts/atwho_autocomplete.js
+++ b/app/assets/javascripts/atwho_autocomplete.js
@@ -4,7 +4,7 @@
         at: "@",
         callbacks: {
           remoteFilter: function(query, callback) {
-            $.getJSON("/api/srch/profiles?srchString=" + query, {}, function(data) {
+            $.getJSON("/api/srch/profiles?srchString=" + query + "&sort_by=recent&field=username", {}, function(data) {
               if (data.hasOwnProperty('items') && data.items.length > 0) {
                 callback(data.items.map(function(i) { return i.docTitle }));
               }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,10 @@ class User < ActiveRecord::Base
     User.where('MATCH(bio, username) AGAINST(? IN BOOLEAN MODE)', query + '*')
   end
 
+  def self.search_by_username(query)
+    User.where('MATCH(username) AGAINST(? IN BOOLEAN MODE)', query + '*')
+  end
+
   def new_contributor
     @uid = id
     return "<span class = 'label label-success'><i>New Contributor</i></span>".html_safe if Node.where(:uid => @uid).length === 1

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -1,5 +1,5 @@
 class SearchCriteria
-  attr_reader :query, :tag, :sort_by, :field
+  attr_reader :query, :tag, :sort_by, :field, :limit
 
   def initialize(params)
     @query = params[:srchString]
@@ -7,6 +7,7 @@ class SearchCriteria
     @sort_by = params[:sort_by]
     @order_direction = params[:order_direction]
     @field = params[:field]
+    @limit = params[:limit]
   end
 
   def valid?

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -1,11 +1,12 @@
 class SearchCriteria
-  attr_reader :query, :tag, :sort_by
+  attr_reader :query, :tag, :sort_by, :field
 
-  def initialize(query, tag: nil, sort_by: nil, order_direction: "DESC")
+  def initialize(query, tag: nil, sort_by: nil, order_direction: "DESC", field: nil)
     @query = query
     @tag = tag
     @sort_by = sort_by
     @order_direction = order_direction
+    @field = field
   end
 
   def valid?

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -1,12 +1,12 @@
 class SearchCriteria
   attr_reader :query, :tag, :sort_by, :field
 
-  def initialize(query, tag: nil, sort_by: nil, order_direction: "DESC", field: nil)
-    @query = query
-    @tag = tag
-    @sort_by = sort_by
-    @order_direction = order_direction
-    @field = field
+  def initialize(params)
+    @query = params[:srchString]
+    @tag = params[:tagName]
+    @sort_by = params[:sort_by]
+    @order_direction = params[:order_direction]
+    @field = params[:field]
   end
 
   def valid?

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -50,11 +50,13 @@ class SearchService
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
   def profiles(search_criteria)
+    limit = search_criteria.limit ? search_criteria.limit : 10
+
     user_scope =
       if search_criteria.field == "username"
-        SrchScope.find_by_username(search_criteria.query, limit = 10)
+        SrchScope.find_by_username(search_criteria.query, limit)
       else
-        SrchScope.find_users(search_criteria.query, limit = 10)
+        SrchScope.find_users(search_criteria.query, limit)
       end
 
     user_scope =
@@ -62,12 +64,11 @@ class SearchService
         user_scope.joins(:revisions)
                   .order("node_revisions.timestamp #{search_criteria.order_direction}")
                   .distinct
-
       else
         user_scope.order(id: :desc)
       end
 
-    users = user_scope.limit(10)
+    users = user_scope.limit(limit)
 
     sresult = DocList.new
     users.each do |match|

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -52,12 +52,7 @@ class SearchService
   def profiles(search_criteria)
     limit = search_criteria.limit ? search_criteria.limit : 10
 
-    user_scope =
-      if search_criteria.field == "username"
-        SrchScope.find_by_username(search_criteria.query, limit)
-      else
-        SrchScope.find_users(search_criteria.query, limit)
-      end
+    user_scope = SrchScope.find_users(search_criteria.query, search_criteria.field, limit = 10)
 
     user_scope =
       if search_criteria.sort_by == "recent"

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -50,7 +50,12 @@ class SearchService
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
   def profiles(search_criteria)
-    user_scope = SrchScope.find_users(search_criteria.query, limit = 10)
+    user_scope =
+      if search_criteria.field == "username"
+        SrchScope.find_by_username(search_criteria.query, limit = 10)
+      else
+        SrchScope.find_users(search_criteria.query, limit = 10)
+      end
 
     user_scope =
       if search_criteria.sort_by == "recent"

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -1,11 +1,12 @@
 # This class provides common methods that Typehead and Search services use
 class SrchScope
   def self.find_users(query, type = nil, limit)
-    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      users = type == "username" ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
-    else
-      users = User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
-    end
+    users =
+      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+        type == "username" ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
+      else
+        User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
+      end
     users = users.limit(limit)
   end
 

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -1,25 +1,12 @@
 # This class provides common methods that Typehead and Search services use
 class SrchScope
-  def self.find_users(query, limit)
+  def self.find_users(query, type = nil, limit)
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      User.search(query)
-          .where('rusers.status = ?', 1)
-          .limit(limit)
+      users = type == "username" ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
     else
-      User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
-          .limit(limit)
+      users = User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
     end
-  end
-
-  def self.find_by_username(query, limit)
-    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      User.search_by_username(query)
-          .where('rusers.status = ?', 1)
-          .limit(limit)
-    else
-      User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
-          .limit(limit)
-    end
+    users = users.limit(limit)
   end
 
   def self.find_tags(input, limit)

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -11,6 +11,17 @@ class SrchScope
     end
   end
 
+  def self.find_by_username(query, limit)
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      User.search_by_username(query)
+          .where('rusers.status = ?', 1)
+          .limit(limit)
+    else
+      User.where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
+          .limit(limit)
+    end
+  end
+
   def self.find_tags(input, limit)
     tags = Tag.includes(:node)
       .references(:node)

--- a/app/services/srch_scope.rb
+++ b/app/services/srch_scope.rb
@@ -6,7 +6,7 @@ class SrchScope
           .where('rusers.status = ?', 1)
           .limit(limit)
     else
-      User.where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
+      User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
           .limit(limit)
     end
   end
@@ -17,7 +17,7 @@ class SrchScope
           .where('rusers.status = ?', 1)
           .limit(limit)
     else
-      User.where('username LIKE ? AND rusers.status = 1', '%' + input + '%')
+      User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
           .limit(limit)
     end
   end

--- a/doc/API.md
+++ b/doc/API.md
@@ -13,6 +13,17 @@ https://publiclab.org/api/swagger_doc.json
 Per-model API endpoints are:
 
 * Profiles: https://publiclab.org/api/srch/profiles?srchString=foo
+
+This also accepts the following additional parameters:
+
+- `sort_by`: if 'recent' is passed, it returns the profiles from users with the most recent activity, otherwise, the results are sorted by user id (desc);
+- `order_direction`: `ASC` or `DESC` (the latter is the default);
+- `field`: if 'username' is passed, it returns the profiles from users searched by username only, otherwise by username and bio for a broader search.
+
+Example of full URL with the optional params (using the order_by DESC default value):
+
+https://publiclab.org/api/srch/profiles?srchString=foo&sort_by=recent&field=username
+
 * Questions: https://publiclab.org/api/srch/questions?srchString=foo
 * Tags: https://publiclab.org/api/srch/tags?srchString=foo
 * Notes: https://publiclab.org/api/srch/notes?srchString=foo

--- a/doc/API.md
+++ b/doc/API.md
@@ -18,7 +18,7 @@ This also accepts the following additional parameters:
 
 - `sort_by`: if 'recent' is passed, it returns the profiles from users with the most recent activity, otherwise, the results are sorted by user id (desc);
 - `order_direction`: `ASC` or `DESC` (the latter is the default);
-- `field`: if 'username' is passed, it returns the profiles from users searched by username only, otherwise by username and bio for a broader search.
+- `field`: if 'username' is passed, it returns the profiles from users searched by username only. Otherwise it returns the profiles by username and bio for a broader search.
 
 Example of full URL with the optional params (using the order_by DESC default value):
 

--- a/test/fixtures/drupal_users.yml
+++ b/test/fixtures/drupal_users.yml
@@ -116,3 +116,10 @@ steff3:
   mail: steff3@pxlshp.com
   uid: 17
   created: <%= Time.now.to_i %>
+
+data:
+  name: data
+  status: 1
+  mail: data@pxlshp.com
+  uid: 18
+  created: <%= Time.now.to_i %>

--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -294,3 +294,15 @@ post_test3:
   type: "note"
   cached_likes: 0
   slug: user3-<%= DateTime.new(2018,8,15).strftime("%m-%d-%Y") %>-post-test3
+
+post_test4:
+  nid: 26
+  uid: 18
+  title: "Post Test 4"
+  path: "/notes/user4/<%= DateTime.new(2018,8,20).strftime("%m-%d-%Y") %>/post-test4"
+  created: <%= DateTime.new(2018,8,20).to_i %>
+  changed: <%= DateTime.new(2018,8,20).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: user3-<%= DateTime.new(2018,8,20).strftime("%m-%d-%Y") %>-post-test4

--- a/test/fixtures/revisions.yml
+++ b/test/fixtures/revisions.yml
@@ -295,6 +295,13 @@ post_test2:
 post_test3:
   nid: 25
   uid: 16
-  title: Post test review 2
-  body: Post test review 2
+  title: Post test review 3
+  body: Post test review 3
   timestamp: <%= DateTime.new(2018,8,15).to_i %>
+
+post_test4:
+  nid: 26
+  uid: 18
+  title: Post test review 4
+  body: Post test review 4
+  timestamp: <%= DateTime.new(2018,8,20).to_i %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -210,3 +210,16 @@ steff3:
   bio: ''
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+data:
+  username: data
+  status: 1
+  email: data@pxlshp.com
+  id: 18
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  last_request_at: <%= Time.now %>
+  bio: 'data is a nice cat and he loves steff!'
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -129,7 +129,7 @@ test_user:
   password_salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
   persistence_token: <%= Authlogic::Random.hex_token %>
-  bio: ''
+  bio: 'I love ruby'
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -313,7 +313,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal selector.size, 20
+    assert_equal selector.size, 21
     assert_select "div p", 'Pending approval by community moderators. Please be patient!'
   end
 
@@ -342,7 +342,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal selector.size, 20
+    assert_equal selector.size, 21
     assert_select "p", "Moderate first-time post: \n              Approve\n              Spam"
   end
 

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -165,6 +165,8 @@ class SearchApiTest < ActiveSupport::TestCase
 
       matcher = JsonExpressions::Matcher.new(pattern)
 
+      json = JSON.parse(last_response.body)
+      
       assert_equal "/profile/data",   json['items'][0]['docUrl']
       assert_equal "/profile/steff3",   json['items'][1]['docUrl']
       assert_equal "/profile/steff2",   json['items'][2]['docUrl']

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -166,11 +166,36 @@ class SearchApiTest < ActiveSupport::TestCase
       matcher = JsonExpressions::Matcher.new(pattern)
 
       json = JSON.parse(last_response.body)
-      
-      assert_equal "/profile/data",   json['items'][0]['docUrl']
+
+      assert_equal "/profile/data",     json['items'][0]['docUrl']
       assert_equal "/profile/steff3",   json['items'][1]['docUrl']
       assert_equal "/profile/steff2",   json['items'][2]['docUrl']
       assert_equal "/profile/steff1",   json['items'][3]['docUrl']
+
+      assert matcher =~ json
+    end
+  end
+
+  # search by bio only
+  test 'search profiles by bio without order_by and default sort_direction' do
+    get '/api/srch/profiles?srchString=ruby'
+    assert last_response.ok?
+
+    # User.search() only works for mysql/mariadb
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      # Expected search pattern
+      pattern = {
+        srchParams: {
+          srchString: 'ruby',
+          seq: nil,
+        }.ignore_extra_keys!
+      }.ignore_extra_keys!
+
+      matcher = JsonExpressions::Matcher.new(pattern)
+
+      json = JSON.parse(last_response.body)
+
+      assert_equal "/profile/testuser",   json['items'][0]['docUrl']
 
       assert matcher =~ json
     end

--- a/test/functional/search_api_test.rb
+++ b/test/functional/search_api_test.rb
@@ -75,9 +75,9 @@ class SearchApiTest < ActiveSupport::TestCase
 
      end
 
-   # returns users by id when order_by is not provided and sorted direction default DESC
-   test 'search profiles without order_by and default sort_direction' do
-     get '/api/srch/profiles?srchString=steff'
+   # search by username and returns users by id when order_by is not provided and sorted direction default DESC
+   test 'search profiles by username without order_by and default sort_direction' do
+     get '/api/srch/profiles?srchString=steff&field=username'
      assert last_response.ok?
 
      # Expected search pattern
@@ -100,9 +100,9 @@ class SearchApiTest < ActiveSupport::TestCase
 
    end
 
-   # returns users sorteded by recent activity and order direction default DESC
-   test 'search recent profiles with sort_by=recent present' do
-     get '/api/srch/profiles?srchString=steff&sort_by=recent'
+   # search by username and returns users sorteded by recent activity and order direction default DESC
+   test 'search recent profiles by username with sort_by=recent present' do
+     get '/api/srch/profiles?srchString=steff&field=username&sort_by=recent'
      assert last_response.ok?
 
      # Expected search pattern
@@ -124,9 +124,9 @@ class SearchApiTest < ActiveSupport::TestCase
      assert matcher =~ json
    end
 
-   # returns users ordered by recent activity and sorted by ASC direction
-   test 'search recent profiles with sort_by=recent present and order_direction ASC' do
-     get '/api/srch/profiles?srchString=steff&sort_by=recent&order_direction=ASC'
+   # search by username and returns users ordered by recent activity and sorted by ASC direction
+   test 'search recent profiles by username with sort_by=recent present and order_direction ASC' do
+     get '/api/srch/profiles?srchString=steff&field=username&sort_by=recent&order_direction=ASC'
      assert last_response.ok?
 
      # Expected search pattern
@@ -146,6 +146,32 @@ class SearchApiTest < ActiveSupport::TestCase
      assert_equal "/profile/steff2",     json['items'][2]['docUrl']
 
      assert matcher =~ json
+  end
+
+  # search by username and bio, returns users by id when order_by is not provided and sorted direction default DESC
+  test 'search profiles by username and bio without order_by and default sort_direction' do
+    get '/api/srch/profiles?srchString=steff'
+    assert last_response.ok?
+
+    # User.search() only works for mysql/mariadb
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      # Expected search pattern
+      pattern = {
+        srchParams: {
+          srchString: 'steff',
+          seq: nil,
+        }.ignore_extra_keys!
+      }.ignore_extra_keys!
+
+      matcher = JsonExpressions::Matcher.new(pattern)
+
+      assert_equal "/profile/data",   json['items'][0]['docUrl']
+      assert_equal "/profile/steff3",   json['items'][1]['docUrl']
+      assert_equal "/profile/steff2",   json['items'][2]['docUrl']
+      assert_equal "/profile/steff1",   json['items'][3]['docUrl']
+
+      assert matcher =~ json
+    end
   end
 
   test 'search notes functionality' do

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -248,7 +248,8 @@ class NodeTest < ActiveSupport::TestCase
     notes = Node.research_notes
     expected = [nodes(:one), nodes(:spam), nodes(:first_timer_note), nodes(:blog),
                 nodes(:moderated_user_note), nodes(:activity), nodes(:upgrade),
-                nodes(:draft), nodes(:post_test1), nodes(:post_test2), nodes(:post_test3)]
+                nodes(:draft), nodes(:post_test1), nodes(:post_test2),
+                nodes(:post_test3), nodes(:post_test4)]
     assert_equal expected, notes
   end
 


### PR DESCRIPTION
Hey everybody!

We are opening this request to fix the issue #3228. 

We added a new parameter to the profile endpoint so now we can search only by username. We will use this new functionality on the autocomplete feature.

We would like some feedback, thanks! :)

fixes #3228
@publiclab/reviewers @publiclab/soc @jywarren 