### PR TITLE
Fix schema-rb-example file for SQLite

### DIFF
--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,313 +13,332 @@
 
 ActiveRecord::Schema.define(version: 2018_08_04_215454) do
 
-  create_table "answer_selections", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "answer_selections", force: true do |t|
     t.integer "user_id"
     t.integer "aid"
-    t.boolean "liking", default: false
+    t.boolean "liking",    default: false
     t.boolean "following", default: false
-    t.index ["user_id", "aid"], name: "index_answer_selections_on_user_id_and_aid"
   end
 
-  create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "uid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.text "content", limit: 4294967295, null: false
-    t.integer "cached_likes", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "accepted", default: false
-    t.index ["uid", "nid"], name: "index_answers_on_uid_and_nid"
+  add_index "answer_selections", ["user_id", "aid"], name: "index_answer_selections_on_user_id_and_aid", using: :btree
+
+  create_table "answers", force: true do |t|
+    t.integer  "uid",                             default: 0,     null: false
+    t.integer  "nid",                             default: 0,     null: false
+    t.text     "content",      limit: 2147483647,                 null: false
+    t.integer  "cached_likes",                    default: 0
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.boolean  "accepted",                        default: false
   end
 
-  create_table "comments", primary_key: "cid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "pid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.integer "uid", default: 0, null: false
-    t.string "subject", limit: 64, default: "", null: false
-    t.text "comment", limit: 4294967295, null: false
-    t.string "hostname", limit: 128, default: "", null: false
-    t.integer "timestamp", default: 0, null: false
-    t.integer "status", default: 1, null: false
-    t.integer "format", limit: 2, default: 0, null: false
-    t.string "thread"
-    t.string "name", limit: 60
-    t.string "mail", limit: 64
-    t.string "homepage"
-    t.integer "aid", default: 0, null: false
-    t.integer "comment_via", default: 0
-    t.string "message_id"
-    t.index ["comment"], name: "index_comments_on_comment", type: :fulltext
-    t.index ["nid"], name: "index_comments_nid"
-    t.index ["pid"], name: "index_comments_pid"
-    t.index ["status"], name: "index_comments_status"
+  add_index "answers", ["uid", "nid"], name: "index_answers_on_uid_and_nid", using: :btree
+
+  create_table "comments", primary_key: "cid", force: true do |t|
+    t.integer "pid",                          default: 0,  null: false
+    t.integer "nid",                          default: 0,  null: false
+    t.integer "uid",                          default: 0,  null: false
+    t.string  "subject",   limit: 64,         default: "", null: false
+    t.text    "comment",   limit: 2147483647,              null: false
+    t.string  "hostname",  limit: 128,        default: "", null: false
+    t.integer "timestamp",                    default: 0,  null: false
+    t.integer "status",                       default: 1,  null: false
+    t.integer "format",    limit: 2,          default: 0,  null: false
+    t.string  "thread"
+    t.string  "name",      limit: 60
+    t.string  "mail",      limit: 64
+    t.string  "homepage"
+    t.integer "aid",                          default: 0,  null: false
+    t.integer "comment_via", limit: 4,          default: 0
+    t.string  "message_id",  limit: 255
   end
 
-  create_table "community_tags", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "tid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.integer "uid", default: 0, null: false
+  add_index "comments", ["comment"], name: "index_comments_on_comment", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+  add_index "comments", ["nid"], name: "index_comments_nid", using: :btree
+  add_index "comments", ["pid"], name: "index_comments_pid", using: :btree
+  add_index "comments", ["status"], name: "index_comments_status", using: :btree
+
+  create_table "community_tags", id: false, force: true do |t|
+    t.integer "tid",  default: 0, null: false
+    t.integer "nid",  default: 0, null: false
+    t.integer "uid",  default: 0, null: false
     t.integer "date", default: 0, null: false
-    t.index ["nid"], name: "index_community_tags_nid"
-    t.index ["tid", "nid"], name: "tid_nid"
-    t.index ["tid"], name: "index_community_tags_tid"
-    t.index ["uid"], name: "index_community_tags_uid"
   end
 
-  create_table "content_field_image_gallery", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "vid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.integer "delta", default: 0, null: false
+  add_index "community_tags", ["nid"], name: "index_community_tags_nid", using: :btree
+  add_index "community_tags", ["tid", "nid"], name: "tid_nid", using: :btree
+  add_index "community_tags", ["tid"], name: "index_community_tags_tid", using: :btree
+  add_index "community_tags", ["uid"], name: "index_community_tags_uid", using: :btree
+
+  create_table "content_field_image_gallery", id: false, force: true do |t|
+    t.integer "vid",                                default: 0, null: false
+    t.integer "nid",                                default: 0, null: false
+    t.integer "delta",                              default: 0, null: false
     t.integer "field_image_gallery_fid"
     t.integer "field_image_gallery_list", limit: 1
-    t.text "field_image_gallery_data"
-    t.index ["nid"], name: "index_content_field_image_gallery_nid"
+    t.text    "field_image_gallery_data"
   end
 
-  create_table "content_field_main_image", primary_key: "vid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "nid", default: 0, null: false
+  add_index "content_field_image_gallery", ["nid"], name: "index_content_field_image_gallery_nid", using: :btree
+
+  create_table "content_field_main_image", primary_key: "vid", force: true do |t|
+    t.integer "nid",                             default: 0, null: false
     t.integer "field_main_image_fid"
     t.integer "field_main_image_list", limit: 1
-    t.text "field_main_image_data"
-    t.index ["nid"], name: "index_content_field_main_image_nid"
+    t.text    "field_main_image_data"
   end
 
-  create_table "content_field_map_editor", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "vid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.integer "delta", default: 0, null: false
-    t.text "field_map_editor_value", limit: 4294967295
-    t.index ["nid"], name: "index_content_field_map_editor_nid"
+  add_index "content_field_main_image", ["nid"], name: "index_content_field_main_image_nid", using: :btree
+
+  create_table "content_field_map_editor", id: false, force: true do |t|
+    t.integer "vid",                                       default: 0, null: false
+    t.integer "nid",                                       default: 0, null: false
+    t.integer "delta",                                     default: 0, null: false
+    t.text    "field_map_editor_value", limit: 2147483647
   end
 
-  create_table "content_field_mappers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "vid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.integer "delta", default: 0, null: false
-    t.text "field_mappers_value", limit: 4294967295
-    t.index ["nid"], name: "index_content_field_mappers_nid"
+  add_index "content_field_map_editor", ["nid"], name: "index_content_field_map_editor_nid", using: :btree
+
+  create_table "content_field_mappers", id: false, force: true do |t|
+    t.integer "vid",                                    default: 0, null: false
+    t.integer "nid",                                    default: 0, null: false
+    t.integer "delta",                                  default: 0, null: false
+    t.text    "field_mappers_value", limit: 2147483647
   end
 
-  create_table "content_type_map", primary_key: "vid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "nid", default: 0, null: false
-    t.string "field_publication_date_value", limit: 20
-    t.string "field_capture_date_value", limit: 20
-    t.text "field_geotiff_url_value", limit: 4294967295
-    t.text "field_google_maps_url_value", limit: 4294967295
-    t.text "field_openlayers_url_value", limit: 4294967295
-    t.text "field_tms_url_value", limit: 4294967295
-    t.text "field_jpg_url_value", limit: 4294967295
-    t.text "field_license_value", limit: 4294967295
-    t.text "field_raw_images_value", limit: 4294967295
-    t.text "field_cartographer_notes_value", limit: 4294967295
+  add_index "content_field_mappers", ["nid"], name: "index_content_field_mappers_nid", using: :btree
+
+  create_table "content_type_map", primary_key: "vid", force: true do |t|
+    t.integer "nid",                                                                         default: 0, null: false
+    t.string  "field_publication_date_value",    limit: 20
+    t.string  "field_capture_date_value",        limit: 20
+    t.text    "field_geotiff_url_value",         limit: 2147483647
+    t.text    "field_google_maps_url_value",     limit: 2147483647
+    t.text    "field_openlayers_url_value",      limit: 2147483647
+    t.text    "field_tms_url_value",             limit: 2147483647
+    t.text    "field_jpg_url_value",             limit: 2147483647
+    t.text    "field_license_value",             limit: 2147483647
+    t.text    "field_raw_images_value",          limit: 2147483647
+    t.text    "field_cartographer_notes_value",  limit: 2147483647
     t.integer "field_cartographer_notes_format"
-    t.text "field_notes_value", limit: 4294967295
+    t.text    "field_notes_value",               limit: 2147483647
     t.integer "field_notes_format"
-    t.text "field_mbtiles_url_value", limit: 4294967295
+    t.text    "field_mbtiles_url_value",         limit: 2147483647
     t.integer "field_zoom_min_value"
-    t.decimal "field_ground_resolution_value", precision: 10, scale: 2
-    t.decimal "field_geotiff_filesize_value", precision: 10, scale: 1
-    t.decimal "field_jpg_filesize_value", precision: 10, scale: 1
-    t.decimal "field_raw_images_filesize_value", precision: 10, scale: 1
-    t.text "field_tms_tile_type_value", limit: 4294967295
+    t.decimal "field_ground_resolution_value",                      precision: 10, scale: 2
+    t.decimal "field_geotiff_filesize_value",                       precision: 10, scale: 1
+    t.decimal "field_jpg_filesize_value",                           precision: 10, scale: 1
+    t.decimal "field_raw_images_filesize_value",                    precision: 10, scale: 1
+    t.text    "field_tms_tile_type_value",       limit: 2147483647
     t.integer "field_zoom_max_value"
-    t.string "authorship"
-    t.index ["nid"], name: "index_content_type_map_nid"
+    t.string  "authorship"
   end
 
-  create_table "files", primary_key: "fid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "uid", default: 0, null: false
-    t.string "filename", default: "", null: false
-    t.string "filepath", default: "", null: false
-    t.string "filemime", default: "", null: false
-    t.integer "filesize", default: 0, null: false
-    t.integer "status", default: 0, null: false
-    t.integer "timestamp", default: 0, null: false
-    t.index ["status"], name: "index_files_status"
-    t.index ["timestamp"], name: "index_files_timestamp"
-    t.index ["uid"], name: "index_files_uid"
+  add_index "content_type_map", ["nid"], name: "index_content_type_map_nid", using: :btree
+
+  create_table "files", primary_key: "fid", force: true do |t|
+    t.integer "uid",       default: 0,  null: false
+    t.string  "filename",  default: "", null: false
+    t.string  "filepath",  default: "", null: false
+    t.string  "filemime",  default: "", null: false
+    t.integer "filesize",  default: 0,  null: false
+    t.integer "status",    default: 0,  null: false
+    t.integer "timestamp", default: 0,  null: false
   end
 
-  create_table "friendly_id_slugs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "slug", null: false
-    t.integer "sluggable_id", null: false
-    t.string "sluggable_type", limit: 40
+  add_index "files", ["status"], name: "index_files_status", using: :btree
+  add_index "files", ["timestamp"], name: "index_files_timestamp", using: :btree
+  add_index "files", ["uid"], name: "index_files_uid", using: :btree
+
+  create_table "friendly_id_slugs", force: true do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 40
     t.datetime "created_at"
   end
 
-  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "title"
-    t.integer "uid"
-    t.integer "nid"
-    t.string "notes"
-    t.integer "version", default: 0
-    t.string "photo_file_name"
-    t.string "photo_content_type"
-    t.string "photo_file_size"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "remote_url"
-    t.integer "vid", default: 0
+  create_table "images", force: true do |t|
+    t.string   "title"
+    t.integer  "uid"
+    t.integer  "nid"
+    t.string   "notes"
+    t.integer  "version",            default: 0
+    t.string   "photo_file_name"
+    t.string   "photo_content_type"
+    t.string   "photo_file_size"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.string   "remote_url"
+    t.integer  "vid",                default: 0
   end
 
-  create_table "impressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "impressionable_type"
-    t.integer "impressionable_id"
-    t.integer "user_id"
-    t.string "controller_name"
-    t.string "action_name"
-    t.string "view_name"
-    t.string "request_hash"
-    t.string "ip_address"
-    t.string "session_hash"
-    t.text "message"
-    t.text "referrer"
-    t.text "params"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
-    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
-    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
-    t.index ["impressionable_id"], name: "index_impressions_on_impressionable_id"
-    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
-    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index", length: { params: 255 }
-    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
-    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
-    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index", length: { message: 255 }
-    t.index ["impressionable_type"], name: "index_impressions_on_impressionable_type"
-    t.index ["user_id"], name: "index_impressions_on_user_id"
+  create_table "impressions", force: true do |t|
+    t.string   "impressionable_type"
+    t.integer  "impressionable_id"
+    t.integer  "user_id"
+    t.string   "controller_name"
+    t.string   "action_name"
+    t.string   "view_name"
+    t.string   "request_hash"
+    t.string   "ip_address"
+    t.string   "session_hash"
+    t.text     "message"
+    t.text     "referrer"
+    t.text     "params"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
   end
 
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "likeable_id"
-    t.integer "user_id"
-    t.string "likeable_type"
+  add_index "impressions", ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index", using: :btree
+  add_index "impressions", ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index", using: :btree
+  add_index "impressions", ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index", using: :btree
+  add_index "impressions", ["impressionable_id"], name: "index_impressions_on_impressionable_id", using: :btree
+  add_index "impressions", ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index", using: :btree
+  add_index "impressions", ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index", length: {"impressionable_type"=>nil, "impressionable_id"=>nil, "params"=>255}, using: :btree
+  add_index "impressions", ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index", using: :btree
+  add_index "impressions", ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index", using: :btree
+  add_index "impressions", ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index", length: {"impressionable_type"=>nil, "message"=>255, "impressionable_id"=>nil}, using: :btree
+  add_index "impressions", ["impressionable_type"], name: "index_impressions_on_impressionable_type", using: :btree
+  add_index "impressions", ["user_id"], name: "index_impressions_on_user_id", using: :btree
+
+  create_table "likes", force: true do |t|
+    t.integer  "likeable_id"
+    t.integer  "user_id"
+    t.string   "likeable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "emoji_type"
+    t.string   "emoji_type"
   end
 
-  create_table "node", primary_key: "nid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "vid", default: 0, null: false
-    t.string "type", limit: 32, default: "", null: false
-    t.string "language", limit: 12, default: "", null: false
-    t.string "title", default: "", null: false
-    t.integer "uid", default: 0, null: false
-    t.integer "status", default: 1, null: false
-    t.integer "created", default: 0, null: false
-    t.integer "changed", default: 0, null: false
-    t.integer "comment", default: 0, null: false
-    t.integer "promote", default: 0, null: false
-    t.integer "moderate", default: 0, null: false
-    t.integer "sticky", default: 0, null: false
-    t.integer "tnid", default: 0, null: false
-    t.integer "translate", default: 0, null: false
-    t.integer "cached_likes", default: 0
-    t.integer "comments_count", default: 0
-    t.integer "drupal_node_revisions_count", default: 0
-    t.string "path"
+  create_table "node", primary_key: "nid", force: true do |t|
+    t.integer "vid",                                    default: 0,  null: false
+    t.string  "type",                        limit: 32, default: "", null: false
+    t.string  "language",                    limit: 12, default: "", null: false
+    t.string  "title",                                  default: "", null: false
+    t.integer "uid",                                    default: 0,  null: false
+    t.integer "status",                                 default: 1,  null: false
+    t.integer "created",                                default: 0,  null: false
+    t.integer "changed",                                default: 0,  null: false
+    t.integer "comment",                                default: 0,  null: false
+    t.integer "promote",                                default: 0,  null: false
+    t.integer "moderate",                               default: 0,  null: false
+    t.integer "sticky",                                 default: 0,  null: false
+    t.integer "tnid",                                   default: 0,  null: false
+    t.integer "translate",                              default: 0,  null: false
+    t.integer "cached_likes",                           default: 0
+    t.integer "comments_count",                         default: 0
+    t.integer "drupal_node_revisions_count",            default: 0
+    t.string  "path"
     t.integer "main_image_id"
-    t.string "slug"
-    t.integer "legacy_views", default: 0
-    t.integer "views", default: 0
-    t.index ["changed"], name: "node_changed"
-    t.index ["created"], name: "node_created"
-    t.index ["moderate"], name: "node_moderate"
-    t.index ["promote", "status"], name: "node_promote_status"
-    t.index ["slug"], name: "index_node_on_slug"
-    t.index ["status", "type", "nid"], name: "node_status_type"
-    t.index ["title", "type"], name: "node_title_type"
-    t.index ["tnid"], name: "index_node_tnid"
-    t.index ["translate"], name: "index_node_translate"
-    t.index ["type"], name: "node_type"
-    t.index ["uid"], name: "index_node_uid"
-    t.index ["vid"], name: "index_node_vid"
+    t.string  "slug"
+    t.integer "legacy_views",                           default: 0
+    t.integer "views",                                  default: 0
   end
 
-  create_table "node_access", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "nid", default: 0, null: false
-    t.integer "gid", default: 0, null: false
-    t.string "realm", default: "", null: false
-    t.integer "grant_view", limit: 1, default: 0, null: false
-    t.integer "grant_update", limit: 1, default: 0, null: false
-    t.integer "grant_delete", limit: 1, default: 0, null: false
+  add_index "node", ["changed"], name: "node_changed", using: :btree
+  add_index "node", ["created"], name: "node_created", using: :btree
+  add_index "node", ["moderate"], name: "node_moderate", using: :btree
+  add_index "node", ["promote", "status"], name: "node_promote_status", using: :btree
+  add_index "node", ["slug"], name: "index_node_on_slug", using: :btree
+  add_index "node", ["status", "type", "nid"], name: "node_status_type", using: :btree
+  add_index "node", ["title", "type"], name: "node_title_type", using: :btree
+  add_index "node", ["tnid"], name: "index_node_tnid", using: :btree
+  add_index "node", ["translate"], name: "index_node_translate", using: :btree
+  add_index "node", ["type"], name: "node_type", using: :btree
+  add_index "node", ["uid"], name: "index_node_uid", using: :btree
+  add_index "node", ["vid"], name: "index_node_vid", using: :btree
+
+  create_table "node_access", id: false, force: true do |t|
+    t.integer "nid",                    default: 0,  null: false
+    t.integer "gid",                    default: 0,  null: false
+    t.string  "realm",                  default: "", null: false
+    t.integer "grant_view",   limit: 1, default: 0,  null: false
+    t.integer "grant_update", limit: 1, default: 0,  null: false
+    t.integer "grant_delete", limit: 1, default: 0,  null: false
   end
 
-  create_table "node_revisions", primary_key: "vid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "nid", default: 0, null: false
-    t.integer "uid", default: 0, null: false
-    t.string "title", default: "", null: false
-    t.text "body", limit: 4294967295, null: false
-    t.text "teaser"
-    t.text "log"
-    t.integer "timestamp", default: 0, null: false
-    t.integer "format", default: 0, null: false
-    t.integer "status", default: 1
-    t.index ["body", "title"], name: "index_node_revisions_on_body_and_title", type: :fulltext
-    t.index ["nid"], name: "index_node_revisions_nid"
-    t.index ["timestamp"], name: "index_node_revisions_timestamp"
-    t.index ["uid"], name: "index_node_revisions_uid"
+  create_table "node_revisions", primary_key: "vid", force: true do |t|
+    t.integer "nid",                          default: 0,  null: false
+    t.integer "uid",                          default: 0,  null: false
+    t.string  "title",                        default: "", null: false
+    t.text    "body",      limit: 2147483647,              null: false
+    t.text    "teaser"
+    t.text    "log"
+    t.integer "timestamp",                    default: 0,  null: false
+    t.integer "format",                       default: 0,  null: false
+    t.integer "status",                       default: 1
   end
 
-  create_table "node_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+   add_index "node_revisions", ["body", "title"], name: "index_node_revisions_on_body_and_title", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+  add_index "node_revisions", ["nid"], name: "index_node_revisions_nid", using: :btree
+  add_index "node_revisions", ["timestamp"], name: "index_node_revisions_timestamp", using: :btree
+  add_index "node_revisions", ["uid"], name: "index_node_revisions_uid", using: :btree
+
+  create_table "node_selections", id: false, force: true do |t|
     t.integer "user_id"
     t.integer "nid"
     t.boolean "following", default: true
     t.boolean "liking",    default: false
   end
 
-  create_table "profile_fields", primary_key: "fid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "title"
-    t.string "name", limit: 128, default: "", null: false
-    t.text "explanation"
-    t.string "category"
-    t.string "page"
-    t.string "type", limit: 128
-    t.integer "weight", limit: 1, default: 0, null: false
-    t.integer "required", limit: 1, default: 0, null: false
-    t.integer "register", limit: 1, default: 0, null: false
-    t.integer "visibility", limit: 1, default: 0, null: false
-    t.integer "autocomplete", limit: 1, default: 0, null: false
-    t.text "options"
-    t.index ["category"], name: "index_profile_fields_category"
-    t.index ["name"], name: "index_profile_fields_name"
+  add_index "node_selections", ["user_id", "nid"], name: "index_node_selections_on_user_id_and_nid", unique: true, using: :btree
+
+  create_table "profile_fields", primary_key: "fid", force: true do |t|
+    t.string  "title"
+    t.string  "name",         limit: 128, default: "", null: false
+    t.text    "explanation"
+    t.string  "category"
+    t.string  "page"
+    t.string  "type",         limit: 128
+    t.integer "weight",       limit: 1,   default: 0,  null: false
+    t.integer "required",     limit: 1,   default: 0,  null: false
+    t.integer "register",     limit: 1,   default: 0,  null: false
+    t.integer "visibility",   limit: 1,   default: 0,  null: false
+    t.integer "autocomplete", limit: 1,   default: 0,  null: false
+    t.text    "options"
   end
 
-  create_table "profile_values", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "fid", default: 0, null: false
-    t.integer "uid", default: 0, null: false
-    t.text "value"
-    t.index ["fid"], name: "index_profile_values_fid"
-    t.index ["uid"], name: "index_profile_values_on_uid"
+  add_index "profile_fields", ["category"], name: "index_profile_fields_category", using: :btree
+  add_index "profile_fields", ["name"], name: "index_profile_fields_name", using: :btree
+
+  create_table "profile_values", id: false, force: true do |t|
+    t.integer "fid",   default: 0, null: false
+    t.integer "uid",   default: 0, null: false
+    t.text    "value"
   end
 
-  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "follower_id"
-    t.integer "followed_id"
+  add_index "profile_values", ["fid"], name: "index_profile_values_fid", using: :btree
+  add_index "profile_values", ["uid"], name: "index_profile_values_on_uid", using: :btree
+
+  create_table "relationships", force: true do |t|
+    t.integer  "follower_id"
+    t.integer  "followed_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "relationships", ["followed_id"], name: "index_relationships_on_followed_id", using: :btree
+  add_index "relationships", ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true, using: :btree
+  add_index "relationships", ["follower_id"], name: "index_relationships_on_follower_id", using: :btree
+
+  create_table "rsessions", force: true do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["followed_id"], name: "index_relationships_on_followed_id"
-    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
-    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
-  create_table "rsessions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["session_id"], name: "index_rsessions_on_session_id"
-    t.index ["updated_at"], name: "index_rsessions_on_updated_at"
-  end
+  add_index "rsessions", ["session_id"], name: "index_rsessions_on_session_id", using: :btree
+  add_index "rsessions", ["updated_at"], name: "index_rsessions_on_updated_at", using: :btree
 
-  create_table "rusers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "username"
-    t.string "email"
-    t.string "crypted_password"
-    t.string "password_salt"
-    t.string "persistence_token"
-    t.integer "login_count", default: 0, null: false
-    t.integer "failed_login_count", default: 0, null: false
+  create_table "rusers", force: true do |t|
+    t.string   "username"
+    t.string   "email"
+    t.string   "crypted_password"
+    t.string   "password_salt"
+    t.string   "persistence_token"
+    t.integer  "login_count",                           default: 0,       null: false
+    t.integer  "failed_login_count",                    default: 0,       null: false
     t.datetime "last_request_at"
     t.datetime "current_login_at"
     t.datetime "last_login_at"
@@ -336,59 +356,70 @@ ActiveRecord::Schema.define(version: 2018_08_04_215454) do
     t.string   "token"
     t.integer  "status",                                default: 0
     t.integer "password_checker", default: 0
-    t.index ["username", "bio"], name: "index_rusers_on_username_and_bio", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-    t.index ["username"], name: "rusers_username_fulltext_idx", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
   end
 
-  create_table "tag_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  add_index "rusers", ["created_at"], name: "index_rusers_created_at", using: :btree
+  add_index "rusers", ["email"], name: "index_rusers_on_email", using: :btree
+  add_index "rusers", ["persistence_token"], name: "index_rusers_on_persistence_token", using: :btree
+  add_index "rusers", ["status"], name: "index_rusers_on_status", using: :btree
+  add_index "rusers", ["username", "bio"], name: "index_rusers_on_username_and_bio", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+  add_index "rusers", ["username"], name: "index_rusers_on_username", using: :btree
+  add_index "rusers", ["username"], name: "rusers_username_fulltext_idx", type: :fulltext if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+
+  create_table "tag_selections", id: false, force: true do |t|
     t.integer "user_id"
     t.integer "tid"
     t.boolean "following", default: false
-    t.index ["user_id", "tid"], name: "index_tag_selections_on_user_id_and_tid", unique: true
   end
 
-  create_table "term_data", primary_key: "tid", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "vid", default: 0, null: false
-    t.string "name", default: "", null: false
-    t.text "description", limit: 4294967295
-    t.integer "weight", limit: 1, default: 0, null: false
+  add_index "tag_selections", ["user_id", "tid"], name: "index_tag_selections_on_user_id_and_tid", unique: true, using: :btree
+
+  create_table "term_data", primary_key: "tid", force: true do |t|
+    t.integer "vid",                            default: 0,  null: false
+    t.string  "name",                           default: "", null: false
+    t.text    "description", limit: 2147483647
+    t.integer "weight",      limit: 1,          default: 0,  null: false
     t.integer "count"
-    t.string "parent"
-    t.index ["name"], name: "index_term_data_on_name"
-    t.index ["parent"], name: "index_term_data_on_parent"
-    t.index ["vid", "name"], name: "index_term_data_vid_name"
-    t.index ["vid", "weight", "name"], name: "index_vid_weight_name"
+    t.string  "parent"
   end
 
-  create_table "term_node", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  add_index "term_data", ["name"], name: "index_term_data_on_name", using: :btree
+  add_index "term_data", ["parent"], name: "index_term_data_on_parent", using: :btree
+  add_index "term_data", ["vid", "name"], name: "index_term_data_vid_name", using: :btree
+  add_index "term_data", ["vid", "weight", "name"], name: "index_vid_weight_name", using: :btree
+
+  create_table "term_node", id: false, force: true do |t|
     t.integer "nid", default: 0, null: false
     t.integer "vid", default: 0, null: false
     t.integer "tid", default: 0, null: false
-    t.index ["nid"], name: "index_term_node_nid"
-    t.index ["vid"], name: "index_term_node_vid"
   end
 
-  create_table "upload", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "fid", default: 0, null: false
-    t.integer "nid", default: 0, null: false
-    t.integer "vid", default: 0, null: false
-    t.string "description", default: "", null: false
-    t.integer "list", limit: 1, default: 0, null: false
-    t.integer "weight", limit: 1, default: 0, null: false
-    t.index ["fid"], name: "index_upload_fid"
-    t.index ["nid"], name: "index_upload_nid"
+  add_index "term_node", ["nid"], name: "index_term_node_nid", using: :btree
+  add_index "term_node", ["vid"], name: "index_term_node_vid", using: :btree
+
+  create_table "upload", id: false, force: true do |t|
+    t.integer "fid",                   default: 0,  null: false
+    t.integer "nid",                   default: 0,  null: false
+    t.integer "vid",                   default: 0,  null: false
+    t.string  "description",           default: "", null: false
+    t.integer "list",        limit: 1, default: 0,  null: false
+    t.integer "weight",      limit: 1, default: 0,  null: false
   end
 
-  create_table "user_selections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  add_index "upload", ["fid"], name: "index_upload_fid", using: :btree
+  add_index "upload", ["nid"], name: "index_upload_nid", using: :btree
+
+  create_table "user_selections", id: false, force: true do |t|
     t.integer "self_id"
     t.integer "other_id"
     t.boolean "following", default: false
-    t.index ["self_id", "other_id"], name: "index_user_selections_on_self_id_and_other_id", unique: true
   end
 
-  create_table "user_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "uid"
-    t.string "value"
+  add_index "user_selections", ["self_id", "other_id"], name: "index_user_selections_on_self_id_and_other_id", unique: true, using: :btree
+
+  create_table "user_tags", force: true do |t|
+    t.integer  "uid"
+    t.string   "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "data"
@@ -424,4 +455,5 @@ ActiveRecord::Schema.define(version: 2018_08_04_215454) do
   add_index "users", ["mail"], name: "index_users_mail", using: :btree
   add_index "users", ["name"], name: "index_users_name", using: :btree
   add_index "users", ["uid"], name: "index_users_uid", using: :btree
+
 end


### PR DESCRIPTION
@milaaraujo  and I have found an error today on the `schema-example.rb` file.

When we were trying to understand what was happening with the Travis error on #3134, we tried several things to connect the app with MySQL and that might have caused it... and since I haven't updated my project to use SQLite, I didn't see the error before.

We realized today that it created a `schema.rb` that only works with MySQL and that was pushed to the master... So this PR fix this. It also fixes an error caused that only happens on SQLite (which we didn't find before because we are using MySQL from now on and Travis as well).

We hope this didn't cause much trouble, but it's really tricky to catch all these things.

Thanks!
