### PR TITLE
Don't export Redis port

### DIFF
--- a/containers/docker-compose-production.yml
+++ b/containers/docker-compose-production.yml
@@ -47,8 +47,6 @@ services:
     restart: on-failure:5
   redis:
     image: redis:latest
-    ports:
-      - '127.0.0.1:6379:6379'
     command: redis-server
   sidekiq:
     build: ..

--- a/containers/docker-compose-stable.yml
+++ b/containers/docker-compose-stable.yml
@@ -47,8 +47,6 @@ services:
     restart: on-failure:5
   redis:
     image: redis:latest
-    ports:
-      - '127.0.0.1:6379:6379'
     command: redis-server
   sidekiq:
     build: ..

--- a/containers/docker-compose-testing.yml
+++ b/containers/docker-compose-testing.yml
@@ -18,8 +18,6 @@ services:
       # if you want to re-import simply put away ../../mysql/*
   redis:
     image: redis:latest
-    ports:
-      - '6379:6379'
     command: redis-server
   web:
     build: ..

--- a/containers/docker-compose-unstable.yml
+++ b/containers/docker-compose-unstable.yml
@@ -47,8 +47,6 @@ services:
     restart: on-failure:5
   redis:
     image: redis:latest
-    ports:
-      - '127.0.0.1:6379:6379'
     command: redis-server
   sidekiq:
     build: ..


### PR DESCRIPTION
We were sharing Redis containers in staging without being aware. I tagged each instance (`unstable`, `stable`, `testing`) and now we found Redis containers were conflicting with each other competing for port 6379. I don't think we need to export Redis port to the Docker host because it should already be accesible to other containers.

Let's see if this fixes the [issues in staging](https://github.com/jywarren/web/issues/168)!