### PR TITLE
Removed the blue banner (fixes #3244)

### DIFF
--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -21,10 +21,6 @@
 
 <div class="row">
 
-<% if !@node.has_tag('locked') && @node.latest.created_at < Time.now - 6.months %>
-  <div class="alert alert-info" role="alert">This wiki page hasn't been edited for a while. If you see anything that needs updating, please help out!</div>
-<% end %>
-
 <div class="col-md-9">
 
   <%= render :partial => "wiki/header" %>


### PR DESCRIPTION
This commit removes the blue banner saying "Hasn't been edited in a while.Files changed:
1. app/views/wiki/show.html.erb

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!

Fixes #3244