### PR TITLE
Don't display link for the current sort option in the results page's sort option links

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -374,15 +374,3 @@
   color: #75754e;
   background: #f3ffc1;
 }
-
-span#searchSortingOptionsLinks a {
-  margin-left: 5px;
-  margin-right: 5px;
-  font-size: small;
-}
-
-span#searchSortingOptionsLinks:not(a) {
-  margin-left: 5px;
-  margin-right: 5px;
-  font-size: small;
-}

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -375,8 +375,14 @@
   background: #f3ffc1;
 }
 
-span#searchSortingOptionsLinks {
+span#searchSortingOptionsLinks a {
   margin-left: 5px;
+  margin-right: 5px;
   font-size: small;
-  color: blue;
+}
+
+span#searchSortingOptionsLinks:not(a) {
+  margin-left: 5px;
+  margin-right: 5px;
+  font-size: small;
 }

--- a/app/views/searches/results.html.erb
+++ b/app/views/searches/results.html.erb
@@ -2,7 +2,7 @@
 
   <h3>
     Search results for <i style="color:#aaa;"><%= params[:id] %> </i>
-    <span id="searchSortingOptionsLinks">
+    <span style="margin-left: 5px; margin-right: 5px; font-size: small;">
       <%= link_to_unless_current 'best match', controller: :searches, action: :results, id: params[:id], order: 'natural' %>
       |
       <%= link_to_unless_current ' likes', controller: :searches, action: :results, id: params[:id], order: 'likes' %>

--- a/app/views/searches/results.html.erb
+++ b/app/views/searches/results.html.erb
@@ -3,13 +3,13 @@
   <h3>
     Search results for <i style="color:#aaa;"><%= params[:id] %> </i>
     <span id="searchSortingOptionsLinks">
-      <%= link_to 'best match', controller: :searches, action: :results, id: params[:id], order: 'natural' %>
+      <%= link_to_unless_current 'best match', controller: :searches, action: :results, id: params[:id], order: 'natural' %>
       |
-      <%= link_to ' likes', controller: :searches, action: :results, id: params[:id], order: 'likes' %>
+      <%= link_to_unless_current ' likes', controller: :searches, action: :results, id: params[:id], order: 'likes' %>
       |
-      <%= link_to 'views', controller: :searches, action: :results, id: params[:id], order: 'views' %>
+      <%= link_to_unless_current 'views', controller: :searches, action: :results, id: params[:id], order: 'views' %>
       |
-      <%= link_to 'date created', controller: :searches, action: :results, id: params[:id] %>
+      <%= link_to_unless current_page?(controller: :searches, action: :results, check_parameters: true), 'date created', controller: :searches, action: :results, id: params[:id] %>
     </span>
   </h3>
 


### PR DESCRIPTION
When a particular sort option is selected, display the text of the selected option in the links bar with a different style and without an anchor element.

Screenshots:

![default-sort](https://user-images.githubusercontent.com/24409418/44823639-1f3a4c00-abd8-11e8-8c4b-12d88f160658.jpg)


![sort-by-likes](https://user-images.githubusercontent.com/24409418/44823641-24979680-abd8-11e8-99b3-a7026de8c7a2.jpg)



@jywarren Take a look at this PR, is something like this what you had in mind [here](https://github.com/publiclab/plots2/pull/3255#issuecomment-416227264)?