### PR TITLE
Revert "Add passenger precompile nginx step (fixes #3287)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,3 @@ ADD . /app
 WORKDIR /app
 
 RUN bower install --allow-root
-RUN passenger-config compile-nginx-engine --connect-timeout 60 --idle-timeout 60


### PR DESCRIPTION
Reverts publiclab/plots2#3288

Terribly sorry, this did not fix issue https://github.com/publiclab/plots2/issues/3287 . While it's a good idea to pre-compile, it's not needed for CI tests and will delay them. So I'll revert this and try something else. Next time I'll push to stable first to try it out before merging!