### PR TITLE
Revert "Revert "Add passenger precompile nginx step (fixes #3287)""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,4 @@ ADD . /app
 WORKDIR /app
 
 RUN bower install --allow-root
+RUN passenger-config compile-nginx-engine --connect-timeout 60 --idle-timeout 60


### PR DESCRIPTION
Reverts publiclab/plots2#3290

I was wrong! This did solve #3287 - Also I think it's right for this to be done at Dockerfile. Ideally we'd use precompiled nginx somehow!