### PR TITLE
[WIP] Mentions can only preceded by one character

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,12 +1,12 @@
 module Callouts
-  FINDER = /(?:\s|^)([^`\w]?)\@([\w-]+)/
+  FINDER = /(\s|^)([^`\w]?)\@([\w-]+)/
   HASHTAG = /(\s)\#([:a-zA-Z0-9_-]+)/
   HASHTAGWITHOUTNUMBER = /(\s)\#([:0-9_-]*[a-zA-Z]+[:0-9_-]*)/
-  PRETTYLINKMD = '\1[@\2](/profile/\2)'
+  PRETTYLINKMD = '\1\2[@\3](/profile/\3)'
   HASHLINKMD = '\1[#\2](/tag/\2)'
   HASHTAGNUMBER = /(\s)\#([:0-9]+)/
   NODELINKMD = '\1[#\2](/n/\2)'
-  PRETTYLINKHTML = '\1<a href="/profile/\2">@\2</a>'
+  PRETTYLINKHTML = '\1\2<a href="/profile/\3">@\3</a>'
   HASHLINKHTML = '\1<a href="/tag/\2">#\2</a>'
   NODELINKHTML = '\1<a href="/n/\2">#\2</a>'
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,5 +1,5 @@
 module Callouts
-  FINDER = /([^`\w]|^)\@([\w-]+)/
+  FINDER = /(?:\s|^)([^`\w]?)\@([\w-]+)/
   HASHTAG = /(\s)\#([:a-zA-Z0-9_-]+)/
   HASHTAGWITHOUTNUMBER = /(\s)\#([:0-9_-]*[a-zA-Z]+[:0-9_-]*)/
   PRETTYLINKMD = '\1[@\2](/profile/\2)'

--- a/test/unit/constants_test.rb
+++ b/test/unit/constants_test.rb
@@ -8,6 +8,12 @@ class ConstantsTest < ActiveSupport::TestCase
     assert_equal expect, string.gsub(Callouts.const_get(:FINDER), ' REPLACE').lstrip!
   end
 
+  test 'should not match within URL' do
+    string = 'https://medium.com/@350/from-the-bayou-to-the-bay-voices-from-the-gulf-f6707c7ecff3'
+    expect = 'https://medium.com/@350/from-the-bayou-to-the-bay-voices-from-the-gulf-f6707c7ecff3'
+    assert_equal expect, string.gsub(Callouts.const_get(:FINDER), ' REPLACE').lstrip!
+  end
+  
   test 'hashtag regex should not match initial hash' do
     string = '#tag'
     assert_no_match Callouts.const_get(:HASHTAG), string


### PR DESCRIPTION
Fixes #3303 

Added non-capture group to look for mentions only preceded by a space. Tested with issue author's test string: http://rubular.com/r/GQSMWkoXYp The solution only allows for mentions to be preceded by a space, non-word character, or beginning of a string.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!