### PR TITLE
Comparing search modes (boolean and natural)

### DIFF
--- a/app/views/searches/results.html.erb
+++ b/app/views/searches/results.html.erb
@@ -3,7 +3,9 @@
   <h3>
     Search results for <i style="color:#aaa;"><%= params[:id] %> </i>
     <span style="margin-left: 5px; margin-right: 5px; font-size: small;">
-      <%= link_to_unless_current 'best match', controller: :searches, action: :results, id: params[:id], order: 'natural' %>
+      <%= link_to_unless_current 'natural mode', controller: :searches, action: :results, id: params[:id], order: 'natural', type: 'natural' %>
+      |
+      <%= link_to_unless_current 'boolean mode', controller: :searches, action: :results, id: params[:id], order: 'natural', type: 'boolean' %>
       |
       <%= link_to_unless_current ' likes', controller: :searches, action: :results, id: params[:id], order: 'likes' %>
       |
@@ -24,7 +26,7 @@
     <%= render partial: "notes/notes", locals: { notes: @nodes } %>
 
   <% end %>
-  
+
 </div>
 
 <%= stylesheet_link_tag "dashboard" %>

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -10,7 +10,9 @@ class SearchFlowTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Perform a GET search with a search term and sort order in query parameters
-    get '/search/map?order=natural'
+    get '/search/map?order=natural&type=natural'
+    assert_response :success
+    get '/search/map?order=natural&type=boolean'
     assert_response :success
     get '/search/map?order=likes'
     assert_response :success


### PR DESCRIPTION
Hey @jywarren, I'm opening this PR to add the boolean mode option to the search view. So the community can compare the different search options and we can decide which one to keep as default.

![desenho sem titulo 3](https://user-images.githubusercontent.com/4355017/45334399-7bce2d00-b52f-11e8-8fb4-de861d9f5e73.png)

'Natural mode' was previously 'best match'. We changed the name for now to make clear that it's the natural mode search. After this period of tests we can choose better names. 
 