### PR TITLE
Using node.search() in the search service methods

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -40,12 +40,14 @@ class Node < ActiveRecord::Base
           nids = Revision.select("node_revisions.nid, node_revisions.body, node_revisions.title, MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN BOOLEAN MODE) AS score")
             .where("MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN BOOLEAN MODE)")
             .limit(limit)
+            .distinct
             .collect(&:nid)
         else
           query = connection.quote(query.to_s)
           nids = Revision.select("node_revisions.nid, node_revisions.body, node_revisions.title, MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN NATURAL LANGUAGE MODE) AS score")
             .where("MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN NATURAL LANGUAGE MODE)")
             .limit(limit)
+            .distinct
             .collect(&:nid)
         end
         where(nid: nids, status: 1)
@@ -55,6 +57,7 @@ class Node < ActiveRecord::Base
         where(nid: nids + tnids, status: 1)
           .order(order_param)
           .limit(limit)
+          .distinct
       end
     else
       nodes = Node.limit(limit)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -85,7 +85,7 @@ class SearchService
     nodes = find_nodes(srchString, 25)
     puts nodes.inspect
     nodes.each do |match|
-      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, '', 0)
+      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, 'NOTES', 0)
       sresult.addDoc(doc)
     end
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -71,7 +71,7 @@ class SearchService
 
     nodes = find_notes(srchString, 25)
     nodes.each do |match|
-      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, match.body.split(/#+.+\n+/, 5)[1], 0)
+      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, 'NOTES', 0)
       sresult.addDoc(doc)
     end
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -15,9 +15,9 @@ class SearchService
     sresult.addAll(nodeList.items)
 
     # User profiles
-    search_criteria.add_sort_by("recent")
-    userList = profiles(search_criteria)
-    sresult.addAll(userList.items)
+    #search_criteria.add_sort_by("recent")
+    #userList = profiles(search_criteria)
+    #sresult.addAll(userList.items)
 
     # Tags
     tagList = textSearch_tags(search_criteria.query)
@@ -83,9 +83,9 @@ class SearchService
     sresult = DocList.new
 
     nodes = find_nodes(srchString, 25)
-    puts nodes.inspect
+
     nodes.each do |match|
-      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, 'NOTES', 0)
+      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, 'PAGES', 0)
       sresult.addDoc(doc)
     end
 
@@ -96,10 +96,9 @@ class SearchService
   def textSearch_maps(srchString)
     sresult = DocList.new
 
-    maps = Node.where('type = "map" AND node.status = 1 AND title LIKE ?', '%' + srchString + '%')
-               .limit(10)
+    maps = find_maps(srchString, 25)
 
-    maps.select('title,type,nid,path').each do |match|
+    maps.each do |match|
       doc = DocResult.fromSearch(match.nid, 'map', match.path, match.title, 'PLACES', 0)
       sresult.addDoc(doc)
     end
@@ -133,14 +132,8 @@ class SearchService
   def textSearch_questions(srchString)
     sresult = DocList.new
 
-    questions = Node.where(
-      'type = "note" AND node.status = 1 AND title LIKE ?',
-      '%' + srchString + '%'
-    )
-      .joins(:tag)
-      .where('term_data.name LIKE ?', 'question:%')
-      .order('node.nid DESC')
-      .limit(10)
+    questions = find_questions(srchString, 25)
+
     questions.each do |match|
       doc = DocResult.fromSearch(match.nid, 'question-circle', match.path(:question), match.title, 'QUESTIONS', match.answers.length.to_i)
       sresult.addDoc(doc)
@@ -226,6 +219,18 @@ class SearchService
   def find_notes(input, limit)
     Node.search(query: input, order: :natural, type: :boolean, limit: limit)
         .where("`node`.`type` = 'note'")
+  end
+
+  def find_maps(input, limit)
+    Node.search(query: input, order: :natural, type: :boolean, limit: limit)
+        .where("`node`.`type` = 'map'")
+  end
+
+  def find_questions(input, limit)
+    Node.search(query: input, order: :natural, type: :boolean, limit: limit)
+        .where("`node`.`type` = 'note'")
+        .joins(:tag)
+        .where('term_data.name LIKE ?', 'question:%')
   end
 
   def find_locations(limit, user_tag = nil)

--- a/test/functional/api/search_api_full_text_test.rb
+++ b/test/functional/api/search_api_full_text_test.rb
@@ -8,6 +8,66 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
     Rails.application
   end
 
+  test 'search all functionality' do
+    get '/api/srch/all?srchString=Blog'
+    assert last_response.ok?
+
+    # Expected search pattern
+    pattern = {
+      srchParams: {
+        srchString: 'Blog',
+        seq: nil,
+      }.ignore_extra_keys!
+    }.ignore_extra_keys!
+
+    matcher = JsonExpressions::Matcher.new(pattern)
+
+    json = JSON.parse(last_response.body)
+
+    assert_equal nodes(:blog).path, json['items'][0]['docUrl']
+    assert_equal "Blog post",       json['items'][0]['docTitle']
+    assert_equal 13,                json['items'][0]['docId']
+
+    assert matcher =~ json
+   end
+
+   test 'search all functionality with multiple responses' do
+     get '/api/srch/all?srchString=question'
+     assert last_response.ok?
+
+     # Expected search pattern
+     pattern = {
+       srchParams: {
+         srchString: 'question',
+         seq: nil,
+       }.ignore_extra_keys!
+     }.ignore_extra_keys!
+
+     matcher = JsonExpressions::Matcher.new(pattern)
+
+     json = JSON.parse(last_response.body)
+
+     assert matcher =~ json
+   end
+
+   test 'search all functionality without search query' do
+     get '/api/srch/all?srchString'
+     assert last_response.ok?
+
+     # Expected search pattern
+     pattern = {
+       srchParams: {
+         srchString: nil,
+         seq: nil,
+       }.ignore_extra_keys!
+     }.ignore_extra_keys!
+
+     matcher = JsonExpressions::Matcher.new(pattern)
+
+     json = JSON.parse(last_response.body)
+     assert matcher =~ json
+   end
+
   def search_profiles_by_username_and_bio_without_order_by_and_default_sort_direction
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
 
@@ -54,5 +114,52 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
     assert_equal "/profile/testuser",   json['items'][0]['docUrl']
 
     assert matcher =~ json
+  end
+
+  test 'search questions functionality' do
+     get '/api/srch/questions?srchString=Question'
+     assert last_response.ok?
+
+     # Expected search pattern
+     pattern = {
+       srchParams: {
+         srchString: 'Question',
+         seq: nil,
+    }.ignore_extra_keys!
+  }.ignore_extra_keys!
+
+  matcher = JsonExpressions::Matcher.new(pattern)
+
+  json = JSON.parse(last_response.body)
+
+  assert_equal "How to use a Spectrometer", json['items'][0]['docTitle']
+  assert_equal 8,                             json['items'][0]['docId']
+
+
+  assert matcher =~ json
+
+end
+
+test 'search notes functionality' do
+  get '/api/srch/notes?srchString=Blog'
+  assert last_response.ok?
+  # Expected search pattern
+  pattern = {
+    srchParams: {
+    srchString: 'Blog',
+    seq: nil,
+    }.ignore_extra_keys!
+  }.ignore_extra_keys!
+
+  matcher = JsonExpressions::Matcher.new(pattern)
+
+  json = JSON.parse(last_response.body)
+
+  assert_equal nodes(:blog).path, json['items'][0]['docUrl']
+  assert_equal "Blog post",       json['items'][0]['docTitle']
+  assert_equal 13,                json['items'][0]['docId']
+
+  assert matcher =~ json
+
   end
 end

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -7,67 +7,7 @@ class SearchApiTest < ActiveSupport::TestCase
     Rails.application
   end
 
-  test 'search all functionality' do
-     get '/api/srch/all?srchString=Blog'
-     assert last_response.ok?
 
-     # Expected search pattern
-     pattern = {
-       srchParams: {
-         srchString: 'Blog',
-         seq: nil,
-       }.ignore_extra_keys!
-     }.ignore_extra_keys!
-
-     matcher = JsonExpressions::Matcher.new(pattern)
-
-     json = JSON.parse(last_response.body)
-
-     assert_equal nodes(:blog).path, json['items'][0]['docUrl']
-     assert_equal "Blog post",       json['items'][0]['docTitle']
-     assert_equal 13,                json['items'][0]['docId']
-
-     assert matcher =~ json
-
-   end
-
-   test 'search all functionality with multiple responses' do
-      get '/api/srch/all?srchString=question'
-      assert last_response.ok?
-
-      # Expected search pattern
-      pattern = {
-        srchParams: {
-          srchString: 'question',
-          seq: nil,
-        }.ignore_extra_keys!
-      }.ignore_extra_keys!
-
-      matcher = JsonExpressions::Matcher.new(pattern)
-
-      json = JSON.parse(last_response.body)
-
-      assert matcher =~ json
-    end
-
-    test 'search all functionality without search query' do
-       get '/api/srch/all?srchString'
-       assert last_response.ok?
-
-       # Expected search pattern
-       pattern = {
-         srchParams: {
-           srchString: nil,
-           seq: nil,
-         }.ignore_extra_keys!
-       }.ignore_extra_keys!
-
-       matcher = JsonExpressions::Matcher.new(pattern)
-
-       json = JSON.parse(last_response.body)
-       assert matcher =~ json
-
-     end
 
    # search by username and returns users by id when order_by is not provided and sorted direction default DESC
    test 'search profiles by username without order_by and default sort_direction' do
@@ -142,71 +82,23 @@ class SearchApiTest < ActiveSupport::TestCase
      assert matcher =~ json
   end
 
-  test 'search notes functionality' do
-      get '/api/srch/notes?srchString=Blog'
-      assert last_response.ok?
-      # Expected search pattern
-      pattern = {
-        srchParams: {
-          srchString: 'Blog',
-          seq: nil,
-        }.ignore_extra_keys!
-      }.ignore_extra_keys!
+  test 'search tags functionality' do
+    get '/api/srch/tags?srchString=Awesome'
+    assert last_response.ok?
 
-      matcher = JsonExpressions::Matcher.new(pattern)
-
-      json = JSON.parse(last_response.body)
-
-      assert_equal nodes(:blog).path, json['items'][0]['docUrl']
-      assert_equal "Blog post",       json['items'][0]['docTitle']
-      assert_equal 13,                json['items'][0]['docId']
-
-      assert matcher =~ json
-
-    end
-
-    test 'search questions functionality' do
-       get '/api/srch/questions?srchString=Question'
-       assert last_response.ok?
-
-       # Expected search pattern
-       pattern = {
-         srchParams: {
-           srchString: 'Question',
-           seq: nil,
+    # Expected search pattern
+    pattern = {
+      srchParams: {
+        srchString: 'Awesome',
+        seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
 
     matcher = JsonExpressions::Matcher.new(pattern)
 
     json = JSON.parse(last_response.body)
-
-    assert_equal "How to use a Spectrometer", json['items'][0]['docTitle']
-    assert_equal 8,                             json['items'][0]['docId']
-
-
     assert matcher =~ json
-
   end
-
-  test 'search tags functionality' do
-     get '/api/srch/tags?srchString=Awesome'
-     assert last_response.ok?
-
-     # Expected search pattern
-     pattern = {
-       srchParams: {
-         srchString: 'Awesome',
-          seq: nil,
-       }.ignore_extra_keys!
-     }.ignore_extra_keys!
-
-     matcher = JsonExpressions::Matcher.new(pattern)
-
-     json = JSON.parse(last_response.body)
-     assert matcher =~ json
-
-    end
 
   test 'search Tag Nearby Nodes functionality' do
     get '/api/srch/taglocations?srchString=71.00,52.00&tagName=awesome'
@@ -277,5 +169,4 @@ class SearchApiTest < ActiveSupport::TestCase
     assert matcher =~ json
 
   end
-
 end

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -181,8 +181,8 @@ class SearchApiTest < ActiveSupport::TestCase
 
     json = JSON.parse(last_response.body)
 
-    assert_equal "Question by a moderated user", json['items'][0]['docTitle']
-    assert_equal 15,                             json['items'][0]['docId']
+    assert_equal "How to use a Spectrometer", json['items'][0]['docTitle']
+    assert_equal 8,                             json['items'][0]['docId']
 
 
     assert matcher =~ json

--- a/test/unit/api/search_service_test.rb
+++ b/test/unit/api/search_service_test.rb
@@ -128,7 +128,7 @@ class SearchServiceTest < ActiveSupport::TestCase
     result = SearchService.new.textSearch_questions('question')
 
     assert_not_nil result
-    assert_equal 2, result.items.length
+    assert_equal 3, result.items.length
 
     assert_equal result.getDocs.to_json, sresult.getDocs.to_json
     assert_equal result.getDocs.to_json.length, result.getDocs.uniq.to_json.length

--- a/test/unit/api/search_service_test.rb
+++ b/test/unit/api/search_service_test.rb
@@ -22,29 +22,11 @@ class SearchServiceTest < ActiveSupport::TestCase
     sresult
   end
 
-  def create_notes_doc_list(notes)
-    sresult = DocList.new
-    notes.each do |match|
-      doc = DocResult.fromSearch(match.nid, 'file', match.path, match.title, 'NOTES', 0)
-      sresult.addDoc(doc)
-    end
-    sresult
-  end
-
   def create_tags_doc_list(notes)
     sresult = DocList.new
     notes.each do |match|
       tagdoc = DocResult.fromSearch(match.nid, 'tag', match.path, match.title, 'TAGS', 0)
       sresult.addDoc(tagdoc)
-    end
-    sresult
-  end
-
-  def create_questions_doc_list(notes)
-    sresult = DocList.new
-    notes.each do |match|
-      doc = DocResult.fromSearch(match.nid, 'question-circle', match.path(:question), match.title, 'QUESTIONS', match.answers.length.to_i)
-      sresult.addDoc(doc)
     end
     sresult
   end
@@ -95,19 +77,6 @@ class SearchServiceTest < ActiveSupport::TestCase
     assert_equal result.getDocs.to_json.length, result.getDocs.uniq.to_json.length
   end
 
-  test 'running search notes' do
-    notes = [nodes(:blog)]
-    sresult = create_notes_doc_list(notes)
-
-    result = SearchService.new.textSearch_notes('Blog')
-
-    assert_not_nil result
-    assert_equal 1, result.items.length
-
-    assert_equal result.getDocs.to_json, sresult.getDocs.to_json
-    assert_equal result.getDocs.to_json.length, result.getDocs.uniq.to_json.length
-  end
-
   test 'running search tags' do
     notes = [nodes(:one), nodes(:about)]
     sresult = create_tags_doc_list(notes)
@@ -116,19 +85,6 @@ class SearchServiceTest < ActiveSupport::TestCase
 
     assert_not_nil result
     assert_equal 2, result.items.length
-
-    assert_equal result.getDocs.to_json, sresult.getDocs.to_json
-    assert_equal result.getDocs.to_json.length, result.getDocs.uniq.to_json.length
-  end
-
-  test 'running search questions' do
-    notes = [nodes(:question3), nodes(:question2)]
-    sresult = create_questions_doc_list(notes)
-
-    result = SearchService.new.textSearch_questions('question')
-
-    assert_not_nil result
-    assert_equal 3, result.items.length
 
     assert_equal result.getDocs.to_json, sresult.getDocs.to_json
     assert_equal result.getDocs.to_json.length, result.getDocs.uniq.to_json.length


### PR DESCRIPTION
Using node.search() in the search service methods.
Removing duplicates from some endpoints (#3310).
Adding 'limit' parameter to methods.