### PR TITLE
Adds twitter handle request to Welcomebot's thank you message on merged PRs

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -16,6 +16,8 @@ newPRWelcomeComment: >
 
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
-  Congrats on merging your first pull request! 🙌🎉⚡️
+  Congrats on merging your first pull request! 🙌🎉⚡️ Your code will likely be published to PublicLab.org in the next few days. In the meantime, can you tell us your Twitter handle so we can thank you properly?
+
+
 
 # It is recommend to include as many gifs and emojis as possible


### PR DESCRIPTION
This handles issue #3342

I took the diff (from first-timers bot) literally and also added two blank lines.