### PR TITLE
Set mailman container to restart upon failure (workaround for #3208)

### DIFF
--- a/containers/docker-compose-production.yml
+++ b/containers/docker-compose-production.yml
@@ -75,3 +75,4 @@ services:
       - EMAIL_PASSWORD=${EMAIL_PASSWORD}
     volumes:
       - ..:/app
+    restart: on-failure:5


### PR DESCRIPTION
I found mailman was down today. I think docker-compose can restart it when it fails!
This should do it.


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
