### PR TITLE
Simple UI improvement for blockquote responses. 

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -23,3 +23,10 @@
   margin-bottom: 0;
   margin-left: 4px;
 }
+
+.blockquotestyle > blockquote {
+  font-size: 14px;
+  font-family: "Helvetica Neue";
+  border-left: 5px solid #736f6f;
+  background-color: #f3f1ef;
+}

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -117,7 +117,7 @@
   
   <div style="border: 1px solid #e7e7e7;padding: 18px;" id="c<%= comment.cid %>show">
 
-    <div style="font-size: 30px;"><% comment_body = render_comment_body(comment) %></div>
+    <% comment_body = render_comment_body(comment) %>
     <p id="comment-body-<%= comment.cid %>"><%= raw filtered_comment_body(comment_body) %></p>
 
     <% if contain_trimmed_body?(comment_body) %>

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -117,12 +117,12 @@
   
   <div style="border: 1px solid #e7e7e7;padding: 18px;" id="c<%= comment.cid %>show">
 
-    <% comment_body = render_comment_body(comment) %>
+    <div style="font-size: 30px;"><% comment_body = render_comment_body(comment) %></div>
     <p id="comment-body-<%= comment.cid %>"><%= raw filtered_comment_body(comment_body) %></p>
 
     <% if contain_trimmed_body?(comment_body) %>
       <span style="background-color: #DCDCDC;  border-radius: 7px; cursor: pointer;" ><a class="email-toggle" data-toggle="collapse" data-target="#comment-<%= comment.cid %>-extra-content" style='text-decoration: none;'>&nbsp;&ensp;&#x2022&#x2022&#x2022&nbsp;&ensp;</a></span>
-      <div class="collapse" id="comment-<%= comment.cid %>-extra-content" ><%= raw trimmed_body(comment_body) %></div>
+      <div class="collapse" id="comment-<%= comment.cid %>-extra-content" ><div class="blockquotestyle"><%= raw trimmed_body(comment_body) %></div></div>
     <% end %>
 
     <% if comment.body.include?('?') %>


### PR DESCRIPTION
Here, I modified the CSS for blockquote responses to easily differentiate it from the original comments. 

The files modified are: 
* app/assets/stylesheets/comments.css 
* app/views/notes/_comment.html.erb

Fixes #3425 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
