### PR TITLE
Add doc for running plots2 with MySQL

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -72,12 +72,12 @@ already using it.
 ## How to run plots2 with MySQL on development and test environments
 
 In development and test environments, the project uses SQLite3, but in production
-it uses [MySQL](https://github.com/publiclab/plots2/blob/master/containers/docker-compose-production.yml).
+it uses [MySQL (or mariadb)](https://github.com/publiclab/plots2/blob/master/containers/docker-compose-production.yml).
 
 If you need to test something that SQLite3 doesn't support, like a full-text
 search, for example, you need to add more steps to your configuration:
 
-1 - Install MySQL on your machine
+1 - Install MySQL or mariadb on your machine
 
 2 - Update your `mysql` group on Gemfile to:
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -27,7 +27,7 @@ Client-side tests (for JavaScript functions) are run using [teaspoon-mocha](http
 
 ****
 
-If you get stuck on testing at any point, you can _open a pull request with your changes_ -- please add the prefix `[testing]` to the title -- which will then be automatically tested by our TravisCI service -- which runs **all tests**. If your additions are pretty basic, and you write tests against them, this may be sufficient without actually running the whole environment yourself! 
+If you get stuck on testing at any point, you can _open a pull request with your changes_ -- please add the prefix `[testing]` to the title -- which will then be automatically tested by our TravisCI service -- which runs **all tests**. If your additions are pretty basic, and you write tests against them, this may be sufficient without actually running the whole environment yourself!
 
 ## Running just one type of test
 
@@ -68,3 +68,85 @@ them to production.
 If you need to use the stable or the unstable branch,
 please ask in the chatroom (https://publiclab.org/chat) if someone else is
 already using it.
+
+## How to run plots2 with MySQL on development and test environments
+
+In development and test environments, the project uses SQLite3, but in production
+it uses [MySQL](https://github.com/publiclab/plots2/blob/master/containers/docker-compose-production.yml).
+
+If you need to test something that SQLite3 doesn't support, like a full-text
+search, for example, you need to add more steps to your configuration:
+
+1 - Install MySQL on your machine
+
+2 - Update your `mysql` group on Gemfile to:
+
+```
+group :mysql, :production, :development, :test do
+  gem 'mysql2', '>= 0.4.4'
+  # mysql 0.4.3+ causes a version mismatch, apparently, and demands 'activerecord-mysql2-adapter'
+end
+```
+
+3 - Comment this group:
+
+```
+group :sqlite, :development do
+  gem 'sqlite3'
+end
+```
+
+4 - Copy the file `config/database.yml.mysql.example` to your `config/database.yml`
+You may need to add a password and a username. If you don't remember them when
+you installed MySQL, run `mysql_secure_installation` to set a new password.
+
+You may also need to create a database, it depends on which OS you're using.
+
+This is an example of the config/database.yml file after following those steps:
+
+```
+development:
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  username: yourusername
+  password: yourpassword
+  database: plots2_development
+  strict: false
+
+production:
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  username: yourusername
+  password: yourpassword
+  database: plots2_production
+
+test:
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  username: yourusername
+  password: yourpassword
+  database: plots2_test
+  strict: false
+```
+
+5 - Run `bundle install`
+
+6 - Run rake `db:setup`
+
+If everything run smoothly, this will avoid some weird errors (like passing the
+tests locally but not on travis). Remember *not to add* those to your commits.
+
+## Tests with MySQL features
+
+It may be a good practice to add the tests that use MySQL features in a different
+file and use a skip method for the SQLite3 adapter:
+
+`skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'`
+
+Take a look at this test [search_service_full_text_search_test.rb](https://github.com/publiclab/plots2/blob/master/test/unit/api/search_service_full_text_search_test.rb) for more details.
+
+This way we don't have errors either using SQLite3 or MySQL on development and tests
+environments.


### PR DESCRIPTION
This is a doc improvement to help anyone that might have problems like this #3170 so they can run plots2 with MySQL on both development and test environments.
