### PR TITLE
Change API params to ruby standard

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -8,12 +8,12 @@ module Srch
     helpers SharedParams
 
     # Endpoint definitions
+    # Basic implementation from classic plots2 SearchController
     resource :srch do
-      # Request URL should be /api/srch/all?srchString=QRY
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/all?query=QRY
       desc 'Perform a search of all available resources', hidden: false,
                                                           is_array: false,
-                                                          nickname: 'srchGetAll'
+                                                          nickname: 'search_all'
       params do
         use :common
       end
@@ -82,11 +82,10 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/profiles?srchString=QRY[&sort_by=recent&order_direction=desc&field=username]
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/profiles?query=QRY[&sort_by=recent&order_direction=desc&field=username]
       desc 'Perform a search of profiles', hidden: false,
                                            is_array: false,
-                                           nickname: 'srchGetProfiles'
+                                           nickname: 'search_profiles'
 
       params do
         use :common, :sorting, :ordering, :field
@@ -109,11 +108,10 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/notes?srchString=QRY
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/notes?query=QRY
       desc 'Perform a search of research notes', hidden: false,
                                                  is_array: false,
-                                                 nickname: 'srchGetNotes'
+                                                 nickname: 'search_notes'
 
       params do
         use :common
@@ -138,11 +136,10 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/wikis?srchString=QRY
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/wikis?query=QRY
       desc 'Perform a search of wikis pages',    hidden: false,
                                                  is_array: false,
-                                                 nickname: 'srchGetWikis'
+                                                 nickname: 'search_wikis'
 
       params do
         use :common
@@ -167,11 +164,10 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/questions?srchString=QRY
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/questions?query=QRY
       desc 'Perform a search of questions tables', hidden: false,
                                                    is_array: false,
-                                                   nickname: 'srchGetQuestions'
+                                                   nickname: 'search_questions'
 
       params do
         use :common
@@ -197,11 +193,10 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/tags?srchString=QRY
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/tags?query=QRY
       desc 'Perform a search of documents associated with tags within the system', hidden: false,
                                                                                    is_array: false,
-                                                                                   nickname: 'srchGetByTags'
+                                                                                   nickname: 'search_tags'
 
       params do
         use :common
@@ -226,11 +221,11 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/taglocations?srchString=QRY[&tagName=awesome]
-      # Note: Query(QRY as above) must have latitude and longitude as srchString=lat,lon
+      # Request URL should be /api/srch/taglocations?query=QRY[&tag=awesome]
+      # Note: Query(QRY as above) must have latitude and longitude as query=lat,lon
       desc 'Perform a search of documents having nearby latitude and longitude tag values', hidden: false,
                                                                                             is_array: false,
-                                                                                            nickname: 'srchGetLocations'
+                                                                                            nickname: 'search_tag_locations'
 
       params do
         use :common, :additional
@@ -259,11 +254,11 @@ module Srch
       end
 
       # API TO FETCH QRY RECENT CONTRIBUTORS
-      # Request URL should be /api/srch/peoplelocations?srchString=QRY[&tagName=group:partsandcrafts]
+      # Request URL should be /api/srch/peoplelocations?query=QRY[&tag=group:partsandcrafts]
       # QRY should be a number
       desc 'Perform a search to show x Recent People',  hidden: false,
                                                         is_array: false,
-                                                        nickname: 'srchGetPeople'
+                                                        nickname: 'search_people_locations'
 
       params do
         use :common, :additional
@@ -291,11 +286,10 @@ module Srch
         end
       end
 
-      # Request URL should be /api/srch/places?srchString=QRY
-      # Basic implementation from classic plots2 SearchController
+      # Request URL should be /api/srch/places?query=QRY
       desc 'Perform a search of places',           hidden: false,
                                                    is_array: false,
-                                                   nickname: 'srchPlaces'
+                                                   nickname: 'search_places'
 
       params do
         use :common
@@ -323,7 +317,7 @@ module Srch
 
     def self.execute(endpoint, params)
       search_type = endpoint
-      search_criteria = SearchCriteria.from_params(params)
+      search_criteria = SearchCriteria.new(params)
 
       if search_criteria.valid?
         ExecuteSearch.new.by(search_type, search_criteria)

--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -5,12 +5,12 @@ module Srch
     extend Grape::API::Helpers
 
     params :common do
-      requires :srchString, type: String, documentation: { example: 'Spec' }
-      optional :limit, type: Integer, documentation: { example: 0 }
+      requires :query, type: String, documentation: { example: 'Spec' }
+      optional :limit, type: Integer, documentation: { example: 10 }
     end
 
     params :additional do
-      optional :tagName, type: String, documentation: { example: 'awesome' }
+      optional :tag, type: String, documentation: { example: 'awesome' }
     end
 
     params :ordering do

--- a/app/assets/javascripts/atwho_autocomplete.js
+++ b/app/assets/javascripts/atwho_autocomplete.js
@@ -4,7 +4,7 @@
     at: "@",
     callbacks: {
       remoteFilter: function(query, callback) {
-        $.getJSON("/api/srch/profiles?srchString=" + query + "&sort_by=recent&field=username", {}, function(data) {
+        $.getJSON("/api/srch/profiles?query=" + query + "&sort_by=recent&field=username", {}, function(data) {
           if (data.hasOwnProperty('items') && data.items.length > 0) {
             callback(data.items.map(function(i) { return i.docTitle }));
           }

--- a/app/assets/javascripts/restful_typeahead.js
+++ b/app/assets/javascripts/restful_typeahead.js
@@ -14,7 +14,7 @@ $(function() {
     autoSelect: false,
     source: function (query, process) {
       var encoded_query = encodeURIComponent(query);
-      return $.getJSON('/api/srch/all?srchString=' + encoded_query, function (data) {
+      return $.getJSON('/api/srch/all?query=' + encoded_query, function (data) {
         return process(data.items);
       },'json');
     },

--- a/app/models/search_request.rb
+++ b/app/models/search_request.rb
@@ -3,17 +3,15 @@ class SearchRequest
   # Minimum query length, or we return an empty result
   MIN_QUERY_LENGTH = 3
 
-  attr_accessor :srchString, :seq, :showCount, :pageNum, :tagName
+  attr_accessor :query, :seq, :tag
 
   def initialize; end
 
   def self.fromRequest(rparams)
     obj = new
-    obj.srchString = rparams[:srchString]
+    obj.query = rparams[:query]
     obj.seq = rparams[:seq]
-    obj.showCount = rparams[:showCount]
-    obj.pageNum = rparams[:pageNum]
-    obj.tagName = rparams[:tagName]
+    obj.tag = rparams[:tag]
     obj
   end
 
@@ -21,18 +19,16 @@ class SearchRequest
   # and make sure it is at least 3 characters
   def valid?
     isValid = true
-    isValid &&= !srchString.blank?
-    isValid &&= srchString.length >= MIN_QUERY_LENGTH
+    isValid &&= !query.blank?
+    isValid &&= query.length >= MIN_QUERY_LENGTH
     isValid
   end
 
   # This subclass is used to auto-generate the RESTful data structure.  It is generally not useful for internal Ruby usage
   #  but must be included for full RESTful functionality.
   class Entity < Grape::Entity
-    expose :srchString, documentation: { type: 'String', desc: 'Search Query text.' }
-    expose :seq, documentation: { type: 'Integer', desc: 'Sequence value passed from client through to the SearchResult.  For client sequencing usage' }
-    expose :showCount, documentation: { type: 'Integer', desc: 'The requested number of records to show per page' }
-    expose :pageNum, documentation: { type: 'Integer', desc: 'Which page (zero-based counting, as in Array indexes) to show paginated data.' }
-    expose :tagName, documentation: { type: 'String', desc: 'To search users having specified tagName.' }
+    expose :query, documentation: { type: 'String', desc: 'Search Query text.' }
+    expose :seq, documentation: { type: 'Integer', desc: 'Sequence value passed from client through to the SearchResult. For client sequencing usage' }
+    expose :tag, documentation: { type: 'String', desc: 'Refine search by specified tag.' }
   end
 end

--- a/app/services/search_criteria.rb
+++ b/app/services/search_criteria.rb
@@ -11,17 +11,6 @@ class SearchCriteria
     @limit = args[:limit] || 10
   end
 
-  def self.from_params(params)
-    args = {
-      query: params[:srchString],
-      tag: params[:tagName],
-      sort_by: params[:sort_by],
-      field: params[:field],
-      limit: params[:limit]
-    }
-    new(args)
-  end
-
   def valid?
     !query.nil? && query != 0
   end

--- a/app/views/editor/questionRich.html.erb
+++ b/app/views/editor/questionRich.html.erb
@@ -44,11 +44,11 @@
         <br />
         <div>
           <input class="form-control input-lg" type="text" placeholder="What's your question? Be specific." value="<%= if @node then @node.title else params[:title] end %>" />
-        </div>    
+        </div>
 
-      </div>    
+      </div>
 
-    </div>    
+    </div>
     <!-- end title module -->
 
     <!-- body module -->
@@ -108,7 +108,7 @@
       </div>
 
     </div>
-      
+
   </div>
 </div>
 
@@ -164,8 +164,8 @@
       titleModule: {
         suggestRelated: true,
         fetchRelated: function(show) {
-          $.getJSON("/api/srch/notes?srchString=" + editor.titleModule.value(), function(response) {
-            /* API provides: 
+          $.getJSON("/api/srch/notes?query=" + editor.titleModule.value(), function(response) {
+            /* API provides:
             {"items":[{
               "docId":14022,
               "docType":"file",

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -255,7 +255,7 @@
       titleModule: {
         suggestRelated: true,
         fetchRelated: function(show) {
-          $.getJSON("/api/srch/notes?srchString=" + editor.titleModule.value(), function(response) {
+          $.getJSON("/api/srch/notes?query=" + editor.titleModule.value(), function(response) {
             /* API provides:
             {"items":[{
               "docId":14022,

--- a/app/views/editor/wikiRich.html.erb
+++ b/app/views/editor/wikiRich.html.erb
@@ -213,7 +213,7 @@
       titleModule: {
         suggestRelated: true,
         fetchRelated: function(show) {
-          $.getJSON("/api/srch/notes?srchString=" + editor.titleModule.value(), function(response) {
+          $.getJSON("/api/srch/notes?query=" + editor.titleModule.value(), function(response) {
             /* API provides:
             {"items":[{
               "docId":14022,

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -15,28 +15,28 @@
   <div class="leaflet-map" id="map<%= unique_id %>"></div>
   <% if defined? people %><p><i><small>Share your own location on <a href='/profile'>your profile</a>.</small></i></p><% end %>
   <script>
-   
+
     var bounds = new L.LatLngBounds(new L.LatLng(84.67351257 , -172.96875) , new L.LatLng(-54.36775852 , 178.59375)) ;
-  
+
     var map<%= unique_id %> = L.map('map<%= unique_id %>' , {
-      maxBounds: bounds , 
+      maxBounds: bounds ,
       maxBoundsViscosity: 0.75
     }).on('load', onMapLoad).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
 
     var map_lat = <%= lat %> ;
-    var map_lon = <%= lon %> ; 
+    var map_lon = <%= lon %> ;
 
-    setupFullScreen(map<%= unique_id %>  , map_lat , map_lon) ; 
+    setupFullScreen(map<%= unique_id %>  , map_lat , map_lon) ;
     setupLEL(map<%= unique_id %> ) ;
-    // var hash = new L.Hash(map< unique_id > );  
-    
+    // var hash = new L.Hash(map< unique_id > );
+
     function onMapLoad(e){
       var lat = <%= lat %> ;
       var lon = <%= lon %> ;
       var s = lat+","+lon ;
-      $.getJSON("/api/srch/locations?srchString="+s , function(data){
+      $.getJSON("/api/srch/locations?query="+s , function(data){
         if (!!data.items){
-          for (i = 0; i < data.items.length ; i++) { 
+          for (i = 0; i < data.items.length ; i++) {
 	        var url = data.items[i].docUrl ;
 	        var title = data.items[i].docTitle ;
                 var default_url = PLmarker_default() ;
@@ -46,4 +46,3 @@
      });
     }
   </script>
-

--- a/app/views/map/_peopleLeaflet.html.erb
+++ b/app/views/map/_peopleLeaflet.html.erb
@@ -15,22 +15,22 @@
   		background: white ;
   	}*/
   </style>
-	
+
 <div onmouseover="document.body.style.overflow='hidden';"  onmouseout="document.body.style.overflow='auto';">
    <div class="leaflet-map" id="map<%= unique_id %>"></div>
  </div>
 	<% if defined? people %>
 		<p><i><small>
 			Share your own location on <a href='/profile'>your profile</a>.
-			Learn about <a href='https://publiclab.org/wiki/location-privacy'>privacy</a> 
+			Learn about <a href='https://publiclab.org/wiki/location-privacy'>privacy</a>
 		</small></i></p>
 	<% end %>
 
   <script>
-  
+
    var bounds = new L.LatLngBounds(new L.LatLng(84.67351257 , -172.96875) , new L.LatLng(-54.36775852 , 178.59375)) ;
    var map<%= unique_id %> = L.map('map<%= unique_id %>', {
-      maxBounds: bounds , 
+      maxBounds: bounds ,
       maxBoundsViscosity: 0.75
     }).on('load', onMapLoad).setView([<%= lat %>,<%= lon %>], 2);
    map<%= unique_id %>.options.minZoom = 2 ;
@@ -41,7 +41,7 @@
    //    layer: searchLayer< = unique_id >,  // name of the layer
    //    initial: false,
    //    minLength: 1,
-   //    textErr: 'Person not found' , 
+   //    textErr: 'Person not found' ,
    //    zoom: 7,        // set zoom to found location when searched
    //    marker: false,
    //    textPlaceholder: 'search people' // placeholder while nothing is searched
@@ -53,26 +53,26 @@
     })
     */
    function onMapLoad(e){
-     $.getJSON("/api/srch/peoplelocations?srchString=100&tagName=<%= @tagname_param %>" , function(data){
-     	var layerGroup = L.layerGroup() ; 
+     $.getJSON("/api/srch/peoplelocations?query=100&tag=<%= @tagname_param %>" , function(data){
+     	var layerGroup = L.layerGroup() ;
        if (!!data.items){
-         for (i = 0; i < data.items.length ; i++) { 
+         for (i = 0; i < data.items.length ; i++) {
 	 	       var default_markers = PLmarker_default() ;
 	 	       var url = data.items[i].docUrl ;
 	 	       var title = data.items[i].docTitle ;
 	   	     var m = L.marker([data.items[i].latitude , data.items[i].longitude], {title: title , icon: default_markers}).addTo(map<%= unique_id %>).bindPopup("<a href=" +  url + ">" + title + "</a>") ;
-   	 	      // searchLayer<%= unique_id %>.addLayer(m) ; 	
+   	 	      // searchLayer<%= unique_id %>.addLayer(m) ;
 	        }
         }
      });
     }
 
     var map_lat = <%= lat %> ;
-    var map_lon = <%= lon %> ; 
+    var map_lon = <%= lon %> ;
 
-    setupFullScreen(map<%= unique_id %>  , map_lat , map_lon) ; 
+    setupFullScreen(map<%= unique_id %>  , map_lat , map_lon) ;
     setupLEL(map<%= unique_id %> ) ;
-    var hash = new L.Hash(map<%= unique_id %> );  
-    
-    
+    var hash = new L.Hash(map<%= unique_id %> );
+
+
   </script>

--- a/doc/API.md
+++ b/doc/API.md
@@ -9,11 +9,11 @@ on the [web interface](https://publiclab.org/api/docs) and on the [json guide](h
 
 To add any additional parameter, you can add the `&` symbol followed by the field to the URL:
 
-`https://publiclab.org/api/srch/profiles?srchString=bob&limit=10`
+`https://publiclab.org/api/srch/profiles?query=bob&limit=10`
 
-where `limit` is an optional parameter.
+where `limit` is an optional parameter
 
-All the endpoints have the optional parameter `limit` where you can specify the number of results for your search. Below you have a description of the available endpoints.
+* Profiles: https://publiclab.org/api/srch/profiles?query=foo
 
 ### All (profiles, notes, tags, maps, etc.)
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -11,29 +11,29 @@ To add any additional parameter, you can add the `&` symbol followed by the fiel
 
 `https://publiclab.org/api/srch/profiles?query=bob&limit=10`
 
-where `limit` is an optional parameter
+where `limit` is an optional parameter.
 
-* Profiles: https://publiclab.org/api/srch/profiles?query=foo
+All the endpoints have the optional parameter `limit` (10 by default) where you can specify the number of results for your search. Below you have a description of the available endpoints.
 
 ### All (profiles, notes, tags, maps, etc.)
 
-* **URL**:  `https://publiclab.org/api/srch/all?srchString=bob`
+* **URL**:  `https://publiclab.org/api/srch/all?query=bob`
 
 * **URL Params** :
 
   **Required:**
 
-  `srchString=[string]`: search for notes, profiles, tags, questions and maps that match the query.
+  `query=[string]`: search for notes, profiles, tags, questions and maps that match the query.
 
 ### Profiles:
 
-* **URL**:  `https://publiclab.org/api/srch/profiles?srchString=bob`
+* **URL**:  `https://publiclab.org/api/srch/profiles?query=bob`
 
 * **URL Params** :
 
   **Required:**
 
-  `srchString=[string]`: search the profiles (users) that have the query on their `username` and `bio` profile info.
+  `query=[string]`: search the profiles (users) that have the query on their `username` and `bio` profile info.
 
   **Optional:**
 
@@ -47,65 +47,65 @@ where `limit` is an optional parameter
 
 ### Notes
 
-* **URL**:  `https://publiclab.org/api/srch/notes?srchString=wind`
+* **URL**:  `https://publiclab.org/api/srch/notes?query=wind`
 * **URL Params** :
 
  **Required:**
 
- `srchString=[string]`: search for notes that have the passed string on their content.
+ `query=[string]`: search for notes that have the passed string on their content.
 
 ### Wikis
 
- * **URL**:  `https://publiclab.org/api/srch/wikis?srchString=balloon`
+ * **URL**:  `https://publiclab.org/api/srch/wikis?query=balloon`
  * **URL Params** :
 
   **Required:**
 
-  `srchString=[string]`: search for wikis that have the passed string on their content.
+  `query=[string]`: search for wikis that have the passed string on their content.
 
 ### Questions
 
-* **URL**:  `https://publiclab.org/api/srch/questions?srchString=arduino`
+* **URL**:  `https://publiclab.org/api/srch/questions?query=arduino`
 * **URL Params** :
 
   **Required:**
 
-  `srchString=[string]`: search for notes that have the `question:srchString` on their tags list.
+  `query=[string]`: search for notes that have the `question:query` on their tags list.
 
 ### Tags
 
-* **URL**:  `https://publiclab.org/api/srch/tags?srchString=wind`
+* **URL**:  `https://publiclab.org/api/srch/tags?query=wind`
 * **URL Params** :
 
   **Required:**
 
-  `srchString=[string]`: search the notes that have the query on their tags list.
+  `query=[string]`: search the notes that have the query on their tags list.
 
 ### TagLocations:
 
-* **URL**:  `https://publiclab.org/api/srch/taglocations?srchString=18,-66`
+* **URL**:  `https://publiclab.org/api/srch/taglocations?query=18,-66`
 * **URL Params** :
 
   **Required:**
 
-  `srchString=[coordinates]`: search notes from users located near the query separated by `,`.
+  `query=[coordinates]`: search notes from users located near the query separated by `,`.
 
   **Optional:**
 
-  `tagName=[string]`: the search can be refined by passing a tag field.
+  `tag=[string]`: the search can be refined by passing a tag field.
 
 ### PeopleLocations
 
-* **URL**:  `https://publiclab.org/api/srch/peoplelocations?srchString=10`
+* **URL**:  `https://publiclab.org/api/srch/peoplelocations?query=10`
 * **URL Params** :
 
   **Required:**
 
-  `srchString=[integer]`: search the the users with most recent activity that have coordinates(lat and lon values) on their user tags.
+  `query=[integer]`: search the the users with most recent activity that have coordinates(lat and lon values) on their user tags.
 
   **Optional:**
 
-  `tagName=[string]`: the search can be refined by passing a tag field.
+  `tag=[string]`: the search can be refined by passing a tag field.
 
 ## API code
 
@@ -120,6 +120,8 @@ We also have 3 services that aim to maintain the code more easier to change/main
 * [SearchCriteria](https://github.com/publiclab/plots2/blob/master/app/services/search_criteria.rb): responsible to validate the params.
 
 * [SearchService](https://github.com/publiclab/plots2/blob/master/app/services/search_service.rb): responsible to perform the endpoints queries.
+
+We also have a [Planning Issue](https://github.com/publiclab/plots2/issues/3520) if you want to contribute to the API.
 
 ## Token based API for creating comment
 

--- a/test/functional/api/search_api_full_text_test.rb
+++ b/test/functional/api/search_api_full_text_test.rb
@@ -10,14 +10,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_all_functionality
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/all?srchString=Blog'
+    get '/api/srch/all?query=Blog'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'Blog',
+        query: 'Blog',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -34,14 +34,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_all_functionality_with_multiple_responses
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/all?srchString=question'
+    get '/api/srch/all?query=question'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'question',
+        query: 'question',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -54,14 +54,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_all_functionality_without_search_query
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/all?srchString'
+    get '/api/srch/all?query'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: nil,
+        query: nil,
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -74,14 +74,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_profiles_by_username_and_bio_without_order_by_and_default_sort_direction
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/profiles?srchString=steff'
+    get '/api/srch/profiles?query=steff'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'steff',
+        query: 'steff',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -100,14 +100,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_profiles_by_bio_without_order_by_and_default_sort_direction
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/profiles?srchString=ruby'
+    get '/api/srch/profiles?query=ruby'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'ruby',
+        query: 'ruby',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -122,14 +122,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_questions_functionality
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/questions?srchString=Question'
+    get '/api/srch/questions?query=Question'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'Question',
+        query: 'Question',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -146,14 +146,14 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
 
   def search_notes_functionality
     skip "full text search only works on mysql/mariadb" if ActiveRecord::Base.connection.adapter_name == 'sqlite3'
-    get '/api/srch/notes?srchString=Blog'
+    get '/api/srch/notes?query=Blog'
 
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'Blog',
+        query: 'Blog',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -9,13 +9,13 @@ class SearchApiTest < ActiveSupport::TestCase
 
    # search by username and returns users by id when order_by is not provided and sorted direction default DESC
    test 'search profiles by username without order_by and default sort_direction' do
-     get '/api/srch/profiles?srchString=steff&field=username'
+     get '/api/srch/profiles?query=steff&field=username'
      assert last_response.ok?
 
      # Expected search pattern
      pattern = {
        srchParams: {
-         srchString: 'steff',
+         query: 'steff',
          seq: nil,
        }.ignore_extra_keys!
      }.ignore_extra_keys!
@@ -34,13 +34,13 @@ class SearchApiTest < ActiveSupport::TestCase
 
    # search by username and returns users sorteded by recent activity and order direction default DESC
    test 'search recent profiles by username with sort_by=recent present' do
-     get '/api/srch/profiles?srchString=steff&field=username&sort_by=recent'
+     get '/api/srch/profiles?query=steff&field=username&sort_by=recent'
      assert last_response.ok?
 
      # Expected search pattern
      pattern = {
        srchParams: {
-         srchString: 'steff',
+         query: 'steff',
          seq: nil
        }.ignore_extra_keys!
      }.ignore_extra_keys!
@@ -58,13 +58,13 @@ class SearchApiTest < ActiveSupport::TestCase
 
    # search by username and returns users ordered by recent activity and sorted by ASC direction
    test 'search recent profiles by username with sort_by=recent present and order_direction ASC' do
-     get '/api/srch/profiles?srchString=steff&field=username&sort_by=recent&order_direction=ASC'
+     get '/api/srch/profiles?query=steff&field=username&sort_by=recent&order_direction=ASC'
      assert last_response.ok?
 
      # Expected search pattern
      pattern = {
        srchParams: {
-         srchString: 'steff',
+         query: 'steff',
          seq: nil
        }.ignore_extra_keys!
      }.ignore_extra_keys!
@@ -73,21 +73,21 @@ class SearchApiTest < ActiveSupport::TestCase
 
      json = JSON.parse(last_response.body)
 
-     assert_equal "/profile/steff2",     json['items'][0]['doc_url']
+     assert_equal "/profile/steff1",     json['items'][0]['doc_url']
      assert_equal "/profile/steff3",     json['items'][1]['doc_url']
-     assert_equal "/profile/steff1",     json['items'][2]['doc_url']
+     assert_equal "/profile/steff2",     json['items'][2]['doc_url']
 
      assert matcher =~ json
   end
 
   test 'search tags functionality' do
-    get '/api/srch/tags?srchString=Awesome'
+    get '/api/srch/tags?query=Awesome'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
       srchParams: {
-        srchString: 'Awesome',
+        query: 'Awesome',
         seq: nil,
       }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -99,14 +99,14 @@ class SearchApiTest < ActiveSupport::TestCase
   end
 
   test 'search Tag Nearby Nodes functionality' do
-    get '/api/srch/taglocations?srchString=71.00,52.00&tagName=awesome'
+    get '/api/srch/taglocations?query=71.00,52.00&tag=awesome'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
-            srchString: '71.00,52.00',
-            tagName: 'awesome',
+            query: '71.00,52.00',
+            tag: 'awesome',
             seq: nil,
         }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -120,13 +120,13 @@ class SearchApiTest < ActiveSupport::TestCase
   end
 
   test 'search Recent People functionality' do
-    get '/api/srch/peoplelocations?srchString=100'
+    get '/api/srch/peoplelocations?query=100'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
-            srchString: '100',
+            query: '100',
             seq: nil,
         }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -144,14 +144,14 @@ class SearchApiTest < ActiveSupport::TestCase
   end
 
   test 'search recent people functionality having specified tagName' do
-    get '/api/srch/peoplelocations?srchString=100&tagName=tool:barometer'
+    get '/api/srch/peoplelocations?query=100&tag=tool:barometer'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
-            srchString: '100',
-            tagName: 'tool:barometer',
+            query: '100',
+            tag: 'tool:barometer',
             seq: nil,
         }.ignore_extra_keys!
     }.ignore_extra_keys!

--- a/test/unit/api/search_service_full_text_search_test.rb
+++ b/test/unit/api/search_service_full_text_search_test.rb
@@ -8,8 +8,8 @@ class SearchServiceFullTextSearchTest < ActiveSupport::TestCase
 
     users = [users(:data), users(:steff3), users(:steff2), users(:steff1)]
 
-    params = { srchString: 'steff' }
-    search_criteria = SearchCriteria.from_params(params)
+    params = { query: 'steff' }
+    search_criteria = SearchCriteria.new(params)
 
     result = SearchService.new.search_profiles(search_criteria)
 

--- a/test/unit/api/search_service_test.rb
+++ b/test/unit/api/search_service_test.rb
@@ -5,8 +5,8 @@ class SearchServiceTest < ActiveSupport::TestCase
   test 'running profiles for specific username' do
     users = [users(:steff1)]
 
-    params = { srchString: 'steff1' }
-    search_criteria = SearchCriteria.from_params(params)
+    params = { query: 'steff1' }
+    search_criteria = SearchCriteria.new(params)
 
     result = SearchService.new.search_profiles(search_criteria)
 
@@ -17,8 +17,8 @@ class SearchServiceTest < ActiveSupport::TestCase
   test 'running profiles by username' do
     users = [users(:steff3), users(:steff2), users(:steff1)]
 
-    params = { srchString: 'steff', field: 'username' }
-    search_criteria = SearchCriteria.from_params(params)
+    params = { query: 'steff', field: 'username' }
+    search_criteria = SearchCriteria.new(params)
 
     result = SearchService.new.search_profiles(search_criteria)
 
@@ -34,8 +34,8 @@ class SearchServiceTest < ActiveSupport::TestCase
   end
 
   test 'running search notes' do
-    params = { srchString: 'Blog' }
-    search_criteria = SearchCriteria.from_params(params)
+    params = {query: 'Blog' }
+    search_criteria = SearchCriteria.new(params)
 
     result = SearchService.new.search_notes(search_criteria.query)
 


### PR DESCRIPTION
After writing the #3508 API docs yesterday, we noticed that we could rename some params from the API so they use the Ruby naming convention. And also, `srchString` was not a good name because some params aren't a string and that could lead to some confusion in the future.

We searched through the whole app to change the API calls. But we were wondering if other repositories also use the API? @jywarren 