### PR TITLE
change doc variables after changing DocResult params to snake case

### DIFF
--- a/app/assets/javascripts/atwho_autocomplete.js
+++ b/app/assets/javascripts/atwho_autocomplete.js
@@ -6,7 +6,7 @@
       remoteFilter: function(query, callback) {
         $.getJSON("/api/srch/profiles?query=" + query + "&sort_by=recent&field=username", {}, function(data) {
           if (data.hasOwnProperty('items') && data.items.length > 0) {
-            callback(data.items.map(function(i) { return i.docTitle }));
+            callback(data.items.map(function(i) { return i.doc_title }));
           }
          });
         }

--- a/app/views/editor/questionRich.html.erb
+++ b/app/views/editor/questionRich.html.erb
@@ -167,11 +167,10 @@
           $.getJSON("/api/srch/notes?query=" + editor.titleModule.value(), function(response) {
             /* API provides:
             {"items":[{
-              "docId":14022,
-              "docType":"file",
-              "docUrl":"/notes/liz/03-15-2017/host-a-balloon-mapping-workshop",
-              "docTitle":"Host a balloon mapping workshop",
-              "docSummary":"...",
+              "doc_id":14022,
+              "doc_type":"file",
+              "doc_url":"/notes/liz/03-15-2017/host-a-balloon-mapping-workshop",
+              "doc_title":"Host a balloon mapping workshop",
               "docScore":0}
             ]}
             */
@@ -180,10 +179,10 @@
             if (response['items']) {
               response['items'].forEach(function(item) {
                 var formattedItem = {};
-                formattedItem.id = item.docId;
-                formattedItem.title = item.docTitle;
-                formattedItem.url = item.docUrl;
-                formattedItem.author = item.docUrl.split('/')[2];
+                formattedItem.id = item.doc_id;
+                formattedItem.title = item.doc_title;
+                formattedItem.url = item.doc_url;
+                formattedItem.author = item.doc_url.split('/')[2];
                 formatted.push(formattedItem);
               });
               show(formatted);

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -258,12 +258,11 @@
           $.getJSON("/api/srch/notes?query=" + editor.titleModule.value(), function(response) {
             /* API provides:
             {"items":[{
-              "docId":14022,
-              "docType":"file",
-              "docUrl":"/notes/liz/03-15-2017/host-a-balloon-mapping-workshop",
-              "docTitle":"Host a balloon mapping workshop",
-              "docSummary":"...",
-              "docScore":0}
+              "doc_id":14022,
+              "doc_type":"file",
+              "doc_url":"/notes/liz/03-15-2017/host-a-balloon-mapping-workshop",
+              "doc_title":"Host a balloon mapping workshop",
+              "doc_score":0}
             ]}
             */
             // But we need: [{ id: 1, title: 'A related post',       url: '/', author: 'eustatic'}, ... ]
@@ -271,10 +270,10 @@
             if (response['items']) {
               response['items'].forEach(function(item) {
                 var formattedItem = {};
-                formattedItem.id = item.docId;
-                formattedItem.title = item.docTitle;
-                formattedItem.url = item.docUrl;
-                formattedItem.author = item.docUrl.split('/')[2];
+                formattedItem.id = item.doc_id;
+                formattedItem.title = item.doc_title;
+                formattedItem.url = item.doc_url;
+                formattedItem.author = item.doc_url.split('/')[2];
                 formatted.push(formattedItem);
               });
               show(formatted);

--- a/app/views/editor/wikiRich.html.erb
+++ b/app/views/editor/wikiRich.html.erb
@@ -216,12 +216,11 @@
           $.getJSON("/api/srch/notes?query=" + editor.titleModule.value(), function(response) {
             /* API provides:
             {"items":[{
-              "docId":14022,
-              "docType":"file",
-              "docUrl":"/notes/liz/03-15-2017/host-a-balloon-mapping-workshop",
-              "docTitle":"Host a balloon mapping workshop",
-              "docSummary":"...",
-              "docScore":0}
+              "doc_id":14022,
+              "doc_type":"file",
+              "doc_url":"/notes/liz/03-15-2017/host-a-balloon-mapping-workshop",
+              "doc_title":"Host a balloon mapping workshop",
+              "doc_score":0}
             ]}
             */
             // But we need: [{ id: 1, title: 'A related post',       url: '/', author: 'eustatic'}, ... ]
@@ -229,10 +228,10 @@
             if (response['items']) {
               response['items'].forEach(function(item) {
                 var formattedItem = {};
-                formattedItem.id = item.docId;
-                formattedItem.title = item.docTitle;
-                formattedItem.url = item.docUrl;
-                formattedItem.author = item.docUrl.split('/')[2];
+                formattedItem.id = item.doc_id;
+                formattedItem.title = item.doc_title;
+                formattedItem.url = item.doc_url;
+                formattedItem.author = item.doc_url.split('/')[2];
                 formatted.push(formattedItem);
               });
               show(formatted);

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -37,11 +37,11 @@
       $.getJSON("/api/srch/locations?query="+s , function(data){
         if (!!data.items){
           for (i = 0; i < data.items.length ; i++) {
-	        var url = data.items[i].docUrl ;
-	        var title = data.items[i].docTitle ;
-                var default_url = PLmarker_default() ;
-    	        L.marker([data.items[i].latitude , data.items[i].longitude] , {icon: default_url}).addTo(map<%= unique_id %>).bindPopup("<a href=" +  url + ">" + title + "</a>") ;
-	    }
+            var url = data.items[i].doc_url ;
+            var title = data.items[i].doc_title ;
+            var default_url = PLmarker_default() ;
+            L.marker([data.items[i].latitude , data.items[i].longitude] , {icon: default_url}).addTo(map<%= unique_id %>).bindPopup("<a href=" +  url + ">" + title + "</a>") ;
+	        }
        }
      });
     }

--- a/app/views/map/_peopleLeaflet.html.erb
+++ b/app/views/map/_peopleLeaflet.html.erb
@@ -57,10 +57,10 @@
      	var layerGroup = L.layerGroup() ;
        if (!!data.items){
          for (i = 0; i < data.items.length ; i++) {
-	 	       var default_markers = PLmarker_default() ;
-	 	       var url = data.items[i].docUrl ;
-	 	       var title = data.items[i].docTitle ;
-	   	     var m = L.marker([data.items[i].latitude , data.items[i].longitude], {title: title , icon: default_markers}).addTo(map<%= unique_id %>).bindPopup("<a href=" +  url + ">" + title + "</a>") ;
+           var default_markers = PLmarker_default() ;
+           var url = data.items[i].doc_url ;
+           var title = data.items[i].doc_title ;
+           var m = L.marker([data.items[i].latitude , data.items[i].longitude], {title: title , icon: default_markers}).addTo(map<%= unique_id %>).bindPopup("<a href=" +  url + ">" + title + "</a>") ;
    	 	      // searchLayer<%= unique_id %>.addLayer(m) ;
 	        }
         }

--- a/test/functional/api/search_api_full_text_test.rb
+++ b/test/functional/api/search_api_full_text_test.rb
@@ -137,8 +137,8 @@ class SearchApiFullTextTest < ActiveSupport::TestCase
     matcher = JsonExpressions::Matcher.new(pattern)
     json = JSON.parse(last_response.body)
 
-    assert_equal "How to use a Spectrometer", json['items'][0]['docTitle']
-    assert_equal 8,                             json['items'][0]['docId']
+    assert_equal "How to use a Spectrometer",   json['items'][0]['doc_title']
+    assert_equal 8,                             json['items'][0]['doc_id']
 
     assert matcher =~ json
 


### PR DESCRIPTION
I found some code on the project that was still using the old DocResult camelcase variables naming (#3357). Now I searched on plots2 for every place that used that and renamed them.