### PR TITLE
Update docs and add tests for the taglocations API method - fix #3597

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -243,7 +243,8 @@ module Srch
               doc_title: model.title,
               score: model.answers.length,
               latitude: model.lat,
-              longitude: model.lon
+              longitude: model.lon,
+              blurred: model.blurred?
             )
           end
           DocList.new(docs, search_request)

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -244,7 +244,7 @@ module Srch
               score: model.answers.length,
               latitude: model.lat,
               longitude: model.lon,
-              blurred: model.blurred?
+              blurred: false
             )
           end
           DocList.new(docs, search_request)

--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -243,8 +243,7 @@ module Srch
               doc_title: model.title,
               score: model.answers.length,
               latitude: model.lat,
-              longitude: model.lon,
-              blurred: false
+              longitude: model.lon
             )
           end
           DocList.new(docs, search_request)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -534,6 +534,10 @@ class Node < ActiveRecord::Base
     drupal_content_type_map.last
   end
 
+  def blurred?
+    has_power_tag('location') && power_tag('location') == "blurred"
+  end
+
   def lat
     if has_power_tag('lat')
       power_tag('lat').to_f

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -197,7 +197,7 @@ class User < ActiveRecord::Base
 
   def get_value_of_power_tag(key)
     tname = user_tags.where('value LIKE ?', key + ':%')
-    tvalue = tname.first.name.partition(':').last
+    tvalue = tname.first.name.partition(':').last if tname.present?
     tvalue
   end
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -82,11 +82,13 @@ class SearchService
   end
 
   # Search nearby nodes with respect to given latitude, longitute and tags
-  # and package up as a DocResult
   def tagNearbyNodes(query, tag, limit = 10)
     raise("Must separate coordinates with ,") unless query.include? ","
 
     lat, lon =  query.split(',')
+
+    raise("Must have at least one digit after .") unless lat.include? "."
+    raise("Must have at least one digit after .") unless lon.include? "."
 
     nodes_scope = NodeTag.joins(:tag)
       .where('name LIKE ?', 'lat:' + lat[0..lat.length - 2] + '%')
@@ -102,8 +104,8 @@ class SearchService
     items = Node.includes(:tag)
       .references(:node, :term_data)
       .where('node.nid IN (?) AND term_data.name LIKE ?', nids, 'lon:' + lon[0..lon.length - 2] + '%')
-      .limit(limit)
       .order('node.nid DESC')
+      .limit(limit)
 
     # selects the items whose node_tags don't have the location:blurred tag
     items.select do |item|
@@ -130,7 +132,6 @@ class SearchService
                        .where('user_tags.value LIKE ?', user_tag)\
                        .where(id: user_locations.select("rusers.id"))
     end
-
     user_locations.limit(query)
   end
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -83,12 +83,14 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
 ### TagLocations:
 
-* **URL**:  `https://publiclab.org/api/srch/taglocations?query=18,-66`
+* **URL**:  `https://publiclab.org/api/srch/taglocations?query=18.00,-66.00`
 * **URL Params** :
 
   **Required:**
 
-  `query=[coordinates]`: search notes from users located near the query separated by `,`.
+  `query=[coordinates]`: search notes from users located near the query separated by `,`
+  and with at least one digit after the '.'. Taking a lat value as example, `lat:18.0`
+  or `lat:18.00` are valid but `lat:18` is not.
 
   **Optional:**
 

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -98,15 +98,14 @@ class SearchApiTest < ActiveSupport::TestCase
     assert matcher =~ json
   end
 
-  test 'search Tag Nearby Nodes functionality' do
-    get '/api/srch/taglocations?query=71.00,52.00&tag=awesome'
+  test 'search Tag Nearby Nodes functionality with a valid query' do
+    get '/api/srch/taglocations?query=71.00,52.00'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
             query: '71.00,52.00',
-            tag: 'awesome',
             seq: nil,
         }.ignore_extra_keys!
     }.ignore_extra_keys!
@@ -115,8 +114,8 @@ class SearchApiTest < ActiveSupport::TestCase
 
     json = JSON.parse(last_response.body)
 
-    assert matcher =~ json
-
+    assert matcher    =~ json
+    assert_equal 13,  json['items'][0]['doc_id']
   end
 
   test 'search Recent People functionality' do

--- a/test/unit/api/search_service_test.rb
+++ b/test/unit/api/search_service_test.rb
@@ -58,4 +58,28 @@ class SearchServiceTest < ActiveSupport::TestCase
     assert_not_nil result
     assert_equal result.size, 3
   end
+
+  test 'running search taglocations with a wrong param format raises an exception' do
+    exception = assert_raises(Exception) { SearchService.new.tagNearbyNodes('30:40', nil) }
+    assert_equal( "Must separate coordinates with ,", exception.message )
+  end
+
+  test 'running search taglocations with invalid params' do
+    exception_1 = assert_raises(Exception) { SearchService.new.tagNearbyNodes('43,71', nil) }
+    exception_2 = assert_raises(Exception) { SearchService.new.tagNearbyNodes('4,7', nil) }
+
+    assert_equal( "Must have at least one digit after .", exception_1.message )
+    assert_equal( "Must have at least one digit after .", exception_2.message )
+  end
+
+  test 'running search taglocations with valid params' do
+    result_1 = SearchService.new.tagNearbyNodes('71.00,52.00', nil)
+    result_2 = SearchService.new.tagNearbyNodes('71.0,52.0', nil)
+
+    assert_not_nil result_1
+    assert_not_nil result_2
+
+    assert_equal result_1.size, 1
+    assert_equal result_2.size, 1
+  end
 end


### PR DESCRIPTION
Fixes #3597

The API docs were showing a wrong param format for the `taglocations` endpoint. After investigating, I believe these changes attempt to fix that.