### PR TITLE
Search API: new endpoint /srch/nearbyPeople

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -253,6 +253,36 @@ module Srch
         end
       end
 
+      # Request URL should be /api/srch/nearbyPeople?query=QRY[&tag=awesome]
+      # Note: Query(QRY as above) must have latitude and longitude as query=lat,lon
+      desc 'Perform a search to show people nearby a given location',  hidden: false,
+                                                                       is_array: false,
+                                                                       nickname: 'search_nearby_people'
+      params do
+        use :common, :additional
+      end
+      get :nearbyPeople do
+        search_request = SearchRequest.fromRequest(params)
+        results = Search.execute(:nearbyPeople, params)
+
+        if results.present?
+          docs = results.map do |model|
+            DocResult.new(
+              doc_id: model.id,
+              doc_type: 'PLACES',
+              doc_url: model.path,
+              doc_title: model.username,
+              latitude: model.lat,
+              longitude: model.lon,
+              blurred: model.blurred?
+            )
+          end
+          DocList.new(docs, search_request)
+        else
+          DocList.new('', search_request)
+        end
+      end
+
       # API TO FETCH QRY RECENT CONTRIBUTORS
       # Request URL should be /api/srch/peoplelocations?query=QRY[&tag=group:partsandcrafts]
       # QRY should be a number

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -23,7 +23,9 @@ class ExecuteSearch
      when :peoplelocations
        sservice.people_locations(search_criteria.query, search_criteria.tag)
      when :taglocations
-       sservice.tagNearbyNodes(search_criteria.query, search_criteria.tag)
+       sservice.tagNearbyNodes(search_criteria.query, search_criteria.tag, search_criteria.limit)
+     when :nearbyPeople
+       sservice.tagNearbyPeople(search_criteria.query, search_criteria.tag, search_criteria.limit)
      else
        sresult = []
      end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -133,7 +133,16 @@ class SearchService
     ids = user_locations.collect(&:id).uniq || []
 
     items = User.where('rusers.status <> 0').joins(:user_tags)
-                .where('rusers.id IN (?) AND value LIKE ?', ids, 'lon:' + lon[0..lon.length - 2] + '%').limit(limit)
+                .where('rusers.id IN (?) AND value LIKE ?', ids, 'lon:' + lon[0..lon.length - 2] + '%')
+    
+    # selects the items whose node_tags don't have the location:blurred tag
+    items.select do |item|
+      item.user_tags.none? do |user_tag|
+        user_tag.name == "location:blurred"
+      end
+    end
+      
+    items = items.limit(limit)
   end
 
   # Returns the location of people with most recent contributions.

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -133,16 +133,7 @@ class SearchService
     ids = user_locations.collect(&:id).uniq || []
 
     items = User.where('rusers.status <> 0').joins(:user_tags)
-                .where('rusers.id IN (?) AND value LIKE ?', ids, 'lon:' + lon[0..lon.length - 2] + '%')
-
-    # selects the items whose node_tags don't have the location:blurred tag
-    items.select do |item|
-      item.user_tags.none? do |user_tag|
-        user_tag.name == "location:blurred"
-      end
-
-      user_locations.limit(limit)
-    end
+                .where('rusers.id IN (?) AND value LIKE ?', ids, 'lon:' + lon[0..lon.length - 2] + '%').limit(limit)
   end
 
   # Returns the location of people with most recent contributions.

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -113,6 +113,38 @@ class SearchService
     end
   end
 
+  # Search nearby people with respect to given latitude, longitute and tags
+  # and package up as a DocResult
+  def tagNearbyPeople(query, tag, limit = 10)
+    raise("Must separate coordinates with ,") unless query.include? ","
+
+    lat, lon =  query.split(',')
+
+    user_locations = User.where('rusers.status <> 0')\
+                         .joins(:user_tags)\
+                         .where('value LIKE ?', 'lat:' + lat[0..lat.length - 2] + '%')\
+                         .distinct
+    if tag.present?
+      user_locations = User.joins(:user_tags)\
+                       .where('user_tags.value LIKE ?', tag)\
+                       .where(id: user_locations.select("rusers.id"))
+    end
+
+    ids = user_locations.collect(&:id).uniq || []
+
+    items = User.where('rusers.status <> 0').joins(:user_tags)
+                .where('rusers.id IN (?) AND value LIKE ?', ids, 'lon:' + lon[0..lon.length - 2] + '%')
+
+    # selects the items whose node_tags don't have the location:blurred tag
+    items.select do |item|
+      item.user_tags.none? do |user_tag|
+        user_tag.name == "location:blurred"
+      end
+
+      user_locations.limit(limit)
+    end
+  end
+
   # Returns the location of people with most recent contributions.
   # The method receives as parameter the number of results to be
   # returned and as optional parameter a user tag. If the user tag


### PR DESCRIPTION
As discussed here ([Question: What more data-layers can we show on map?](https://publiclab.org/questions/sagarpreet/07-01-2018/what-more-data-layers-can-we-show-on-map)) I implemented a new method to search nearby people with respect to given latitude, longitute and tag (optional). 

I'm not filtering by most recent users... That would make things a little bit more complicated! Do you think the way it is now this endpoint would be useful? Do you have suggestions?

@jywarren @stefannibrasil @sagarpreet-chadha @steviepubliclab (I hope I've mentioned the right people here! Usernames are different...)