### PR TITLE
/api/srch/profiles: search by user tag 

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -88,7 +88,7 @@ module Srch
                                            nickname: 'search_profiles'
 
       params do
-        use :common, :sorting, :ordering, :field
+        use :common, :sorting, :ordering, :field, :additional
       end
       get :profiles do
         search_request = SearchRequest.fromRequest(params)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -30,7 +30,7 @@ class SearchService
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
   def search_profiles(search_criteria)
-    user_scope = find_users(search_criteria.query, search_criteria.limit, search_criteria.field)
+    user_scope = find_users(search_criteria.query, search_criteria.limit, search_criteria.field, search_criteria.tag)
 
     user_scope =
       if search_criteria.sort_by == "recent"
@@ -134,14 +134,14 @@ class SearchService
 
     items = User.where('rusers.status <> 0').joins(:user_tags)
                 .where('rusers.id IN (?) AND value LIKE ?', ids, 'lon:' + lon[0..lon.length - 2] + '%')
-    
+
     # selects the items whose node_tags don't have the location:blurred tag
     items.select do |item|
       item.user_tags.none? do |user_tag|
         user_tag.name == "location:blurred"
       end
     end
-      
+
     items = items.limit(limit)
   end
 
@@ -166,13 +166,20 @@ class SearchService
     user_locations.limit(query)
   end
 
-  def find_users(query, limit, type = nil)
+  def find_users(query, limit, type = nil, user_tag = nil)
     users =
       if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
         type == "username" ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
       else
         User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
       end
+
+    if user_tag.present?
+      users = User.joins(:user_tags)\
+                           .where('user_tags.value LIKE ?', user_tag)\
+                           .where(id: users.select("rusers.id"))
+    end
+
     users = users.limit(limit)
   end
 end

--- a/doc/API.md
+++ b/doc/API.md
@@ -45,6 +45,8 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
   `field=[string]`: Accepts the value `username` for searching profiles only by
    the field `username`.
 
+   `tag=[string]`: The search can be refined by passing a tag field.
+
 ### Notes
 
 * **URL**:  `https://publiclab.org/api/srch/notes?query=wind`


### PR DESCRIPTION
Fixes #3506 

/api/srch/profiles: Adding the option to search for user tags.

`/api/srch/profiles?query=[user_name]&tag=[tag_name]`


