### PR TITLE
Fix error alert on empty comment body

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -40,7 +40,10 @@ class CommentController < ApplicationController
       end
     rescue CommentError
       flash[:error] = 'The comment could not be saved.'
-      render plain: 'failure'
+      render(
+        html: "<script>alert('Faliure! The comment could not be saved.')</script>".html_safe,
+        layout: 'application'
+        )
     end
   end
 

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -43,7 +43,7 @@ class CommentController < ApplicationController
       render(
         html: "<script>alert('Faliure! The comment could not be saved.')</script>".html_safe,
         layout: 'application'
-        )
+      )
     end
   end
 


### PR DESCRIPTION
Updated error strings which add up on clicking Publish button to error alert.

![error alert](https://user-images.githubusercontent.com/36580419/47621664-253da200-db21-11e8-8125-7bc72ca9d560.png)


Fixes #3657 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
