### PR TITLE
Fixed Show more of table

### DIFF
--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -53,9 +53,9 @@
     <% end %>
   </tr>
 <% end %>
-<% if nodes.count > 9 %>
+<% if nodes.count > 10 %>
     <tfoot>
-      <th class="show-all"><a>Show <%= nodes.length - 10 %> more <b class="caret"></b></a></th>
+      <th class="show-all" id="notes-table-footer"><a>Show <%= nodes.length - 10 %> more <b class="caret"></b></a></th>
       <th></th>
       <th></th>
       <th></th>
@@ -76,6 +76,7 @@
 (function(){
   $(".<%= className %>-<%= randomSeed %> .show-all a").click(function() {
     $(".<%= className %>-<%= randomSeed %> tr.hide").toggleClass("hide");
+    $("#notes-table-footer")[0].innerHTML="";
   });
   $(".grid-embed-<%= randomSeed %>").click(function() {
     prompt('Use this HTML code to embed this table on another site.', '<iframe style="border:none;" width="100%" height="900px" src="//publiclab.org/embed/grid/<% if type != "notes" %><%= type.gsub('questions', 'question').gsub('activities', 'activity') %>:<% end %><%= tagname %>"></iframe>')


### PR DESCRIPTION
Fixes  #3654 

Problem:
There were some problems in the show more button on the learn more page of infragram.

1. Let's say that there were 10 more items to be viewed in the  table, the show more button said "Show 10 more items". Now,even after the user has clicked that once, it said the same text "Show 10 more items", which may confuse the user.

2.If there were exact 10 items  in the table then the show more button said "Show 0 more items" which doesn't make much sense.

Changes Proposed:
1. Once the user clicks the button the text vanishes.
2. Also the button is displayed only in case there are strictly more than 10 items in the table. This fixes the second problem.

Since views were changed, the relevant screen shots are attached. 


![before_clicking](https://user-images.githubusercontent.com/18489285/47795276-4c29ed00-dd48-11e8-897a-42bbd4b1cfaa.png)
![after_clicking](https://user-images.githubusercontent.com/18489285/47795304-55b35500-dd48-11e8-8488-a6e4056726e1.png)
