### PR TITLE
Reduce worker process count

### DIFF
--- a/containers/docker-compose-production.yml
+++ b/containers/docker-compose-production.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - "127.0.0.1:4001:4001"
     build: ..
-    command: /bin/bash -c "sleep 5 && /usr/local/bundle/bin/passenger start --max-request-queue-size 200 --max-pool-size 8 --min-instances 8 -p 4001"
+    command: /bin/bash -c "sleep 5 && /usr/local/bundle/bin/passenger start --max-request-queue-size 200 --max-pool-size 7 --min-instances 7 -p 4001"
     environment:
       - RAILS_ENV=${RAILS_ENV}
       - SECRET_KEY_BASE=${SECRET_KEY_BASE}


### PR DESCRIPTION
To reduce memory footprint. Our calculations for tweaking this in production didn't take into account Mailman and Sidekick so reducing by one process. We've recently experienced Memory exhaustion when doing backups, apparently.

Fixes #0000 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
