### PR TITLE
Fix hidden likes column of wiki pages for narrower displays

### DIFF
--- a/app/views/wiki/_wikis.html.erb
+++ b/app/views/wiki/_wikis.html.erb
@@ -14,7 +14,7 @@
       <td><%= distance_of_time_in_words(Time.at(wiki.latest.created_at), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %> <%= raw t('wiki._wikis.by') %>
       <a href="/profile/<%= wiki.latest.author.name %>"><%= wiki.latest.author.name %></a></td>
       <td><%= wiki.revisions.length %></td>
-      <td class="hidden-xs"><%= number_with_delimiter(wiki.totalviews) %></td>
+      <td><%= number_with_delimiter(wiki.totalviews) %></td>
       <td><%= number_with_delimiter(wiki.cached_likes) %></td>
     </tr>
   <% end %>


### PR DESCRIPTION
Removes the "hidden-xs" class of line 17 to show the number of likes per page on mobile devices with narrower displays.

Fixes #3617 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [✔️] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [✔️] code is in uniquely-named feature branch and has no merge conflicts
* [✔️] PR is descriptively titled
* [✔️] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
