### PR TITLE
Add a link to the Comment Templates page from the tagging menu

### DIFF
--- a/app/views/tag/_advanced_tagging.html.erb
+++ b/app/views/tag/_advanced_tagging.html.erb
@@ -17,6 +17,7 @@
     <li><a href="#" data-value="with:">Add Coauthor (notes only)</a></li>
     <li><a href="#" data-value="series:">Mark as part of a series</a></li>
     <li><a href="#" data-value="comment-template:">Add template to the comment form</a></li>
+    <li><a target="_blank" href="/wiki/comment-templates">Write a template for the comment form</a></li>
   <% end %>
   <li role="separator" class="divider"></li>
   <li><a href="https://publiclab.org/power-tags" target="_blank">Learn About Powertags</a></li>


### PR DESCRIPTION
Original issue: Add a link to the Comment Templates page from the tagging menu

Fixes for #3923



Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
