### PR TITLE
Added insert_extra() properly into comments so they show inline shortcuts[resolves 3978]

### DIFF
--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -118,7 +118,7 @@
   <div style="border: 1px solid #e7e7e7;padding: 18px;" id="c<%= comment.cid %>show">
 
     <% comment_body = comment.render_body %>
-    <p id="comment-body-<%= comment.cid %>"><%= raw filtered_comment_body(comment_body) %></p>
+    <p id="comment-body-<%= comment.cid %>"><%= raw insert_extras(comment_body) %></p>
 
     <% if contain_trimmed_body?(comment_body) %>
       <span style="background-color: #DCDCDC;  border-radius: 7px; cursor: pointer;" ><a class="email-toggle" data-toggle="collapse" data-target="#comment-<%= comment.cid %>-extra-content" style='text-decoration: none;'>&nbsp;&ensp;&#x2022&#x2022&#x2022&nbsp;&ensp;</a></span>

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -118,7 +118,7 @@
   <div style="border: 1px solid #e7e7e7;padding: 18px;" id="c<%= comment.cid %>show">
 
     <% comment_body = comment.render_body %>
-    <p id="comment-body-<%= comment.cid %>"><%= raw insert_extras(comment_body) %></p>
+    <p id="comment-body-<%= comment.cid %>"><%= raw insert_extras(filtered_comment_body(comment_body)) %></p>
 
     <% if contain_trimmed_body?(comment_body) %>
       <span style="background-color: #DCDCDC;  border-radius: 7px; cursor: pointer;" ><a class="email-toggle" data-toggle="collapse" data-target="#comment-<%= comment.cid %>-extra-content" style='text-decoration: none;'>&nbsp;&ensp;&#x2022&#x2022&#x2022&nbsp;&ensp;</a></span>


### PR DESCRIPTION
Fixes #3978

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
[✔️] code is in uniquely-named feature branch and has no merge conflicts
[✔️] PR is descriptively titled
[✔️ ] ask `@publiclab/reviewers` for help, in a comment below

Replaced `filtered_comment_body` with `insert_extras` and now inline shortcuts like `notes:topic_tag` written in the comment will display a table of links.