### PR TITLE
removed auto-added aesterisk in boolean search

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -35,15 +35,15 @@ class Node < ActiveRecord::Base
 
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
       if order == :natural
+        query = connection.quote(query.to_s)
         if type == :boolean
-          query = connection.quote(query.to_s + "*")
+          # Query is done as a boolean full-text search. More info here: https://dev.mysql.com/doc/refman/5.5/en/fulltext-boolean.html
           nids = Revision.select("node_revisions.nid, node_revisions.body, node_revisions.title, MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN BOOLEAN MODE) AS score")
             .where("MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN BOOLEAN MODE)")
             .limit(limit)
             .distinct
             .collect(&:nid)
         else
-          query = connection.quote(query.to_s)
           nids = Revision.select("node_revisions.nid, node_revisions.body, node_revisions.title, MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN NATURAL LANGUAGE MODE) AS score")
             .where("MATCH(node_revisions.body, node_revisions.title) AGAINST(#{query} IN NATURAL LANGUAGE MODE)")
             .limit(limit)


### PR DESCRIPTION
Fixes #3490

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with rake test
code is in uniquely-named feature branch and has no merge conflicts
PR is descriptively titled

    ask @publiclab/reviewers for help, in a comment below

I've removed the auto-added asterisk and added a link to the boolean-search info page as a comment above. I believe that's what's required to fix the issue, but I'm open to any suggestions!