### PR TITLE
Removed regex filter to allow titles to use non-latin characters

### DIFF
--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -9,8 +9,7 @@ class Revision < ApplicationRecord
 
   validates :title,
     presence: :true,
-    length: { minimum: 2 },
-    format: { with: /[A-Z][\w\-_]*/i, message: 'can only include letters, numbers, and dashes' }
+    length: { minimum: 2 }
   validates :body, presence: :true
   validates :uid, presence: :true
   validates :nid, presence: :true


### PR DESCRIPTION
Fixes #3988 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[✔️] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
[✔️] code is in uniquely-named feature branch and has no merge conflicts
[✔️] PR is descriptively titled
[✔️ ] ask `@publiclab/reviewers` for help, in a comment below

If tests do fail, click on the red `X` to learn why by reading the logs.

Removed a regex filter in app/models/revision.rb line 13 that limited titles of wikis/notes/questions to only begin with standard english characters.  This is a problem when users from other countries/languages try to write entries.