### PR TITLE
Corrected the use of carats in the header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -28,9 +28,9 @@
       </form>
 
       <ul class="nav navbar-nav navbar-left">
-        <li class="dropdown"><i class="fas fa-caret-down"></i>
+        <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-            Get Involved
+            Get Involved <i class="fa fa-caret-down" style="color:grey"></i>
           </a>
           <ul class="dropdown-menu">
             <li><a href="/events">Attend an event</a></li>
@@ -51,7 +51,7 @@
 
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-            <%= t('layout._header.about.about_title') %>
+            <%= t('layout._header.about.about_title') %> <i class="fa fa-caret-down" style="color:grey"></i>
           </a>
           <ul class="dropdown-menu">
             <li><a href="/wiki/stories"><%= t('layout._header.about.stories') %></a></li>


### PR DESCRIPTION
Fixes # No issue for this

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[✔️] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
[✔️] code is in uniquely-named feature branch and has no merge conflicts
[✔️] PR is descriptively titled
[✔️] ask `@publiclab/reviewers` for help, in a comment below

A simple fix for some layout issues.  It seems that someone tried adding a down carat to the to header to indicate those button were drop down menus, but they put the carat in the wrong spot and it was colored black with a black background so it didn't show up anyway.  Corrected the placement of the first carat and added a second and made them both grey to be seen.
Before:
![screen shot 2018-11-25 at 9 22 16 pm](https://user-images.githubusercontent.com/26209735/48989678-5ba71680-f0f9-11e8-8202-33950c5c168f.png)

After:
![screen shot 2018-11-25 at 9 22 56 pm](https://user-images.githubusercontent.com/26209735/48989690-6792d880-f0f9-11e8-89d0-86beb15b118f.png)

