### PR TITLE
Updated scrypt and removed inserting new answer's text into comment form

### DIFF
--- a/app/views/answers/create.js.erb
+++ b/app/views/answers/create.js.erb
@@ -1,4 +1,4 @@
-$('#answers').append('<%= escape_javascript(render :partial => "questions/answer", :locals => {answer: @answer}) %>')
+$('#answers').append('<%= escape_javascript(render :partial => "questions/answer", :locals => {answer: @answer, new_answer: true}) %>')
 $('#short-comment-count')[0].innerHTML = parseInt($('#short-comment-count')[0].innerHTML)+1
 $('textarea').val("");
 notyNotification('mint', 3000, 'success', 'topRight', 'Answer Created!');

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -21,7 +21,7 @@
         body = Node.find_by(slug: @node.power_tag('comment-template')).try(:body)
       end
     %>
-    <textarea style="border: 1px solid #bbb;border-bottom-left-radius: 0;border-bottom-right-radius: 0;border-bottom: 0;padding: 10px;" onFocus="editing=true" name="body" class="form-control" id="text-input" rows="6" cols="40" placeholder="<%= placeholder %>"><%= body %></textarea>
+    <textarea style="border: 1px solid #bbb;border-bottom-left-radius: 0;border-bottom-right-radius: 0;border-bottom: 0;padding: 10px;" onFocus="editing=true" name="body" class="form-control" id="text-input" rows="6" cols="40" placeholder="<%= placeholder %>"><% if local_assigns[:is_new_answer].blank? %> <%= body %><% end %></textarea>
     <div id="imagebar">
 
       <div id="create_progress" style="display:none;" class="progress progress-striped active pull-right">

--- a/app/views/questions/_answer.html.erb
+++ b/app/views/questions/_answer.html.erb
@@ -71,7 +71,7 @@
       <div id="answer-<%= answer.id %>-comment-section" style="display: flex;background: white;padding: 15px;">
       <% if current_user %>
       <div class="inline" id="question-comment-form">
-        <%= render partial: "comments/form", locals: { aid: answer.id, title: "Post Comment", placeholder: I18n.t('notes._comments.post_placeholder') } %>
+        <%= render partial: "comments/form", locals: { aid: answer.id, title: "Post Comment", placeholder: I18n.t('notes._comments.post_placeholder'), is_new_answer: !local_assigns[:new_answer].blank? } %>
       </div>
       <% else %>
       <p><%= link_to "Log in", new_user_session_path( return_to: request.path )%> to comment</p>


### PR DESCRIPTION
Fixes #3836 

Sorry for my delay, I had exams and also problems with installation. So I updated scrypt to solve problems with installation. Also I solved GCI task (#3836). So now new comment form on new answer isn't filling with the answer's text:

![Screenshot of PR](https://user-images.githubusercontent.com/24986597/49016615-34178300-f1b9-11e8-8ed0-4c010ad92768.png)
