### PR TITLE
Fix autocomplete on post pages

### DIFF
--- a/app/views/editor/questionRich.html.erb
+++ b/app/views/editor/questionRich.html.erb
@@ -6,7 +6,6 @@
 <link href="/lib/publiclab-editor/dist/PublicLab.Editor.css" rel="stylesheet">
 
 <!-- required for TagsModule -->
-<script src="/lib/typeahead.js/dist/typeahead.jquery.js"></script>
 <script src="/lib/typeahead.js/dist/bloodhound.js"></script>
 <script src="/lib/bootstrap-tokenfield/dist/bootstrap-tokenfield.js"></script>
 

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -4,7 +4,6 @@
 <link href="/lib/bootstrap-tokenfield/dist/css/bootstrap-tokenfield.min.css" rel="stylesheet">
 
 <!-- required for TagsModule -->
-<script src="/lib/typeahead.js/dist/typeahead.jquery.js"></script>
 <script src="/lib/typeahead.js/dist/bloodhound.js"></script>
 <script src="/lib/bootstrap-tokenfield/dist/bootstrap-tokenfield.js"></script>
 

--- a/app/views/editor/wikiRich.html.erb
+++ b/app/views/editor/wikiRich.html.erb
@@ -4,7 +4,6 @@
 <link href="/lib/bootstrap-tokenfield/dist/css/bootstrap-tokenfield.min.css" rel="stylesheet">
 
 <!-- required for TagsModule -->
-<script src="/lib/typeahead.js/dist/typeahead.jquery.js"></script>
 <script src="/lib/typeahead.js/dist/bloodhound.js"></script>
 <script src="/lib/bootstrap-tokenfield/dist/bootstrap-tokenfield.js"></script>
 


### PR DESCRIPTION
Fixes #2795 (<=== Add issue number here)

I checked the properties of the search bar on the post page and found it was different from that on all other pages. 

On Post:
![image](https://user-images.githubusercontent.com/44309027/49033076-d6ad1300-f173-11e8-9311-01abb15523d8.png)

On other pages:
![image](https://user-images.githubusercontent.com/44309027/49033087-df054e00-f173-11e8-85ad-3a4c4d1a2b96.png)

I determined the cause of this change to be `typeahead.jquery.js` here. 
https://github.com/publiclab/plots2/blob/b1a667548cf3dda6b85496a223fb7feab1a2b9dd/app/views/editor/rich.html.erb#L7

Upon removing this file, autocomplete appears to work.

![autocompleteonpost](https://user-images.githubusercontent.com/44309027/48992708-e8080800-f0fe-11e8-9e5f-beb64f83846a.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts
* [X] PR is descriptively titled
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
