### PR TITLE
Adjust formatting of inline thumbnail grids

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -362,12 +362,26 @@ div.note .meta {
   color:#888;
 }
 
+.image-container {
+  height:auto;
+  overflow:auto;
+}
+
 #notes .note a.img {
-  max-height: 200px;
   height:160px;
-  display: block;
+  display: inline-block;
   overflow: hidden;
   margin-bottom: 10px;
+}
+
+.note-image {
+  height: auto;
+  overflow: hidden;
+}
+
+.grid-image {
+  width: auto;
+  height: 150px;
 }
 
 #notes .note h3 a {

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -378,10 +378,13 @@ div.note .meta {
   height: auto;
   overflow: hidden;
 }
+.note-image img {
+  width: 100%;
+}
 
 .grid-image {
   width: auto;
-  height: 150px;
+  height: 160px;
 }
 
 #notes .note h3 a {
@@ -435,6 +438,11 @@ div.note.moderated h4 {
 @media (max-width:768px) {
   table {
     font-size: 90%;
+  }
+
+  .grid-image {
+    width: auto;
+    height: 200px;
   }
 }
 

--- a/app/views/grids/_thumbnail.html.erb
+++ b/app/views/grids/_thumbnail.html.erb
@@ -1,21 +1,21 @@
-  <table class="table table-responsive">
+  <div class="image-container row">
     <% nodes.each_with_index do |node, index| %>
-
-        <% if index % 3 == 0  %>
-            <tr> 
-          <% end %>
-          <td>
-            <a class="img" href="<%= node.path %>">
-              <% if node.main_image %>
-                <img style="width:100%;" alt="image" class="img-fluid" src="<%= node.main_image.path(:default)  %>">
-              <% end %>
-            </a>
-            <h3 style="padding: 0px; margin: 10px;"><a href="<%=node.path%>" style="padding-top: 0px"><%=node.title%></a></h3>
-            <p class="meta"><small>
-              <% if node.type == 'note' %>
-                by <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a> <%= node.author.new_author_contributor %>
-              <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope:'datetime.time_ago_in_words' }) %>
-              | <a href="<%= node.path %>#comments"><i style="color:#888;" class="fa fa-comment-o"></i> <%= node.comment_count %></a>
+        <% if index > 8 %>
+          <div class="hidden note-image col-md-4">
+        <% else %>
+          <div class="note-image col-md-4">
+        <% end %>
+          <a class="img" href="<%= node.path %>">
+            <% if node.main_image %>
+              <img alt="image" class="img-fluid grid-image" src="<%= node.main_image.path(:default) %>">
+            <% end %>
+          </a>
+          <h4 style="padding: 0px; margin: 10px;"><a href="<%=node.path%>" style="padding-top: 0px"><%=node.title%></a></h4>
+          <p class="meta"><small>
+            <% if node.type == 'note' %>
+              by <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a> <%= node.author.new_author_contributor %>
+            <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope:'datetime.time_ago_in_words' }) %>
+            | <a href="<%= node.path %>#comments"><i style="color:#888;" class="fa fa-comment-o"></i> <%= node.comment_count %></a>
             <% else %>
               <%= t('notes._notes.last_edit_by') %> <a href="/profile/<%= node.latest.author.name %>"><%= node.latest.author.name %></a>
               <%= distance_of_time_in_words(Time.at(node.latest.timestamp), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %>
@@ -23,19 +23,37 @@
             | <i class="fa fa-eye"></i> <%= number_with_delimiter(node.totalviews) %> <span class="hidden-xs hidden-sm"><%= t('notes._notes.views') %></span>
             | <i style="<% if node.likes > 0 %>color:#db4;<% else %>color:#888;<% end %>" class="fa fa-star-o"></i> <%= node.likes %>
           </small></p>
-
-          </td>
-          <% if index % 3 == 2  %>
-            </tr>
-          <%end %>
-
-      <% end %>
-</table>
-
+        </div>
+    <% end %>
+  </div>
+  <div class="row">
+    <a id="show-all" class="col-md-2 col-md-offset-5 show-all">See more</a>
+  </div>
+<script>
+    $('#show-all').on('click', function(){
+      if ($('.hidden').length > 0) {
+        $('.hidden').addClass('show');
+        $('.show').removeClass('hidden');
+        $('#show-all').html('See less');
+      } else {
+        $('.show').addClass('hidden');
+        $('.show').removeClass('show');
+        $('#show-all').html('See more');
+      }
+    });
+</script>
 <style>
-.table thead tr th, .table tbody tr td {
-    border: none;
-}
-
-
+  .table thead tr th, .table tbody tr td {
+      border: none;
+  }
+  .hidden {
+    display: none;
+  }
+  .show {
+    display: block;
+  }
+  .show-all {
+    color: black;
+    text-decoration: underline;
+  }
 </style>

--- a/app/views/grids/_thumbnail.html.erb
+++ b/app/views/grids/_thumbnail.html.erb
@@ -1,9 +1,9 @@
   <div class="image-container row">
     <% nodes.each_with_index do |node, index| %>
         <% if index > 8 %>
-          <div class="hidden note-image col-md-4">
+          <div class="hidden note-image col-lg-4 col-md-6 col-sm-6 col-xs-12 text-center">
         <% else %>
-          <div class="note-image col-md-4">
+          <div class="note-image col-lg-4 col-md-5 col-sm-6 col-xs-12 text-center">
         <% end %>
           <a class="img" href="<%= node.path %>">
             <% if node.main_image %>
@@ -27,18 +27,18 @@
     <% end %>
   </div>
   <div class="row">
-    <a id="show-all" class="col-md-2 col-md-offset-5 show-all">See more</a>
+    <a id="show-all" class="col-md-2 col-md-offset-5 show-all">Show more</a>
   </div>
 <script>
     $('#show-all').on('click', function(){
       if ($('.hidden').length > 0) {
         $('.hidden').addClass('show');
         $('.show').removeClass('hidden');
-        $('#show-all').html('See less');
+        $('#show-all').html('Show less');
       } else {
         $('.show').addClass('hidden');
         $('.show').removeClass('show');
-        $('#show-all').html('See more');
+        $('#show-all').html('Show more');
       }
     });
 </script>
@@ -50,7 +50,7 @@
     display: none;
   }
   .show {
-    display: block;
+    display: inline-block;
   }
   .show-all {
     color: black;


### PR DESCRIPTION
Fixes #3970 

Gif showing the `show more` button (I added a `show less` too but I couldn't upload it because Github just allows 10MB)
![more](https://user-images.githubusercontent.com/20969831/49053903-e3ac1f80-f1d0-11e8-8262-81c3383db756.gif)

And, here is a static image of grids of notes
<img width="893" alt="screen shot 2018-11-26 at 11 16 41 pm" src="https://user-images.githubusercontent.com/20969831/49054010-5c12e080-f1d1-11e8-870e-bcc3d860b31b.png">
