### PR TITLE
Fixed login control and login prompt in questions index

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -21,15 +21,17 @@
   <div class="row">
     <div class="col-md-6">
       <h4>Ask a question here</h4>
-      <p>To ask a question, please <a href="/login?return_to=/questions">log in</a> or <a href="/signup?return_to=/questions">sign up</a> first.</p>
+      <% if !current_user %>
+        <p>To ask a question, please <a href="/login?return_to=/questions">log in</a> or <a href="/signup?return_to=/questions">sign up</a> first.</p>
+      <% end %>
       <form id="questions_searchform" class="form-horizontal" role="search" autocomplete="off" action="/post">
         <div class="input-group">
-          <input tabindex="1" id="questions_searchform_input" type="text" name="title" class="<%= "disabled " if current_user %>form-control search-query typeahead" qryType="questions" placeholder="type your question">
+          <input tabindex="1" id="questions_searchform_input" type="text" name="title" class="<%= "disabled " if !current_user %>form-control search-query typeahead" qryType="questions" placeholder="type your question">
           <input type="hidden" name="tags" value="question:general">
           <input type="hidden" name="template" value="question">
           <input type="hidden" name="redirect" value="question">
           <span class="input-group-btn">
-            <button type="submit" rel="tooltip" title="Ask a question with the entered title" class="<%= "disabled " if current_user %>btn btn-primary">Continue</button>
+            <button type="submit" rel="tooltip" title="Ask a question with the entered title" class="<%= "disabled " if !current_user %>btn btn-primary">Continue</button>
             </span>
         </div>
       </form>

--- a/app/views/tag/_sorting.html.erb
+++ b/app/views/tag/_sorting.html.erb
@@ -1,4 +1,10 @@
 <h4>View questions by topic</h4>
+<!-- <hr> and sign in check is here to create a space that makes the form
+line up nicely if the user is asked to login on the questions/index page -->
+<% if !current_user %>
+  <hr style="visibility:hidden;" />
+<% end %>
+
 <form id="tagform" class="form-horizontal" method="GET" action="/questions/tag/">
   <div class="input-group">
     <input tabindex="1" autocomplete="off" id="taginput" name="id" type="text" placeholder="type your topic" data-provide="typeahead" class="form-control" />


### PR DESCRIPTION
Fixes #4058 
related to fixes for #3847 

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

Found that the refactor from PR #3968 had a few issues.  It contained a login prompt that was always present even when the user was logged in. 

The login check to submit the form was `<%= "disabled " if current_user %>`.  This made it so that when a user logged in the button would disabled.  Changed the condition to `if !current_user`.  

Also added a `<hr/>` with a login check to `app/views/tag/_sorting.html.erb` to make the forms line up nicely if the user is not signed in.
Before when not logged in, notice the `Continue` button is active:
![screen shot 2018-11-27 at 7 40 48 am](https://user-images.githubusercontent.com/26209735/49082502-ec741400-f217-11e8-8d6f-1f626b2eeb8e.png)

Before when logged in, notice the `Continue` button is disabled:
![screen shot 2018-11-27 at 7 39 32 am](https://user-images.githubusercontent.com/26209735/49082528-fc8bf380-f217-11e8-8bf3-cc846ff25edc.png)

After when not logged in:
![screen shot 2018-11-27 at 7 43 16 am](https://user-images.githubusercontent.com/26209735/49082596-25ac8400-f218-11e8-89dd-87d56d945933.png)

After when logged in:
![screen shot 2018-11-27 at 7 44 14 am](https://user-images.githubusercontent.com/26209735/49082634-4674d980-f218-11e8-8e7a-d27a0b7a62b8.png)

