### PR TITLE
Email to moderators (create a comment_moderation mailer)

### DIFF
--- a/app/helpers/comment_helper.rb
+++ b/app/helpers/comment_helper.rb
@@ -3,7 +3,11 @@ module CommentHelper
   end
 
   def create_comment(node, user, body)
-    @comment = node.add_comment(uid: user.uid, body: body)
+    status = 1
+    if user.first_time_poster && user.first_time_commenter
+      status = 4
+    end
+    @comment = node.add_comment(uid: user.uid, body: body, status: status)
     if user && @comment.save
       @comment.notify user
       return @comment

--- a/app/helpers/comment_helper.rb
+++ b/app/helpers/comment_helper.rb
@@ -3,11 +3,7 @@ module CommentHelper
   end
 
   def create_comment(node, user, body)
-    status = 1
-    if user.first_time_poster && user.first_time_commenter
-      status = 4
-    end
-    @comment = node.add_comment(uid: user.uid, body: body, status: status)
+    @comment = node.add_comment(uid: user.uid, body: body)
     if user && @comment.save
       @comment.notify user
       return @comment

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -44,7 +44,7 @@ class AdminMailer < ActionMailer::Base
   # Should: prompt moderators to reach out if it's not spam, but a guidelines violation
   # def notify_author_of_spam(node)
   # end
-  
+
   def notify_moderators_of_comment_spam(comment, moderator)
     subject = '[New Public Lab comment needs moderation]'
     @author = comment.author

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -16,6 +16,19 @@ class AdminMailer < ActionMailer::Base
     )
   end
 
+  def notify_comment_moderators(comment)
+    subject = '[New Public Lab poster needs moderation]'
+    @comment = comment
+    @user = comment.author.user
+    @footer = feature('email-footer')
+    moderators = User.where(role: %w(moderator admin)).collect(&:email)
+    mail(
+      to: "comment-moderators@#{ActionMailer::Base.default_url_options[:host]}",
+      bcc: moderators,
+      subject: subject
+    )
+  end
+
   def notify_author_of_approval(node, moderator)
     subject = '[Public Lab] Your post was approved!'
     @author = node.author

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -132,7 +132,7 @@ class Comment < ApplicationRecord
   # email all users in this thread
   # plus all who've starred it
   def notify(current_user)
-    if current_user.first_time_commenter&.first_time_poster
+    if status == 4
       AdminMailer.notify_comment_moderators(self).deliver_now
     else
       if parent.uid != current_user.uid && !UserTag.exists?(parent.uid, 'notify-comment-direct:false')

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -132,18 +132,22 @@ class Comment < ApplicationRecord
   # email all users in this thread
   # plus all who've starred it
   def notify(current_user)
-    if parent.uid != current_user.uid && !UserTag.exists?(parent.uid, 'notify-comment-direct:false')
-      CommentMailer.notify_note_author(parent.author, self).deliver_now
+    if current_user.first_time_commenter
+      AdminMailer.notify_comment_moderators(self).deliver_now
+    else
+      if parent.uid != current_user.uid && !UserTag.exists?(parent.uid, 'notify-comment-direct:false')
+        CommentMailer.notify_note_author(parent.author, self).deliver_now
+      end
+
+      notify_callout_users
+
+      # notify other commenters, revisers, and likers, but not those already @called out
+      already = mentioned_users.collect(&:uid) + [parent.uid]
+      uids = uids_to_notify - already
+
+      notify_users(uids, current_user)
+      notify_tag_followers(already + uids)
     end
-
-    notify_callout_users
-
-    # notify other commenters, revisers, and likers, but not those already @called out
-    already = mentioned_users.collect(&:uid) + [parent.uid]
-    uids = uids_to_notify - already
-
-    notify_users(uids, current_user)
-    notify_tag_followers(already + uids)
   end
 
   def answer_comment_notify(current_user)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -132,7 +132,7 @@ class Comment < ApplicationRecord
   # email all users in this thread
   # plus all who've starred it
   def notify(current_user)
-    if current_user.first_time_commenter
+    if current_user.first_time_commenter&.first_time_poster
       AdminMailer.notify_comment_moderators(self).deliver_now
     else
       if parent.uid != current_user.uid && !UserTag.exists?(parent.uid, 'notify-comment-direct:false')

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -603,7 +603,7 @@ class Node < ActiveRecord::Base
                     subject: '',
                     hostname: '',
                     comment: params[:body],
-                    status: 1,
+                    status: params[:status],
                     format: 1,
                     thread: thread,
                     timestamp: DateTime.now.to_i,

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -597,13 +597,18 @@ class Node < ActiveRecord::Base
     else
       comment_via_status = params[:comment_via].to_i
     end
+    user = User.find(params[:uid])
+    status = 1
+    if user.first_time_poster && user.first_time_commenter
+      status = 4
+    end
     c = Comment.new(pid: 0,
                     nid: nid,
                     uid: params[:uid],
                     subject: '',
                     hostname: '',
                     comment: params[:body],
-                    status: params[:status],
+                    status: status,
                     format: 1,
                     thread: thread,
                     timestamp: DateTime.now.to_i,

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -587,21 +587,10 @@ class Node < ActiveRecord::Base
   # Automated constructors for associated models
 
   def add_comment(params = {})
-    thread = if !comments.empty? && !comments.last.nil?
-               comments.last.next_thread
-             else
-               '01/'
-    end
-    if params[:comment_via].nil?
-      comment_via_status = 0
-    else
-      comment_via_status = params[:comment_via].to_i
-    end
+    thread = !comments.empty? && !comments.last.nil? ? comments.last.next_thread : '01/'
+    comment_via_status = params[:comment_via].nil? ? 0 : params[:comment_via].to_i
     user = User.find(params[:uid])
-    status = 1
-    if user.first_time_poster && user.first_time_commenter
-      status = 4
-    end
+    status = user.first_time_poster && user.first_time_commenter ? 4 : 1
     c = Comment.new(pid: 0,
                     nid: nid,
                     uid: params[:uid],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -346,7 +346,7 @@ class User < ActiveRecord::Base
   end
   
   def first_time_commenter
-    Comment.where(status: 1).count == 0
+    Comment.where(status: 1, uid: uid).count == 0
   end
 
   def follow(other_user)

--- a/app/views/admin_mailer/notify_comment_moderators.html.erb
+++ b/app/views/admin_mailer/notify_comment_moderators.html.erb
@@ -10,9 +10,9 @@
   </p>
 
   <p>
-    <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/publish/<%= @comment.id %>">Approve</a>
+    <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/admin/publish_comment/<%= @comment.id %>">Approve</a>
     or
-    <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= @comment.id %>">Spam</a>
+    <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/admin/spam_comments/<%= @comment.id %>">Spam</a>
   </p>
 
   <hr />
@@ -41,11 +41,6 @@
       </tr>
     </tbody>
   </table>
-
-  <hr />
-
-  <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/publish/<%= @comment.id %>">Approve</a> or <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= @comment.id %>">Spam</a>
-
 </div>
 
 <div style="color:#aaa;">

--- a/app/views/admin_mailer/notify_comment_moderators.html.erb
+++ b/app/views/admin_mailer/notify_comment_moderators.html.erb
@@ -1,0 +1,59 @@
+<div class="body">
+  <p>
+    First-time poster <a href='https://<%= ActionMailer::Base.default_url_options[:host] %>/profile/<%= @comment.author.name %>'><%= @comment.author.name %></a>
+    has submitted their first research comment!
+  </p>
+
+  <p>
+    Help to approve it or mark it as spam:
+    https://<%= ActionMailer::Base.default_url_options[:host] %><%= @comment.node.path %>
+  </p>
+
+  <p>
+    <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/publish/<%= @comment.id %>">Approve</a>
+    or
+    <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= @comment.id %>">Spam</a>
+  </p>
+
+  <hr />
+
+  <p>It has the following tags: </p>
+  <ul>
+    <% @comment.tags.each do |tag| %>
+    <li><%= tag.name %></li>
+    <% end %>
+  </ul>
+
+  <table border="1">
+    <thead>User Info</thead>
+    <tbody>
+      <tr>
+        <th>ID</th>
+        <td><%= @user.id %></td>
+      </tr>
+      <tr>
+        <th>Username</th>
+        <td><%= @user.username %></td>
+      </tr>
+      <tr>
+        <th>Email</th>
+        <td><%= @user.email %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr />
+
+  <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/publish/<%= @comment.id %>">Approve</a> or <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= @comment.id %>">Spam</a>
+
+</div>
+
+<div style="color:#aaa;">
+
+  <p>You received this email because you are <a href="https://<%= ActionMailer::Base.default_url_options[:host] %>/wiki/moderation">a Public Lab community moderator</a></p>
+
+  <p>To discuss spam/abuse, forward this to <a href="mailto:moderators@<%= ActionMailer::Base.default_url_options[:host] %>">moderators@<%= ActionMailer::Base.default_url_options[:host] %></a></p>
+
+  <%= @footer %>
+
+</div>

--- a/test/fixtures/drupal_users.yml
+++ b/test/fixtures/drupal_users.yml
@@ -123,3 +123,10 @@ data:
   mail: data@pxlshp.com
   uid: 18
   created: <%= Time.now.to_i %>
+
+user_first_time_poster:
+  name: user_first_time_poster
+  status: 1
+  mail: user_first_time_poster@pxlshp.com
+  uid: 19
+  created: <%= Time.now.to_i %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -223,3 +223,16 @@ data:
   bio: 'data is a nice cat and he loves steff!'
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+user_first_time_poster:
+  username: user_first_time_poster
+  status: 1
+  email: first_time_poste@pxlshp.com
+  id: 19
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  last_request_at: <%= Time.now %>
+  bio: 'user_first_time_poster'
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -235,6 +235,16 @@ class CommentControllerTest < ActionController::TestCase
     assert_template 'comments/delete.js.erb'
   end
 
+  test 'should create a comment with status 4 if user has never created nothing before' do
+    user = users(:user_first_time_poster)
+    UserSession.create(user)
+
+    post :create, params: { id: nodes(:one).nid, body: 'example' }, xhr: true
+
+    assert_equal 19, Comment.last.author.id
+    assert_equal 4, Comment.last.status
+  end
+
   test 'should send mail to moderator if comment has status 4' do
     UserSession.create(users(:moderator))
     post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -28,7 +28,7 @@ class CommentControllerTest < ActionController::TestCase
     assert_template partial: 'notes/_comment'
     assert_equal 1, css_select(".comment table").size # test inline grid rendering
   end
- 
+
   test 'should create question comments' do
     UserSession.create(users(:bob))
     assert_difference 'Comment.count' do
@@ -235,6 +235,12 @@ class CommentControllerTest < ActionController::TestCase
     assert_template 'comments/delete.js.erb'
   end
 
+  test 'should send mail to moderator if comment has status 4' do
+    UserSession.create(users(:moderator))
+    post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true
+    assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:moderator).email])
+  end
+
   test 'should send mail to tag followers in the comment' do
     UserSession.create(users(:jeff))
     post :create, params: { id: nodes(:question).nid, body: 'Question #awesome', type: 'question' }, xhr: true
@@ -300,7 +306,7 @@ class CommentControllerTest < ActionController::TestCase
     comment = comments(:first)
     assert_no_difference 'Comment.count' do
       post :make_answer,
-          params: { 
+          params: {
            id: comment.id
           }
     end

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -242,14 +242,21 @@ class CommentControllerTest < ActionController::TestCase
     post :create, params: { id: nodes(:one).nid, body: 'example' }, xhr: true
 
     comment = Comment.last
-    assert_equal user.id, comment.author.id
-    assert_equal 4, comment.status
+    assert_equal 4, user.id && comment.status, comment.author.id
   end
 
   test 'should send mail to moderator if comment has status 4' do
     UserSession.create(users(:moderator))
     post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:moderator).email])
+  end
+
+  test 'should not send mail to moderator if comment has status different than 4' do
+    UserSession.create(users(:bob))
+    post :create, params: { id: nodes(:one).nid, body: 'example' }, xhr: true
+
+    assert_equal 1, Comment.last.status
+    assert_not ActionMailer::Base.deliveries.collect(&:to).include?("comment-moderators@#{ActionMailer::Base.default_url_options[:host]}")
   end
 
   test 'should send mail to tag followers in the comment' do

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -241,8 +241,9 @@ class CommentControllerTest < ActionController::TestCase
 
     post :create, params: { id: nodes(:one).nid, body: 'example' }, xhr: true
 
-    assert_equal 19, Comment.last.author.id
-    assert_equal 4, Comment.last.status
+    comment = Comment.last
+    assert_equal user.id, comment.author.id
+    assert_equal 4, comment.status
   end
 
   test 'should send mail to moderator if comment has status 4' do


### PR DESCRIPTION
Fixes #4050 
Ok, in the navigator I'm logged a moderator and in incognito navigator I'm a basic user that have never commented and publish before. This is what happen when the basic user comment for first time: The moderator use receive an email saying that the comment needs review.
 **First time poster:**
![example_first](https://user-images.githubusercontent.com/20969831/49347959-367a5100-f681-11e8-9b91-c9389ffe2043.gif)

And here is what happen if the user already has comment created. In this case, the moderator receive an email too because he is the creator of note that user commented. You can see that in the email text. 
**Not first time poster:**
![example_not_first](https://user-images.githubusercontent.com/20969831/49348732-e2be3680-f685-11e8-895a-9bee452c0f13.gif)

The test passed!
**Mailer test:**
<img width="572" alt="screen shot 2018-12-02 at 12 30 43 am" src="https://user-images.githubusercontent.com/20969831/49335294-a75e3200-f5c9-11e8-8706-5436627138a8.png">

**Functional test:**
<img width="569" alt="screen shot 2018-12-02 at 11 18 12 pm" src="https://user-images.githubusercontent.com/20969831/49349270-9e806580-f688-11e8-8251-337ea4235b82.png">
