### PR TITLE
/api/srch/profiles: search only by user tag 

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -88,7 +88,7 @@ module Srch
                                            nickname: 'search_profiles'
 
       params do
-        use :common, :sorting, :ordering, :field, :additional
+        use :common, :sorting, :ordering, :field
       end
       get :profiles do
         search_request = SearchRequest.fromRequest(params)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -179,7 +179,6 @@ class SearchService
         User.where('rusers.status = 1')
             .joins(:user_tags)\
             .where('user_tags.value LIKE ?', '%' + query + '%')\
-            #.where(id: users.select("rusers.id"))
       else if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
         type == "username" ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
       else

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -30,7 +30,7 @@ class SearchService
   # If no sort_by value present, then it returns a list of profiles ordered by id DESC
   # a recent activity may be a node creation or a node revision
   def search_profiles(search_criteria)
-    user_scope = find_users(search_criteria.query, search_criteria.limit, search_criteria.field, search_criteria.tag)
+    user_scope = find_users(search_criteria.query, search_criteria.limit, search_criteria.field)
 
     user_scope =
       if search_criteria.sort_by == "recent"
@@ -173,18 +173,18 @@ class SearchService
     user_locations.limit(query)
   end
 
-  def find_users(query, limit, type = nil, user_tag = nil)
+  def find_users(query, limit, type = nil)
     users =
-      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      if type == "tag"
+        User.where('rusers.status = 1')
+            .joins(:user_tags)\
+            .where('user_tags.value LIKE ?', '%' + query + '%')\
+            #.where(id: users.select("rusers.id"))
+      else if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
         type == "username" ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
       else
         User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
       end
-
-    if user_tag.present?
-      users = User.joins(:user_tags)\
-                           .where('user_tags.value LIKE ?', user_tag)\
-                           .where(id: users.select("rusers.id"))
     end
 
     users = users.limit(limit)

--- a/doc/API.md
+++ b/doc/API.md
@@ -43,9 +43,7 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
   `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
 
   `field=[string]`: Accepts the value `username` for searching profiles only by
-   the field `username`.
-
-   `tag=[string]`: The search can be refined by passing a tag field.
+   the field `username`. And accepts the value `tag` for searching profiles by tag.
 
 ### Notes
 


### PR DESCRIPTION
Fixes #3506

/api/srch/profiles: Adding the option to search for user tags.

`/api/srch/profiles?query=[tag_name]&field=tag`