### PR TITLE
Add Outlook Reply By Email Feature

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -240,15 +240,15 @@ class Comment < ApplicationRecord
                   gmail_parsed_mail mail_doc
                 else
                   {
-                    "comment_content" => mail_doc,
-                    "extra_content" => nil
+                    comment_content: mail_doc,
+                    extra_content: nil
                   }
                 end
-      if content["extra_content"].nil?
-        comment_content_markdown = ReverseMarkdown.convert content["comment_content"]
+      if content[:extra_content].nil?
+        comment_content_markdown = ReverseMarkdown.convert content[:comment_content]
       else
-        extra_content_markdown = ReverseMarkdown.convert content["extra_content"]
-        comment_content_markdown = ReverseMarkdown.convert content["comment_content"]
+        extra_content_markdown = ReverseMarkdown.convert content[:extra_content]
+        comment_content_markdown = ReverseMarkdown.convert content[:comment_content]
         comment_content_markdown = comment_content_markdown + COMMENT_FILTER + extra_content_markdown
       end
       message_id = mail.message_id
@@ -279,15 +279,15 @@ class Comment < ApplicationRecord
                   gmail_parsed_mail mail_doc
                 else
                   {
-                    "comment_content" => mail_doc,
-                    "extra_content" => nil
+                    comment_content: mail_doc,
+                    extra_content: nil
                   }
                 end
-      if content["extra_content"].nil?
-        comment_content_markdown = ReverseMarkdown.convert content["comment_content"]
+      if content[:extra_content].nil?
+        comment_content_markdown = ReverseMarkdown.convert content[:comment_content]
       else
-        extra_content_markdown = ReverseMarkdown.convert content["extra_content"]
-        comment_content_markdown = ReverseMarkdown.convert content["comment_content"]
+        extra_content_markdown = ReverseMarkdown.convert content[:extra_content]
+        comment_content_markdown = ReverseMarkdown.convert content[:comment_content]
         comment_content_markdown = comment_content_markdown + COMMENT_FILTER + extra_content_markdown
       end
       message_id = mail.message_id
@@ -315,8 +315,8 @@ class Comment < ApplicationRecord
     end
 
     {
-      "comment_content" => comment_content,
-      "extra_content" => extra_content
+      comment_content: comment_content,
+      extra_content: extra_content
     }
   end
 
@@ -331,8 +331,8 @@ class Comment < ApplicationRecord
     end
 
     {
-      "comment_content" => comment_content,
-      "extra_content" => extra_content
+      comment_content: comment_content,
+      extra_content: extra_content
     }
   end
 
@@ -349,8 +349,8 @@ class Comment < ApplicationRecord
     end
 
     {
-      "comment_content" => comment_content,
-      "extra_content" => extra_content
+      comment_content:  comment_content,
+      extra_content: extra_content
     }
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -228,14 +228,8 @@ class Comment < ApplicationRecord
   def self.add_answer_comment(mail, answer_id, user)
     answer = Answer.where(id: answer_id).first
     if answer
-      #puts "---------------------- NEW MESSAGE ----------------------"
       mail_doc = Nokogiri::HTML(mail.html_part.body.decoded) # To parse the mail to extract comment content and reply content
-      #puts "#{mail_doc}"
-      #puts "-------- DOMAIN ---------"
-
       domain = get_domain mail.from.first
-      #puts "#{domain}"
-      Mailman.logger.debug "#{domain}"
       content = if domain == "gmail"
                   gmail_parsed_mail mail_doc
                 elsif domain == "yahoo"
@@ -272,21 +266,15 @@ class Comment < ApplicationRecord
     node = Node.where(nid: node_id).first
     if node
       mail_doc = Nokogiri::HTML(mail.html_part.body.decoded) # To parse the mail to extract comment content and reply content
-      #puts "---------------------- NEW MESSAGE HTML----------------------"
-      #puts "#{mail_doc}"
-      #Mailman.logger.debug "#{mail_doc}"
-      #puts "-------- DOMAIN ---------"
       domain = get_domain mail.from.first
-      puts "#{domain}"
-      #Mailman.logger.debug "#{domain}"
       content = if domain == "gmail"
                   gmail_parsed_mail mail_doc
                 elsif domain == "yahoo"
                   yahoo_parsed_mail mail_doc
-                elsif gmail_quote_present?(mail_doc)
-                  gmail_parsed_mail mail_doc
                 elsif domain == "outlook"
                   outlook_parsed_mail mail_doc
+                elsif gmail_quote_present?(mail_doc)
+                  gmail_parsed_mail mail_doc
                 else
                   {
                     "comment_content" => mail_doc,
@@ -348,31 +336,35 @@ class Comment < ApplicationRecord
 
   def self.outlook_parsed_mail(mail_doc) 
     mail_doc_test = mail_doc.css("div[style]")
-    Mailman.logger.debug "--------------- TEST STUFF -----------------"
-    #Mailman.logger.debug "#{mail_doc_test}"
-
+    
     Mailman.logger.debug "---------------- USING MATCH -------------"
     separator = mail_doc.inner_html.match(/(.+)(<div id="appendonsend"><\/div>)(.+)/m)
-    Mailman.logger.debug separator[1]
-    Mailman.logger.debug separator[2]
-    Mailman.logger.debug separator[3]
-    
-    iMessage = separator[1].match(/(.+)(<body dir="ltr">)(.+)/m)
-    Mailman.logger.debug "---------------- iMESSAGE ----------------"
-    Mailman.logger.debug iMessage[3]
-    
-    comment_content = Nokogiri::HTML(iMessage[3])
-    
-    trimm = separator[3].match(/(.+)(<\/body>)(.+)/m)
-    Mailman.logger.debug "---------------- trimm ----------------"
-    Mailman.logger.debug trimm[1]
-    
-    extra_content = Nokogiri::HTML(trimm[1]);
+    if(separator.nil?) 
+      comment_content = mail_doc
+      extra_content = nil
+    else
+      Mailman.logger.debug separator[1]
+      Mailman.logger.debug separator[2]
+      Mailman.logger.debug separator[3]
+  
+      bodyMessage = separator[1].match(/(.+)(<body dir="ltr">)(.+)/m)
+      Mailman.logger.debug "---------------- body message ----------------"
+      Mailman.logger.debug bodyMessage[3]
+  
+      comment_content = Nokogiri::HTML(bodyMessage[3])
+  
+      trimmedMessage = separator[3].match(/(.+)(<\/body>)(.+)/m)
+      Mailman.logger.debug "---------------- trimmed message ----------------"
+      Mailman.logger.debug trimmedMessage[1]
+  
+      extra_content = Nokogiri::HTML(trimmedMessage[1]);
+    end
     {
       "comment_content" => comment_content,
       "extra_content" => extra_content
     }
   end
+    
   def trimmed_content?
     comment.include?(COMMENT_FILTER)
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -338,7 +338,7 @@ class Comment < ApplicationRecord
 
   def self.outlook_parsed_mail(mail_doc)
     separator = mail_doc.inner_html.match(/(.+)(<div id="appendonsend"><\/div>)(.+)/m)
-    if separator.nil? 
+    if separator.nil?
       comment_content = mail_doc
       extra_content = nil
     else
@@ -347,13 +347,13 @@ class Comment < ApplicationRecord
       trimmed_message = separator[3].match(/(.+)(<\/body>)(.+)/m)
       extra_content = Nokogiri::HTML(trimmed_message[1])
     end
-    
+
     {
       "comment_content" => comment_content,
       "extra_content" => extra_content
     }
   end
-    
+
   def trimmed_content?
     comment.include?(COMMENT_FILTER)
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -337,27 +337,17 @@ class Comment < ApplicationRecord
   def self.outlook_parsed_mail(mail_doc) 
     mail_doc_test = mail_doc.css("div[style]")
     
-    Mailman.logger.debug "---------------- USING MATCH -------------"
     separator = mail_doc.inner_html.match(/(.+)(<div id="appendonsend"><\/div>)(.+)/m)
     if(separator.nil?) 
       comment_content = mail_doc
       extra_content = nil
     else
-      Mailman.logger.debug separator[1]
-      Mailman.logger.debug separator[2]
-      Mailman.logger.debug separator[3]
   
       bodyMessage = separator[1].match(/(.+)(<body dir="ltr">)(.+)/m)
-      Mailman.logger.debug "---------------- body message ----------------"
-      Mailman.logger.debug bodyMessage[3]
-  
       comment_content = Nokogiri::HTML(bodyMessage[3])
-  
       trimmedMessage = separator[3].match(/(.+)(<\/body>)(.+)/m)
-      Mailman.logger.debug "---------------- trimmed message ----------------"
-      Mailman.logger.debug trimmedMessage[1]
-  
       extra_content = Nokogiri::HTML(trimmedMessage[1]);
+      
     end
     {
       "comment_content" => comment_content,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -336,17 +336,16 @@ class Comment < ApplicationRecord
     }
   end
 
-  def self.outlook_parsed_mail(mail_doc) 
+  def self.outlook_parsed_mail(mail_doc)
     separator = mail_doc.inner_html.match(/(.+)(<div id="appendonsend"><\/div>)(.+)/m)
-    
-    if(separator.nil?) 
+    if separator.nil? 
       comment_content = mail_doc
       extra_content = nil
     else
-      bodyMessage = separator[1].match(/(.+)(<body dir="ltr">)(.+)/m)
-      comment_content = Nokogiri::HTML(bodyMessage[3])
-      trimmedMessage = separator[3].match(/(.+)(<\/body>)(.+)/m)
-      extra_content = Nokogiri::HTML(trimmedMessage[1]);
+      body_message = separator[1].match(/(.+)(<body dir="ltr">)(.+)/m)
+      comment_content = Nokogiri::HTML(body_message[3])
+      trimmed_message = separator[3].match(/(.+)(<\/body>)(.+)/m)
+      extra_content = Nokogiri::HTML(trimmed_message[1])
     end
     
     {

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -234,6 +234,8 @@ class Comment < ApplicationRecord
                   gmail_parsed_mail mail_doc
                 elsif domain == "yahoo"
                   yahoo_parsed_mail mail_doc
+                elsif domain == "outlook"
+                  outlook_parsed_mail mail_doc
                 elsif gmail_quote_present?(mail_doc)
                   gmail_parsed_mail mail_doc
                 else
@@ -335,20 +337,18 @@ class Comment < ApplicationRecord
   end
 
   def self.outlook_parsed_mail(mail_doc) 
-    mail_doc_test = mail_doc.css("div[style]")
-    
     separator = mail_doc.inner_html.match(/(.+)(<div id="appendonsend"><\/div>)(.+)/m)
+    
     if(separator.nil?) 
       comment_content = mail_doc
       extra_content = nil
     else
-  
       bodyMessage = separator[1].match(/(.+)(<body dir="ltr">)(.+)/m)
       comment_content = Nokogiri::HTML(bodyMessage[3])
       trimmedMessage = separator[3].match(/(.+)(<\/body>)(.+)/m)
       extra_content = Nokogiri::HTML(trimmedMessage[1]);
-      
     end
+    
     {
       "comment_content" => comment_content,
       "extra_content" => extra_content

--- a/test/fixtures/drupal_users.yml
+++ b/test/fixtures/drupal_users.yml
@@ -130,3 +130,10 @@ user_first_time_poster:
   mail: user_first_time_poster@pxlshp.com
   uid: 19
   created: <%= Time.now.to_i %>
+
+outlook_test:
+  name: kluo
+  status: 1
+  mail: pl.usertest@outlook.com
+  uid: 20
+  created: <%= Time.now.to_i %>

--- a/test/fixtures/incoming_test_emails/outlook/final_parsed_comment.txt
+++ b/test/fixtures/incoming_test_emails/outlook/final_parsed_comment.txt
@@ -1,0 +1,30 @@
+This is the second reply sent by the user.
+<!-- @@$$%% Trimmed Content @@$$%% -->* * *
+
+<font face="Calibri, sans-serif" style="font-size:11pt" color="#000000"><b>From:</b> TestUser PublicLab<br>
+<b>Sent:</b> Wednesday, December 12, 2018 8:43 PM<br>
+<b>To:</b> kevinzluo PublicLab<br>
+<b>Subject:</b> Re: (#a2)</font>
+&nbsp;
+
+<style type="text/css" style="display:none">
+<!--
+p
+	{margin-top:0;
+	margin-bottom:0}
+-->
+</style>
+
+ This is the first reply sent by the user.
+
+* * *
+
+<font face="Calibri, sans-serif" color="#000000" style="font-size:11pt"><b>From:</b> kevinzluo PublicLab &lt;pl.kevinzluo@gmail.com&gt;<br>
+<b>Sent:</b> Wednesday, December 12, 2018 8:42 PM<br>
+<b>To:</b> pl.usertest@outlook.com<br>
+<b>Subject:</b> (#a2)</font>
+&nbsp;
+
+This is the email sent to the user by PublicLab.
+
+

--- a/test/fixtures/incoming_test_emails/outlook/final_parsed_comment.txt
+++ b/test/fixtures/incoming_test_emails/outlook/final_parsed_comment.txt
@@ -1,4 +1,4 @@
-This is the second reply sent by the user.
+ This is the second reply sent by the user.
 <!-- @@$$%% Trimmed Content @@$$%% -->* * *
 
 <font face="Calibri, sans-serif" style="font-size:11pt" color="#000000"><b>From:</b> TestUser PublicLab<br>
@@ -26,5 +26,4 @@ p
 &nbsp;
 
 This is the email sent to the user by PublicLab.
-
 

--- a/test/fixtures/incoming_test_emails/outlook/incoming_outlook_email.eml
+++ b/test/fixtures/incoming_test_emails/outlook/incoming_outlook_email.eml
@@ -1,0 +1,162 @@
+Return-Path: <pl.usertest@outlook.com>
+Received: by 2002:a6b:ce09:0:0:0:0:0 with SMTP id p9csp451442iob;=0D=0A       
+ Wed, 12 Dec 2018 20:43:58 -0800 (PST)
+Received: from NAM05-DM3-obe.outbound.protection.outlook.com (mail-oln040092014045.outbound.protection.outlook.com. [40.92.14.45])        by mx.google.com with ESMTPS id s11si727376pgi.324.2018.12.12.20.43.57        for <pl.kevinzluo@gmail.com>        (version=TLS1_2 cipher=ECDHE-RSA-AES128-SHA bits=128/128); Wed, 12 Dec 2018 20:43:58 -0800
+Received: from CO1NAM05FT046.eop-nam05.prod.protection.outlook.com (10.152.96.54) by CO1NAM05HT198.eop-nam05.prod.protection.outlook.com (10.152.97.144) with Microsoft SMTP Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384) id 15.20.1446.5; Thu, 13 Dec 2018 04:43:56 +0000
+Received: from DM5PR01MB2505.prod.exchangelabs.com (10.152.96.51) by CO1NAM05FT046.mail.protection.outlook.com (10.152.96.161) with Microsoft SMTP Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384) id 15.20.1446.5 via Frontend Transport; Thu, 13 Dec 2018 04:43:56 +0000
+Received: from DM5PR01MB2505.prod.exchangelabs.com ([fe80::e41f:9de1:7996:df8b]) by DM5PR01MB2505.prod.exchangelabs.com ([fe80::e41f:9de1:7996:df8b%8]) with mapi id 15.20.1425.016; Thu, 13 Dec 2018 04:43:56 +0000
+Date: Thu, 13 Dec 2018 04:43:56 +0000
+From: TestUser PublicLab <pl.usertest@outlook.com>
+To: kevinzluo PublicLab <pl.kevinzluo@gmail.com>
+Message-ID: <DM5PR01MB250561C74DF9AA49822904EBE9A00@DM5PR01MB2505.prod.exchangelabs.com>
+In-Reply-To: <DM5PR01MB25050815E0E552D30A4F375FE9A00@DM5PR01MB2505.prod.exchangelabs.com>
+References: <CALYjBRXjhyvpWB3q41tsNfp1k6p39Z_PGm5PkT0nHxrREyB+mg@mail.gmail.com>,<DM5PR01MB25050815E0E552D30A4F375FE9A00@DM5PR01MB2505.prod.exchangelabs.com>
+Subject: Re: (#a2)
+Mime-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary=_000_DM5PR01MB250561C74DF9AA49822904EBE9A00DM5PR01MB2505prod_
+Content-Transfer-Encoding: 7bit
+Delivered-To: pl.kevinzluo@gmail.com
+X-Google-Smtp-Source: AFSGD/XbSlelEPb7ACR+ykJaELls3StYILoiubB9g5SolOOvTukF3USysFNxgkl78SLYfZFdROyo
+X-Received: by 2002:a65:5a8e:: with SMTP id
+ c14mr20388452pgt.137.1544676238140;        Wed, 12 Dec 2018 20:43:58 -0800
+ (PST)
+ARC-Seal: i=1; a=rsa-sha256; t=1544676238; cv=none;        d=google.com;
+ s=arc-20160816;       
+ b=eilSWd4AfHYASN6In3kUbS3ED0FGUR/d8DNf91mkbJuA4586GQ4vU/tZPua1b48uon        
+ ygheVEnTXe9bmQCAyaaNzni599YTjLmYmfEAKfUKG0+00rRdtqKfyOdgs0JglHqNCz/o        
+ b0M+G5Qym6+p6eAqueTixaITP1z9huLYUo850eINOF5UD2YRCzvkGYPOzoeQ1gn7BaEN        
+ vtbKQLNPcLpDrPxSO8DqC5XiBa23ZYIR9//JhYNFJ+t6MEc/6AHgxxIcjgox/dkcRC8x        
+ s6aleW7zu/AGABSCRAgzJIrFdzpJ9DlZ28v6v05yME6xV8tTLLOlp3zczMlhyQT9V5Em        
+ i/Mw==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com;
+ s=arc-20160816;       
+ h=mime-version:content-language:accept-language:in-reply-to        
+ :references:message-id:date:thread-index:thread-topic:subject:to        
+ :from:dkim-signature;        bh=cSfy/P8ZFKRvny7oi3zR0YvUurm8DTZkISd1W3tk9VQ=; 
+       b=tulCgNIv+1tCGFfq9S8LRaC6ndfbOxcS7zjwaMNOMnONi3zEmTbM/RsC2yG5xwxmnK    
+     c5ftdpSAMWcs3IjBqkMOU347sirzIGdyowmrZOzoSr3Tv36cI93f+hCRdjKlPwxRGaNG      
+   iFiOdjmqMzBQ4Gvu14QiosVZqgNgb84dGEvGS1O8iB0p0tm1lDfXoslmmUe71eNesHf8        
+ 9WPd6xMAuOwCEb11NPK0HbeCH4UI/E/+jDFkHc1UHPgMUvgwRvtnlBfDEbjGVpptO6/r        
+ fmcT9umqone86POdC4rI0+WIQth1j0ikL/+IDEsY81y7eo3cyeJnn/dRbVRI1MzEhSn9        
+ 0DdA==
+ARC-Authentication-Results: i=1; mx.google.com;       dkim=pass
+ header.i=@outlook.com header.s=selector1 header.b=kWd1Mo5u;       spf=pass
+ (google.com: domain of pl.usertest@outlook.com designates 40.92.14.45 as
+ permitted sender) smtp.mailfrom=pl.usertest@outlook.com;       dmarc=pass
+ (p=NONE sp=QUARANTINE dis=NONE) header.from=outlook.com
+Received-SPF: pass (google.com: domain of pl.usertest@outlook.com designates
+ 40.92.14.45 as permitted sender) client-ip=40.92.14.45;
+Authentication-Results: mx.google.com;       dkim=pass header.i=@outlook.com
+ header.s=selector1 header.b=kWd1Mo5u;       spf=pass (google.com: domain of
+ pl.usertest@outlook.com designates 40.92.14.45 as permitted sender)
+ smtp.mailfrom=pl.usertest@outlook.com;       dmarc=pass (p=NONE sp=QUARANTINE
+ dis=NONE) header.from=outlook.com
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=outlook.com;
+ s=selector1;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck;
+ bh=cSfy/P8ZFKRvny7oi3zR0YvUurm8DTZkISd1W3tk9VQ=;
+ b=kWd1Mo5uACEutsR9Nk0Xk7/hx6qtV4d2eAZ14t3OeFMscP52JtX1pPEYNMOnRiAhuZa2G6mOyCQzMLZMhjCMAoyUziiWIrnAW6U29GKrZ0pSK0FvNlu744dLPwkwzm8/hc9fDYm7eyOdCmh4/BQu2EsA5WGTkatbXLfjLQPmHUN1MstE0n4Q6Pt+d+n44L7Z/A1XhzNDwqbu/9tN5BlbPjsxvqTraA5YUUsoOoqPemA9WgKAArkBGXctvfOIkgRrFJXW4417sTYvZQ+DnTHkGsRW2y2t/K5/sglUKbC7kJhHzJEW9S0L0Y0Rf+ByWsAo2LwF5RRLJshUSYaf6/c7cA==
+Thread-Topic: (#a2)
+Thread-Index: AQHUkp48CHugBDk6dEyMGAZg2L5bDKV8F1opgAAAR1w=
+Accept-Language: en-US
+Content-Language: en-US
+X-MS-Has-Attach: 
+X-MS-TNEF-Correlator: 
+x-incomingtopheadermarker: OriginalChecksum:AAC45E70F13F3F18E35792CDE67E01988FE2343BDD5AA11B335884CD72060C5C;UpperCasedChecksum:5BF61DCC16FF2664835455159CDDC9EF09FB08BF78D5E9DC05F5BB5B638B1549;SizeAsReceived:7152;Count:45
+x-tmn: [4Lgv8AIluPNE999K2+l1K7vwBDBLL/euF75k7smS1mK7e3y1I9ZQ/nfGQVffnB83ldRcUcAyHlA=]
+x-ms-publictraffictype: Email
+x-microsoft-exchange-diagnostics: 1;CO1NAM05HT198;6:V2mX8EaAUwNx26HRH+CDySWl28VWQ8Nq6Kb68tB+O7PGDsHvfQzKa53ibzhPKtskJdNDg8H3fo1hcE+TuDV6Qx6SydJyfLsB9YE+N3pUi5sVtLLrEwbukUJ++/DbTlE2XitSuHf5FNsCyi0a2mF8yEGCfS4NVMMRUwyZkT13XJLbZv3Ny8aM/wrFjnzXdPIiQQqQ9/X7ZKA9oLL2DU2rrIwBY2inV93vx2h1t/MqtxOCeXGQSf9v7842y5oLrc0Xb26ffX4EGjo0lnla+v5k1TvbGORiJGGMY4zoHwqcxwKidd7KrIhunO4loKWPdJyqrvL6tJR2qRg7Y0qHuCKdycV4Oi/VhEW129C+ajWQ10v+kR1zbol32rzWrAQUlw9kQKI50tbBaSfL8RGi4MQEfa7knmhXrI1xm/7iqre0bPkL3IoYmbDhdGEbki+egQdmWhsdyfG+aSJmbncXfNDE6A==;5:VjzmWHhosvTEBJHw6Bly1LkI9wld+CeGzaMVvcYWWE8wYPnj5+UBygHOQSAUgHE95AAFklrfjDIhb2fIEILfn+hRDvGoG0vwY0bKSDHlHtoIgzimXG2MbObtDvrOCF7gxemhrrsXmal8d66DYbquL8t64umlvYEuUqSCIDbRDH4=;7:H6OrUHJ710SF9XXyk7DjIrAVw0rjjQzENM8OzBO/muBNm86Id7TOci1pk/BJYfBFGMfgUov2MxdXKusMc5VoAhXHUypB1R4uqvfH1H6AlYQYMT4WS+0E0yUGJTfi1/WA6R+zGeMooOcan3jEXLswJg==
+x-incomingheadercount: 45
+x-eopattributedmessage: 0
+x-microsoft-antispam: BCL:0;PCL:0;RULEID:(2390098)(7020095)(201702061078)(5061506573)(5061507331)(1603103135)(2017031320274)(9118020)(2017031324274)(2017031323274)(2017031322404)(1603101475)(1601125500)(1701031045);SRVR:CO1NAM05HT198;
+x-ms-traffictypediagnostic: CO1NAM05HT198:
+x-exchange-antispam-report-cfa-test: BCL:0;PCL:0;RULEID:(4566010)(82015058);SRVR:CO1NAM05HT198;BCL:0;PCL:0;RULEID:;SRVR:CO1NAM05HT198;
+x-microsoft-antispam-message-info: /JOBQiGRLIDT+xZREs+zYxLffEaldzb2eqVY/w5TAd4BGyy44jB/vsC4vXOMoiY9
+X-OriginatorOrg: outlook.com
+X-MS-Exchange-CrossTenant-RMS-PersistedConsumerOrg: 24fd1209-d934-423e-a578-ee886993c07f
+X-MS-Exchange-CrossTenant-Network-Message-Id: 8a685a54-2c8a-4317-634a-08d660b597a1
+X-MS-Exchange-CrossTenant-rms-persistedconsumerorg: 24fd1209-d934-423e-a578-ee886993c07f
+X-MS-Exchange-CrossTenant-originalarrivaltime: 13 Dec 2018 04:43:56.8162 (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Internet
+X-MS-Exchange-CrossTenant-id: 84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: CO1NAM05HT198
+
+
+--_000_DM5PR01MB250561C74DF9AA49822904EBE9A00DM5PR01MB2505prod_
+Content-Type: text/plain;
+ charset=us-ascii
+Content-Transfer-Encoding: quoted-printable
+
+This is the second reply sent by the user.=0D
+________________________________=0D
+From: TestUser PublicLab=0D
+Sent: Wednesday, December 12, 2018 8:43 PM=0D
+To: kevinzluo PublicLab=0D
+Subject: Re: (#a2)=0D
+=0D
+This is the first reply sent by the user.=0D
+________________________________=0D
+From: kevinzluo PublicLab <pl.kevinzluo@gmail.com>=0D
+Sent: Wednesday, December 12, 2018 8:42 PM=0D
+To: pl.usertest@outlook.com=0D
+Subject: (#a2)=0D
+=0D
+This is the email sent to the user by PublicLab.=0D
+
+--_000_DM5PR01MB250561C74DF9AA49822904EBE9A00DM5PR01MB2505prod_
+Content-Type: text/html;
+ charset=us-ascii
+Content-Transfer-Encoding: quoted-printable
+
+<html>=0D
+<head>=0D
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dus-asci=
+i">=0D
+<style type=3D"text/css" style=3D"display:none;"> P {margin-top:0;margin-=
+bottom:0;} </style>=0D
+</head>=0D
+<body dir=3D"ltr">=0D
+<div style=3D"font-family: Calibri, Arial, Helvetica, sans-serif; font-si=
+ze: 12pt; color: rgb(0, 0, 0);">=0D
+This is the second reply sent by the user.</div>=0D
+<div id=3D"appendonsend"></div>=0D
+<hr style=3D"display:inline-block;width:98%" tabindex=3D"-1">=0D
+<div id=3D"divRplyFwdMsg" dir=3D"ltr"><font face=3D"Calibri, sans-serif" =
+style=3D"font-size:11pt" color=3D"#000000"><b>From:</b> TestUser PublicLa=
+b<br>=0D
+<b>Sent:</b> Wednesday, December 12, 2018 8:43 PM<br>=0D
+<b>To:</b> kevinzluo PublicLab<br>=0D
+<b>Subject:</b> Re: (#a2)</font>=0D
+<div>&nbsp;</div>=0D
+</div>=0D
+<style type=3D"text/css" style=3D"display:none">=0D
+<!--=0D
+p=0D
+	{margin-top:0;=0D
+	margin-bottom:0}=0D
+-->=0D
+</style>=0D
+<div dir=3D"ltr">=0D
+<div style=3D"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:1=
+2pt; color:rgb(0,0,0)">=0D
+This is the first reply sent by the user.</div>=0D
+<div id=3D"x_appendonsend"></div>=0D
+<hr tabindex=3D"-1" style=3D"display:inline-block; width:98%">=0D
+<div id=3D"x_divRplyFwdMsg" dir=3D"ltr"><font face=3D"Calibri, sans-serif=
+" color=3D"#000000" style=3D"font-size:11pt"><b>From:</b> kevinzluo Publi=
+cLab &lt;pl.kevinzluo@gmail.com&gt;<br>=0D
+<b>Sent:</b> Wednesday, December 12, 2018 8:42 PM<br>=0D
+<b>To:</b> pl.usertest@outlook.com<br>=0D
+<b>Subject:</b> (#a2)</font>=0D
+<div>&nbsp;</div>=0D
+</div>=0D
+<div>=0D
+<div dir=3D"ltr">This is the email sent to the user by PublicLab.</div>=0D=
+
+</div>=0D
+</div>=0D
+</body>=0D
+</html>=0D
+
+--_000_DM5PR01MB250561C74DF9AA49822904EBE9A00DM5PR01MB2505prod_--

--- a/test/fixtures/incoming_test_emails/outlook/incoming_outlook_email.html
+++ b/test/fixtures/incoming_test_emails/outlook/incoming_outlook_email.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=us-ascii">
+	<style type="text/css" style="display:none;">
+		P {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	</style>
+</head>
+
+<body dir="ltr">
+	<div style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);">
+		This is the second reply sent by the user.</div>
+	<div id="appendonsend"></div>
+	<hr style="display:inline-block;width:98%" tabindex="-1">
+	<div id="divRplyFwdMsg" dir="ltr">
+		<font face="Calibri, sans-serif" style="font-size:11pt" color="#000000"><b>From:</b> TestUser PublicLab<br>
+			<b>Sent:</b> Wednesday, December 12, 2018 8:43 PM<br>
+			<b>To:</b> kevinzluo PublicLab<br>
+			<b>Subject:</b> Re: (#a2)</font>
+		<div>&#160;</div>
+	</div>
+	<style type="text/css" style="display:none">
+		< !-- p {
+			margin-top: 0;
+			margin-bottom: 0
+		}
+
+		-->
+	</style>
+	<div dir="ltr">
+		<div style="font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0)">
+			This is the first reply sent by the user.</div>
+		<div id="x_appendonsend"></div>
+		<hr tabindex="-1" style="display:inline-block; width:98%">
+		<div id="x_divRplyFwdMsg" dir="ltr">
+			<font face="Calibri, sans-serif" color="#000000" style="font-size:11pt"><b>From:</b> kevinzluo PublicLab &lt;pl.kevinzluo@gmail.com&gt;<br>
+				<b>Sent:</b> Wednesday, December 12, 2018 8:42 PM<br>
+				<b>To:</b> pl.usertest@outlook.com<br>
+				<b>Subject:</b> (#a2)</font>
+			<div>&#160;</div>
+		</div>
+		<div>
+			<div dir="ltr">This is the email sent to the user by PublicLab.</div>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/test/fixtures/incoming_test_emails/outlook/readme.md
+++ b/test/fixtures/incoming_test_emails/outlook/readme.md
@@ -1,0 +1,9 @@
+This documents the various steps done to parse mail from Outlook.
+
+1.	`incoming_outlook_email.eml` is a sample incoming mail from Outlook.
+2.	`incoming_yahoo_email.html` file contains `incoming_outlook_email.eml` converted to html
+3.   Finally `final_parsed_comment.txt` contains the final parsed comment.
+
+To parse the mails coming from Outlook and to separate the main body content and trimmed content which contains conversation thread information we have used a `div` element with id `appendonsend` (`<div id="appendonsend"></div>`).
+
+As seen in `incoming_outlook_email.html`, this `div` html element separates the email body from the quoted content. So we have used Regex to retrieve these section before, which becomes the comment content, and the section after, which becomes the trimmed content.

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -236,3 +236,16 @@ user_first_time_poster:
   bio: 'user_first_time_poster'
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+kluo:
+  username: kluo
+  status: 1
+  email: pl.usertest@outlook.com
+  id: 20
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  last_request_at: <%= Time.now %>
+  bio: 'Hi. Am I missing something?'
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/integration/incoming_mail_parsing_test/outlook_parsing_test.rb
+++ b/test/integration/incoming_mail_parsing_test/outlook_parsing_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+class OutlookParsingTest < ActionDispatch::IntegrationTest
+  test 'should parse incoming mail from outlook service correctly and add answer comment' do
+    require 'mail'
+    mail = Mail.read('test/fixtures/incoming_test_emails/outlook/incoming_outlook_email.eml')
+    answer = Answer.last
+    mail.subject = "Re: (#a#{answer.id})"
+    Comment.receive_mail(mail)
+    f = File.open('test/fixtures/incoming_test_emails/outlook/final_parsed_comment.txt', 'r')
+    comment = Comment.last
+    user_email = mail.from.first
+    assert_equal comment.comment, f.read
+    assert_equal comment.aid, answer.id
+    assert_equal comment.message_id, mail.message_id
+    assert_equal comment.comment_via, 1
+    assert_equal User.find(comment.uid).email, user_email
+    f.close()
+  end
+end


### PR DESCRIPTION
Fixes #3426  (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

I have added outlook reply by email. The parsing is done using regex instead of nokogiri.
ANSWERS:
Replying once:
![showfirstoutlookrevamp](https://user-images.githubusercontent.com/44309027/49700121-2e9a3f80-fba0-11e8-8da7-b7ebce56fd1e.gif)

Replying twice:
![showsecondoutlookrevamp](https://user-images.githubusercontent.com/44309027/49700122-335ef380-fba0-11e8-8c11-0c1b790b0ee1.gif)


NOTES/QUESTIONS:
Replying Once:
![showfirstoutlooknoterevamp](https://user-images.githubusercontent.com/44309027/49700147-ad8f7800-fba0-11e8-89d6-8eb1aa9f145a.gif)

Replying Twice:
![showsecondoutlooknoterevamp](https://user-images.githubusercontent.com/44309027/49700151-b41def80-fba0-11e8-9326-4440c65328ad.gif)



* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts
* [X] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
