### PR TITLE
Linked login modal to comments and answers

### DIFF
--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -15,7 +15,8 @@
     <% if current_user %>
       <%= render :partial => "comments/form", :locals => { title: I18n.t('notes._comments.post_comment'), comment: false, placeholder: I18n.t('notes._comments.post_placeholder') } %>
     <% else %>
-    <p><%= raw t('notes._comments.must_be_logged_in', :url1 => new_user_session_path( return_to: request.path )) %></p>
+    <p><a data-toggle="modal" data-target="#loginModal">
+          <%= t('layout._header.login.login_title') %></a> to comment. </p>
     <% end %>
 
   </div>

--- a/app/views/questions/_answers.html.erb
+++ b/app/views/questions/_answers.html.erb
@@ -10,7 +10,8 @@
     <% if current_user %>
       <%= render :partial => "comments/form", :locals => { title: "Post an answer", comment: false, placeholder: "Help users by posting an answer to this question", is_answer: true } %>
     <% else %>
-    <p><%= link_to "Sign up", signup_path( return_to: request.path )%> or <%= link_to "Login", new_user_session_path( return_to: request.path )%> to post an answer to this question.</p>
+    <p><%= link_to "Sign up", signup_path( return_to: request.path )%> or <a data-toggle="modal" data-target="#loginModal">
+          <%= t('layout._header.login.login_title') %> </a> to post an answer to this question.</p>
     <% end %> 
     </div>
   </div>


### PR DESCRIPTION
Fixes #4156 and #4157 
@publiclab/reviewers Please review this one.

Comments login modal on /note

![comment on note](https://user-images.githubusercontent.com/39333058/49700261-5c17d500-fc02-11e8-89c8-929ba533ab2d.gif)

Answer login modal on /question

![answer on question](https://user-images.githubusercontent.com/39333058/49700270-6cc84b00-fc02-11e8-9c3b-fe062cfd4b12.gif)

Comment login modal on /question

![comment on question](https://user-images.githubusercontent.com/39333058/49700276-7ce02a80-fc02-11e8-8107-e1e999c4faee.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
