### PR TITLE
Question page title stays after login on questions

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -66,7 +66,7 @@
       e.preventDefault();
       $('#loginModal').modal();
       var postQuery = '/post?tags=question:general&template=question&title=' + encodeURI($('#questions_searchform_input').val()) + '&redirect=question';
-      console.log(postQuery);
+      //console.log(postQuery);
       $.getJSON(postQuery);
   });
 </script>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -31,7 +31,7 @@
           <input type="hidden" name="template" value="question">
           <input type="hidden" name="redirect" value="question">
           <span class="input-group-btn">
-            <button type="submit" rel="tooltip" title="Ask a question with the entered title" class="<%= "disabled " if !current_user %>btn btn-primary">Continue</button>
+            <button id="question_search" type="submit" rel="tooltip" title="Ask a question with the entered title" class="btn btn-primary">Continue</button>
             </span>
         </div>
       </form>
@@ -60,5 +60,15 @@
   <%= render :partial => "questions/questions" %>
 
 </div>
-
+<% if !current_user %>
+<script>
+  $('#question_search').on('click', function(e) {
+      e.preventDefault();
+      $('#loginModal').modal();
+      var postQuery = '/post?tags=question:general&template=question&title=' + encodeURI($('#questions_searchform_input').val()) + '&redirect=question';
+      console.log(postQuery);
+      $.getJSON(postQuery);
+  });
+</script>
+<% end %>
 <%= stylesheet_link_tag "dashboard" %>


### PR DESCRIPTION
Fixes #2592 

Now the user, if not logged in, can then log in and their query is preserved.

We should discuss whether or not to keep the text above the search input.

Sorry about the rambled text. I can't really show login through the modal because it is currently broken on cloud9, so I had to use a bunch of random letters to show that the page loaded is really the request I sent.

![gifquestionspreserved2](https://user-images.githubusercontent.com/44309027/49721862-e410d580-fc28-11e8-9f83-e16c0d98c9e3.gif)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!


* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts
* [X] PR is descriptively titled
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
