### PR TITLE
Compact design for dashboard comments

### DIFF
--- a/app/views/dashboard/_node_comment.html.erb
+++ b/app/views/dashboard/_node_comment.html.erb
@@ -1,24 +1,25 @@
 <div class="col-md-6 note-container-comment">
   <div class="note note-pane note-comment" data-index="<%= index %>">
 
-    <div class="header-icon"><i class="fa fa-comment-o"></i> <a href="/n/<%= node.parent.id %>"><i class="fa fa-link"></i></a></div>
+    <div class="header-icon">
+     <% if node.aid == 0 %>
+      <a href="<% if node.parent.has_power_tag('question') %><%= node.parent.path(:question) %>#anwer-0-comment<% else %><%= node.parent.path %>#comments<% end %>"> <i class="fa fa-comment-o"> <%= node.parent.comments.count %> </i> </a>
+      <% else %>
+      <a href="<%= node.parent.path(:question) %>#answer-<%= node.answer.id %>-comment"> <i class="fa fa-comment-o"> 
+      <% end %> 
+      </a>
+      <a href="/n/<%= node.parent.id %>"><i class="fa fa-link"></i></a>
+    </div>
+    
     <p class="meta">
       <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a>  <%= node.author.new_author_contributor %>
       <span><%= t('dashboard._node_comment.commented_on') %></span> <% unless node.aid == 0 %> an answer about<% end %> <% if node.parent.has_power_tag('question') %><a href="<%= node.parent.path(:question) %>"><% else %><a href="<%= node.parent.path %>"><% end %><%= node.parent.title %></a>
+      <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %>
     </p>
     <%= render partial: 'dashboard/comment_moderate', locals: { comment: node } %>
 
-    <p class="body"><%= raw strip_tags(node.body_markdown).truncate(100) %></p>
-
-    <p class="meta">
-      <% if node.aid == 0 %>
-      <a href="<% if node.parent.has_power_tag('question') %><%= node.parent.path(:question) %>#anwer-0-comment<% else %><%= node.parent.path %>#comments<% end %>" class="btn btn-default pull-right btn-xs"><%= node.parent.comments.count %>
-      <% else %>
-      <a href="<%= node.parent.path(:question) %>#answer-<%= node.answer.id %>-comment" class="btn btn-default pull-right btn-xs"><%= node.answer.comments.count %>
-      <% end %>
-      <%= t('dashboard._node_comment.comments') %> &raquo;</a>
-      <a href="/n/<%= node.parent.id %>" class="btn btn-default pull-right btn-xs"><i class="fa fa-link"></i></a>
-      <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %>
+    <p class="body"><%= raw strip_tags(node.body_markdown).truncate(100) %>
+      
     </p>
 
   </div>


### PR DESCRIPTION
Fixes #4126 
@publiclab/reviewers Please review this one.

I changed the `time of comment` location from bottom to above in the `main` line.
Also, I removed the `x comments` and `link` button in bottom bar..

Previous `comment` layout on dashboard
![screenshot 99](https://user-images.githubusercontent.com/39333058/49801383-08c39500-fd70-11e8-829d-94da17aae40c.png)

New changed layout
![screenshot 98](https://user-images.githubusercontent.com/39333058/49801392-111bd000-fd70-11e8-9667-a820bca11c79.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
