### PR TITLE
fixes #4285 Use same styles for buttons at /profile

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -203,9 +203,9 @@
   <hr />
 
   <p>
-    <a class="btn btn-default btn-sm btn-block" href="/feed/<%= @user.name %>.rss"><i class="fa fa-rss" style="color:orange;"></i> <%= t('users.profile.rss_feed_for') %> <%= @user.name %></a>
+    <a class="btn btn-default btn-block" href="/feed/<%= @user.name %>.rss"><i class="fa fa-rss" style="color:orange;"></i> <%= t('users.profile.rss_feed_for') %> <%= @user.name %></a> 
     <% if current_user && current_user.uid == @user.uid %>
-      <a href="/profile/<%= @user.name %>/edit" class="btn btn-default btn-sm btn-block"><i class="fa fa-pencil"></i> <%= t('users.profile.edit_profile') %></a>
+      <a href="/profile/<%= @user.name %>/edit" class="btn btn-default btn-block"><i class="fa fa-pencil"></i> <%= t('users.profile.edit_profile') %></a> 
     <% end %>
   </p>
 


### PR DESCRIPTION
Fixes #4285 
The buttons below tag at /profile had inconsistent styles.
![image](https://user-images.githubusercontent.com/40794215/49889495-aa79dd80-fe67-11e8-9be7-9df2d105cdd4.png)

They now have the same button class, thus removing the inconsistency.

![image](https://user-images.githubusercontent.com/40794215/49889528-bd8cad80-fe67-11e8-9650-2694f22e53bb.png)


