### PR TITLE
 'Follow' icon is the same as 'number of views' icon(4278)

### DIFF
--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <% if current_user.following("everything") %>
-      <a rel="tooltip" title="<%= t('home.subscriptions.click_unfollow') %>" class="btn btn-default active" href="/unsubscribe/tag/everything" data-method="delete"><i class="fa fa-eye"></i> <%= t('home.subscriptions.following') %> <b><%= t('home.subscriptions.research_notes') %></b></a>
+      <a rel="tooltip" title="<%= t('home.subscriptions.click_unfollow') %>" class="btn btn-default active" href="/unsubscribe/tag/everything" data-method="delete"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('home.subscriptions.following') %> <b><%= t('home.subscriptions.research_notes') %></b></a>
     <% else %>
       <a href="/subscribe/tag/everything" class="btn btn-default"><i class="fa fa-tag"></i> <%= t('home.subscriptions.subscribe_to') %> <b><%= t('home.subscriptions.all') %></b> <%= t('home.subscriptions.notes') %></a>
     <% end %>

--- a/app/views/like/_like.html.erb
+++ b/app/views/like/_like.html.erb
@@ -11,7 +11,7 @@
       <i class="fa fa-flag"></i>
     </a>
     <li rel="tooltip" title="Follow" class="btn btn-default btn-sm" data-html="true" rel="popover" data-content="<%= "No tags" if tagnames.nil? || tagnames.length == 0 %><% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-default btn-mini'><%= tagname %></a></p><% end %><% end %><hr /><i class='fa fa-user'></i><% if current_user && !current_user.following?(node.author.user) %>&nbsp;<a class='btn btn-sm' href='/relationships?followed_id=<%= node.author.id %>' data-method='post' > <%= node.author.name %></a><% else %><%= node.author.name %><% end %>" title="Follow by tag or author" data-placement="left">
-      <i class="fa fa-eye"></i>
+      <i class="fa fa-user-plus" aria-hidden="true"></i> 
     </li>
 
   <li rel="tooltip" title="Helpful? Like it and get updates!" class="btn btn-default btn-sm btn-like" node-id="<%= node.id %>" id="like-button-<%= node.id %>">

--- a/app/views/tag/_contributors.html.erb
+++ b/app/views/tag/_contributors.html.erb
@@ -23,9 +23,9 @@
     <div class="btn-group">
       <a class="btn btn-default btn-sm" href="/feed/tag/<%= params[:id] %>.rss"><i class="fa fa-rss"></i> RSS</a>
       <% if current_user.following(params[:id]) %>
-        <a rel="tooltip" title="<%= t('tag.contributors.unfollow') %>" class="btn btn-default btn-sm" href="/unsubscribe/tag/<%= params[:id] %>"><i class="fa fa-eye"></i> <%= t('tag.contributors.following') %> <b><%= params[:id] %></b></a>
+        <a rel="tooltip" title="<%= t('tag.contributors.unfollow') %>" class="btn btn-default btn-sm" href="/unsubscribe/tag/<%= params[:id] %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.contributors.following') %> <b><%= params[:id] %></b></a>
       <% else %>
-        <a class="btn btn-default btn-sm" href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-eye"></i> <%= t('tag.contributors.follow') %> <b><%= params[:id] %></b></a>
+        <a class="btn btn-default btn-sm" href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.contributors.follow') %> <b><%= params[:id] %></b></a>
       <% end %>
       <a class="btn btn-default btn-sm" rel="popover" data-placement="bottom" data-html="true" data-title="<%= t('tag.show.users_following_tag') %>" data-content="<% Tag.followers(params[:id]).each do |user| %><i class='fa fa-star-o'></i> <a href='/profile/<%= user.username %>'><%= user.username %></a><br /><% end %><% if Tag.follower_count(params[:id]) == 0 %><i><%= t('tag.show.none') %></i><% end %>"><%= Tag.follower_count(params[:id]) %> <i class="fa fa-user"></i> <span class="caret"></span></a>
     </div>

--- a/app/views/tag/blog.html.erb
+++ b/app/views/tag/blog.html.erb
@@ -15,7 +15,7 @@
       <% if current_user %>
         <a class="btn btn-default btn-sm" href="/feed/tag/<%= params[:id] %>.rss"><i class="fa fa-rss"></i> RSS</a>
         <% if current_user.following(params[:id]) %>
-        <a rel="tooltip" title="<%= t('tag.blog.unfollow') %>" class="btn btn-default btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>"><i class="fa fa-eye"></i> <%= t('tag.blog.following') %> <b><%= params[:id] %></b></a>
+        <a rel="tooltip" title="<%= t('tag.blog.unfollow') %>" class="btn btn-default btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.blog.following') %> <b><%= params[:id] %></b></a>
         <% else %>
         <br><br>
         <div class="alert alert-success" role="alert">

--- a/app/views/tag/contributors-index.html.erb
+++ b/app/views/tag/contributors-index.html.erb
@@ -45,9 +45,9 @@
       <div class="btn-group">
         <a class="btn btn-sm" href="/feed/tag/<%= tag.name %>.rss"><i class="fa fa-rss"></i> RSS</a>
         <% if current_user.following(tag.name) %>
-          <a rel="tooltip" title="<%= t('tag.contributors-index.unfollow') %>" class="btn btn-sm active" href="/unsubscribe/tag/<%= tag.name %>"><i class="fa fa-eye"></i> <%= t('tag.contributors-index.following') %> <b><%= tag.name %></b></a>
+          <a rel="tooltip" title="<%= t('tag.contributors-index.unfollow') %>" class="btn btn-sm active" href="/unsubscribe/tag/<%= tag.name %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.contributors-index.following') %> <b><%= tag.name %></b></a>
         <% else %>
-          <a class="btn btn-sm" href="/subscribe/tag/<%= tag.name %>"><i class="fa fa-eye"></i> <%= t('tag.contributors-index.follow') %> <b><%= tag.name %></b></a>
+          <a class="btn btn-sm" href="/subscribe/tag/<%= tag.name %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.contributors-index.follow') %> <b><%= tag.name %></b></a>
         <% end %>
       </div>
       <!-- AJAXify -->

--- a/app/views/tag/index.html.erb
+++ b/app/views/tag/index.html.erb
@@ -42,9 +42,9 @@
         <% if current_user %>
           <td>
              <% if current_user.following(tag.name) %>
-                <a rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="btn btn-default btn-sm active" href="/unsubscribe/tag/<%= tag.name %>"><i class="fa fa-eye"></i> <%= t('tag.show.following') %></a>
+                <a rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="btn btn-default btn-sm active" href="/unsubscribe/tag/<%= tag.name %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.show.following') %></a>
                 <% else %>
-                <a class="btn btn-default btn-sm" href="/subscribe/tag/<%= tag.name %>"><i class="fa fa-eye"></i> <%= t('tag.show.follow') %></a>
+                <a class="btn btn-default btn-sm" href="/subscribe/tag/<%= tag.name %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.show.follow') %></a>
                 <% end %>
           </td>
         <% end %>

--- a/app/views/tag/show/_user_controls.html.erb
+++ b/app/views/tag/show/_user_controls.html.erb
@@ -4,9 +4,9 @@
   <a class="btn btn-default btn-sm" href="/feed/tag/<%= params[:id] %>.rss"><i class="fa fa-rss"></i> RSS</a>
   <% unless @wildcard %>
     <% if current_user.following(params[:id]) %>
-      <a rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="btn btn-default btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>" data-method="delete"><i class="fa fa-eye"></i> <%= t('tag.show.following') %> <b><%= params[:id] %></b></a>
+      <a rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="btn btn-default btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>" data-method="delete"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.show.following') %> <b><%= params[:id] %></b></a>
     <% else %>
-      <a class="btn btn-default btn-sm" href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-eye"></i> <%= t('tag.show.follow') %> <b><%= params[:id] %></b></a>
+      <a class="btn btn-default btn-sm" href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.show.follow') %> <b><%= params[:id] %></b></a>
     <% end %>
       <a class="btn btn-default btn-sm" rel="popover" data-placement="bottom" data-html="true" data-title="<%= t('tag.show.users_following_tag') %>" data-content="<% Tag.followers(params[:id]).each do |user| %><i class='fa fa-star-o'></i> <a href='/profile/<%= user.username %>'><%= user.username %></a><br /><% end %><% if Tag.follower_count(params[:id]) == 0 %><i><%= t('tag.show.none') %></i><% end %>"><%= Tag.follower_count(params[:id]) %> <i class="fa fa-user"></i> <span class="caret"></span></a>
   <% end %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -203,9 +203,9 @@
   <hr />
 
   <p>
-    <a class="btn btn-default btn-sm btn-block" href="/feed/<%= @user.name %>.rss"><i class="fa fa-rss" style="color:orange;"></i> <%= t('users.profile.rss_feed_for') %> <%= @user.name %></a>
+    <a class="btn btn-default btn-block" href="/feed/<%= @user.name %>.rss"><i class="fa fa-rss" style="color:orange;"></i> <%= t('users.profile.rss_feed_for') %> <%= @user.name %></a> 
     <% if current_user && current_user.uid == @user.uid %>
-      <a href="/profile/<%= @user.name %>/edit" class="btn btn-default btn-sm btn-block"><i class="fa fa-pencil"></i> <%= t('users.profile.edit_profile') %></a>
+      <a href="/profile/<%= @user.name %>/edit" class="btn btn-default btn-block"><i class="fa fa-pencil"></i> <%= t('users.profile.edit_profile') %></a> 
     <% end %>
   </p>
 


### PR DESCRIPTION
Fixes #4278 

Earlier, 'Follow' icon was the same as 'number of views' icon.

![image](https://user-images.githubusercontent.com/40794215/49937299-4f45fa80-fefc-11e8-8c7a-155bb9e22c5b.png)
![image](https://user-images.githubusercontent.com/40794215/49937312-5967f900-fefc-11e8-8d97-fcfe6f508d61.png)

To avoid any confusion for the users, the 'Follow' icon has now been updated to this:

![image](https://user-images.githubusercontent.com/40794215/49937388-9207d280-fefc-11e8-84e0-ffe6e39a626f.png)

![image](https://user-images.githubusercontent.com/40794215/49937347-7ac8e500-fefc-11e8-851c-48a5d9471145.png)
