### PR TITLE
Logout will not redirect to homepage

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -162,12 +162,14 @@ class UserSessionsController < ApplicationController
     @user_session = UserSession.find
     @user_session.destroy
     flash[:notice] = I18n.t('user_sessions_controller.logged_out')
-    redirect_to '/' + '?_=' + Time.now.to_i.to_s
+    prev_uri = URI(request.referer || "").path
+    redirect_to prev_uri + '?_=' + Time.now.to_i.to_s
   end
 
   def logout_remotely
     current_user.reset_persistence_token!
     flash[:notice] = I18n.t('user_sessions_controller.logged_out')
-    redirect_to '/' + '?_=' + Time.now.to_i.to_s
+    prev_uri = URI(request.referer || "").path
+    redirect_to prev_uri + '?_=' + Time.now.to_i.to_s
   end
 end


### PR DESCRIPTION
Fixes #4259

Earlier, when the user logged out, he/she was redirected to the Home Page.

Now, logging out will redirect the user to the same page he/she was on. Although, if the user was on a page that required him/her to be logged in, on logging out, the redirection will be to the suitable page or to the login page, as specified before.

![image](https://user-images.githubusercontent.com/40794215/50134703-4d42b980-02b7-11e9-83f8-846dbc7dec0c.png)

![image](https://user-images.githubusercontent.com/40794215/50134718-5df32f80-02b7-11e9-9f29-a768340c396b.png)
