### PR TITLE
Fix(modal): fix login modal for cloud9 and unstable

### DIFF
--- a/app/views/user_sessions/_new.html.erb
+++ b/app/views/user_sessions/_new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-<%= form_for :user_session, :as => :user_session, :url => user_sessions_url + "?return_to=" + request.fullpath, :html => {:class => "form col-md-6 offset-3"} do |f| %>
+<%= form_for :user_session, :as => :user_session, :url => "user_sessions?return_to=" + request.fullpath, :html => {:class => "form col-md-6 offset-3"} do |f| %>
 
   <h2><%= raw t('user_sessions.new.log_in_or_sign_up', :url1 => "/signup") %></h2>
   <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages %></div><% end %>


### PR DESCRIPTION
Make route for login modal consistent with signup so that it works on cloud9 and unstable.

![fixloginroute](https://user-images.githubusercontent.com/44309027/50199111-a8ef6000-0314-11e9-8550-83ecb3f48db9.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
