### PR TITLE
Fixes #4244 Input fields in Login Modal.

### DIFF
--- a/app/views/layouts/_social_icons.html.erb
+++ b/app/views/layouts/_social_icons.html.erb
@@ -31,6 +31,7 @@
 	  margin-top: 20px;
 	  margin-bottom: 20px;
 	  border: 0;
+	  width: 85%;
 	  border-top: 1px solid #eee;
 	  text-align: center;
 	  height: 0px;

--- a/app/views/user_sessions/_new.html.erb
+++ b/app/views/user_sessions/_new.html.erb
@@ -15,9 +15,9 @@
   <div id="toggle" class='col-lg-11 col-md-11 col-sm-11'>
     <div class="form-group">
       <label for="username"><%= t('user_sessions.new.username') %></label>
-      <%= f.text_field :username, { tabindex: 1, class: 'form-control', id: 'username-signup' } %>
+      <%= f.text_field :username, { tabindex: 1, class: 'form-control', id: 'username-signup', style: 'width: 85%' } %>
       <label for="password"><%= t('user_sessions.new.password') %></label>
-      <%= f.password_field :password, { tabindex: 2, class: 'form-control', id: 'password-signup' } %>
+      <%= f.password_field :password, { tabindex: 2, class: 'form-control', id: 'password-signup', style: 'width: 85%' } %>
     </div>
 
     <input type="hidden" name="return_to" value="<%= params[:return_to] %>" />


### PR DESCRIPTION
Fixes #4244 

Input fields of login modal are now fixed,=. Earlier, they were extending out of the modal on resizing browser window.

![inputfields 1](https://user-images.githubusercontent.com/40794215/50402437-b1381700-07bc-11e9-8b06-422201cdc746.gif)

