### PR TITLE
Fix(modal): Use new anchor class for ask question on wiki page

### DIFF
--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -65,13 +65,7 @@
 
 <a class="grid-embed grid-embed-<%= randomSeed %>" title="Embed this table on another site."><i class="fa fa-code" style="color:#aaa;"></i></a>
 <% if type == "questions" || tagname.include?('question:') %>
-  <p id= "buttons-<%= randomSeed %>"><a href='/post?tags=question:<%= tagname %>,<%= tagname %>&template=question&title=How%20do%20I...&redirect=question' class='btn btn-primary add-activity'>Ask a question</a> &nbsp;or <a href='/subscribe/tag/question:<%= tagname %>'>help answer future questions<span class='hidden-sm hidden-xs'> on this topic</span></a></p>
-  <script>
-    $(document).ready(function() {      
-      var href = '/post?tags=question:<%= tagname %>,<%= tagname %>&template=question&title=How%20do%20I...&redirect=question';
-      gridLinkModal('#buttons-<%= randomSeed %>', href);
-    });
-  </script>
+  <p><a href='/post?tags=question:<%= tagname %>,<%= tagname %>&template=question&title=How%20do%20I...&redirect=question' class='btn btn-primary add-activity requireLogin'>Ask a question</a> &nbsp;or <a href='/subscribe/tag/question:<%= tagname %>'>help answer future questions<span class='hidden-sm hidden-xs'> on this topic</span></a></p>
 <% elsif type == "activity" || tagname.include?('activity:') %>
   <p id = "buttons-<%= randomSeed %>"><a href='/post?tags=activity:<%= tagname %>,<%= tagname %>,seeks:replications&title=How%20to%20do%20X' class='btn btn-primary add-activity'>Add an activity</a> &nbsp;or <a href='/post?tags=<%= tagname %>,question:<%= tagname %>,request:activity&template=question&title=How%20do%20I...&redirect=question' class='request-activity'>request an activity<span class='hidden-xs hidden-sm'> guide you don't see listed</span></a></p>
   <p><i>Activities should include a materials list, costs and a step-by-step guide to construction with photos. Learn what <a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity">makes a good activity here</a>.</i>


### PR DESCRIPTION
Fixes #4230  (<=== Add issue number here)

Replaces the changes in #4239 using the new anchor class.

Basic flow:
![askaquestionwikipage](https://user-images.githubusercontent.com/44309027/50428993-443a8500-0881-11e9-86d0-d13dc2bdb6f3.gif)

Alternate Flow:
![askaquestionwikipage2](https://user-images.githubusercontent.com/44309027/50428997-4b619300-0881-11e9-89a2-3a4c8acf6c82.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] PR is descriptively titled 📑
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
