### PR TITLE
Fix(modal): Use new anchor class for activity on wiki pages. Remove obsolete gridLinkModal.

### DIFF
--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -73,7 +73,7 @@
     });
   </script>
 <% elsif type == "activity" || tagname.include?('activity:') %>
-  <p id = "buttons-<%= randomSeed %>"><a href='/post?tags=activity:<%= tagname %>,<%= tagname %>,seeks:replications&title=How%20to%20do%20X' class='btn btn-primary add-activity'>Add an activity</a> &nbsp;or <a href='/post?tags=<%= tagname %>,question:<%= tagname %>,request:activity&template=question&title=How%20do%20I...&redirect=question' class='request-activity'>request an activity<span class='hidden-xs hidden-sm'> guide you don't see listed</span></a></p>
+  <p><a href='/post?tags=activity:<%= tagname %>,<%= tagname %>,seeks:replications&title=How%20to%20do%20X' class='btn btn-primary add-activity requireLogin'>Add an activity</a> &nbsp;or <a href='/post?tags=<%= tagname %>,question:<%= tagname %>,request:activity&template=question&title=How%20do%20I...&redirect=question' class='request-activity requireLogin'>request an activity<span class='hidden-xs hidden-sm'> guide you don't see listed</span></a></p>
   <p><i>Activities should include a materials list, costs and a step-by-step guide to construction with photos. Learn what <a href="https://publiclab.org/notes/warren/09-17-2016/what-makes-a-good-activity">makes a good activity here</a>.</i>
   </p>
 <% end %>
@@ -101,22 +101,6 @@
   });
   //setupGridSorters(".<%= className %>-<%= randomSeed %>"); Should order the items by time. Commented out because it reorders the items each time show more/less is clicked
 })()
-
-function gridLinkModal(selector, href) {
-  var current_user = $('ul.nav.navbar-nav.navbar-right').children('li:nth-of-type(2)').text().trim() !== "Login"
-  if(!current_user) {
-    
-    var anchor = $(selector).find('a[href="' + href + '"]');
-    anchor.attr({
-      'href': '',
-      'data-toggle': 'modal',
-      'data-target': '#loginModal'
-    });
-    anchor.on('click', function() {
-      $.getJSON(href);
-    });
-  }
-}
 </script>
 <style>
   a.grid-embed {


### PR DESCRIPTION
Fixes #4161, Fixes #4229

Merry Christmas everyone.

Redoing #4228 with the new anchor class. Using new anchor class for add and request activity. Removes obsolete method I wrote before.

Basic Flow for Add Activity:
![addactivity1](https://user-images.githubusercontent.com/44309027/50429206-9b8d2500-0882-11e9-80c5-c4304e2c3576.gif)

Alt Flow for Add Activity:
![addactivity2](https://user-images.githubusercontent.com/44309027/50429210-a1830600-0882-11e9-9293-7710c4759e99.gif)

Basic Flow for Request Activity:
![requestactivity1](https://user-images.githubusercontent.com/44309027/50429213-a6e05080-0882-11e9-8605-5fd4a32cd0d2.gif)

Alt Flow for Request Activity:
![requestactivity2](https://user-images.githubusercontent.com/44309027/50429216-aba50480-0882-11e9-8cad-54a4d5bc51e0.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] PR is descriptively titled 📑
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
