### PR TITLE
Fix(Blurred Location Input): Only show blurred location modal

### DIFF
--- a/app/views/locations/_modal.html.erb
+++ b/app/views/locations/_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal" tabindex="-1" role="dialog">
+<div class="modal fade" id="blurred-location-modal" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/views/tag/_location.html.erb
+++ b/app/views/tag/_location.html.erb
@@ -4,6 +4,7 @@
 <script>
   jQuery(document).ready(function() {
     $('.blurred-location-input').click(function createBlurredLocationInput() {
+      $(this).attr("disabled", "disabled");
       <% if params[:action] == "profile" %>
         $.ajax('/locations/modal?reload=true')
       <% else %>
@@ -11,8 +12,9 @@
       <% end %>
        .done(function(response) {
          $('.blurred-location-container').html(response);
-         $('.modal').on('shown.bs.modal', function () { blurredLocation.map.invalidateSize(); });
-         $('.modal').modal();
+         $('#blurred-location-modal').on('shown.bs.modal', function () { blurredLocation.map.invalidateSize(); });
+         $('#blurred-location-modal').on('hide.bs.modal', function() {$('.blurred-location-input').removeAttr('disabled');});
+         $('#blurred-location-modal').modal();
        });
     });
   });


### PR DESCRIPTION
Fixes #4348 
Assigned ID to the blurred location modal. Also added fade

![blurredlocation](https://user-images.githubusercontent.com/44309027/50447677-79c38a80-08e2-11e9-8f38-41cc70b901ff.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] PR is descriptively titled 📑
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
