### PR TITLE
Fixes #4405 Link Modal to Empty Notes Grid Message

### DIFF
--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -21,7 +21,7 @@
   </tr>
 <% if nodes.empty? %>
   <tr>
-    <td>Nothing yet on the topic "<b><a href="/tag/<%= tagname %>"><%= tagname %></a></b>" -- be the first to <a href="/post?tags=<%= tagname %>">post something</a>!</td>
+    <td>Nothing yet on the topic "<b><a href="/tag/<%= tagname %>"><%= tagname %></a></b>" -- be the first to <a href="/post?tags=<%= tagname %>" class="requireLogin">post something</a>!</td>
     <td></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
Added the class `requireLogin` to the anchor tag

Fixes #4405  