### PR TITLE
Fixes #4281 Link to social media button doesn't work

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -217,7 +217,7 @@
     <button data-toggle="modal" data-target="#socialModal" class="btn btn-default btn-block">Link Social media</button>
     <div class="modal fade" id="socialModal" tabindex="-1" role="dialog" aria-labelledby="socialModal" aria-hidden="true">
       <div class="modal-dialog" role="document">
-        <div class="modal-content">
+        <div class="modal-content" style="opacity: 1">
           <div class="modal-header">
             <h5 class="modal-title" id="socialModal">Link Social media</h5>
           </div>


### PR DESCRIPTION
Fixes #4281 

On clicking "Link Social Media" on profile page for users:

![image](https://user-images.githubusercontent.com/40794215/50486228-fd829180-0a1e-11e9-99b3-51c73c01e17c.png)

