### PR TITLE
Fixes #4422 Login modal not working at /profile page

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -181,7 +181,7 @@
 <!-- Login/Signup Modal -->
 <div class="modal fade" id="loginModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog" role="document">
-    <div class="modal-content">
+    <div class="modal-content" style="opacity: 1">
       <div class="modal-body">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <!-- close button -->
           <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
Fixes #4422

On clicking on login button in navbar in /profile page (this page can be viewd to logged out user if he logged out from /profile page only) 

![image](https://user-images.githubusercontent.com/40794215/50515923-9e2f8a80-0acd-11e9-836c-e585ea7fd8ce.png)
