### PR TITLE
Fix(Signup Modal): Link signup modal at questions-answers

### DIFF
--- a/app/views/questions/_answers.html.erb
+++ b/app/views/questions/_answers.html.erb
@@ -10,7 +10,7 @@
     <% if current_user %>
       <%= render :partial => "comments/form", :locals => { title: "Post an answer", comment: false, placeholder: "Help users by posting an answer to this question", is_answer: true } %>
     <% else %>
-    <p><%= link_to "Sign up", signup_path( return_to: request.path )%> or <a data-toggle="modal" data-target="#loginModal"> <%= t('layout._header.login.login_title') %> </a> to post an answer to this question.</p>
+    <p><a data-toggle="modal" data-target="#loginModal" onclick="setMode('signup')">Sign up</a> or <a data-toggle="modal" data-target="#loginModal"> <%= t('layout._header.login.login_title') %> </a> to post an answer to this question.</p>
     <% end %> 
     </div>
   </div>


### PR DESCRIPTION
Fixes #4415  (<=== Add issue number here)

Linked to Signup at Question-answers
Basic Flow:
![linktosignupbasic](https://user-images.githubusercontent.com/44309027/50541902-3f255080-0b75-11e9-9ad8-d4b38cf566d2.gif)

Alt Flow:
![linktosignupalt](https://user-images.githubusercontent.com/44309027/50541903-48162200-0b75-11e9-9ac1-dea2d7d820c9.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] PR is descriptively titled 📑
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
