### PR TITLE
Adapt requireLogin for signup

### DIFF
--- a/app/views/questions/_answers.html.erb
+++ b/app/views/questions/_answers.html.erb
@@ -10,7 +10,7 @@
     <% if current_user %>
       <%= render :partial => "comments/form", :locals => { title: "Post an answer", comment: false, placeholder: "Help users by posting an answer to this question", is_answer: true } %>
     <% else %>
-    <p><a data-toggle="modal" data-target="#loginModal" onclick="setMode('signup')">Sign up</a> or <a data-toggle="modal" data-target="#loginModal"> <%= t('layout._header.login.login_title') %> </a> to post an answer to this question.</p>
+    <p><a class="requireLogin" data-mode="signup">Sign up</a> or <a data-toggle="modal" data-target="#loginModal"> <%= t('layout._header.login.login_title') %> </a> to post an answer to this question.</p>
     <% end %> 
     </div>
   </div>

--- a/app/views/user_sessions/_new.html.erb
+++ b/app/views/user_sessions/_new.html.erb
@@ -43,8 +43,9 @@
         $(document).ready(function() { 
           $('a.requireLogin').click(function(e) { //For every link that should require login
             e.preventDefault(); //Prevent automatically redirecting to the link specified by href
-            setMode("login"); //Sets the mode of the modal to login, to show only the login partial
-            $('#loginModal').modal();//Open the login modal to allow user to login
+            var mode = $(this).data('mode') || 'login';
+            setMode(mode); //Sets the mode of the modal to login if data-mode not specified
+            $('#loginModal').modal('show');//Open the login modal to allow user to login
             $.getJSON($(this).attr('href'));
              /*send a request for the site the href specified, 
              Because login modal uses request.fullpath as part of its 


### PR DESCRIPTION
requireLogin now can take a data-mode parameter to open signup modal instead. Will allow us to redo #4451 more easily.

`<a data-toggle="modal" data-target="#loginModal" onclick="setMode('signup')">Sign up</a>`
can become 
`<a class="requireLogin" data-mode="signup">Sign up</a>`

This is backwards compatible with previous fixes.
Example fix:
![examplefix](https://user-images.githubusercontent.com/44309027/50542158-ec9b6280-0b7b-11e9-8e43-3ce16f93be1c.gif)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
