### PR TITLE
Change nearby nodes logic (/api/srch/nearbyPeople)

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -228,7 +228,7 @@ module Srch
                                                                                             nickname: 'search_tag_locations'
 
       params do
-        use :geographical
+        use :geographical, :additional
       end
       get :taglocations do
         search_request = SearchRequest.fromRequest(params)
@@ -259,7 +259,7 @@ module Srch
                                                                        is_array: false,
                                                                        nickname: 'search_nearby_people'
       params do
-        use :common, :sorting, :additional
+        use :geographical, :sorting, :additional
       end
       get :nearbyPeople do
         search_request = SearchRequest.fromRequest(params)

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -25,7 +25,7 @@ class ExecuteSearch
      when :taglocations
        sservice.tagNearbyNodes(search_criteria.coordinates, search_criteria.tag, search_criteria.limit)
      when :nearbyPeople
-       sservice.tagNearbyPeople(search_criteria.query, search_criteria.tag, search_criteria.sort_by, search_criteria.limit)
+       sservice.tagNearbyPeople(search_criteria.coordinates, search_criteria.tag, search_criteria.sort_by, search_criteria.limit)
      else
        sresult = []
      end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -153,7 +153,6 @@ class SearchService
       .where('user_tags.value LIKE ?', 'lon%')
       .where('REPLACE(user_tags.value, "lon:", "") BETWEEN ' + coordinates["nwlng"].to_s + ' AND ' + coordinates["selng"].to_s)
 
-
     # selects the items whose node_tags don't have the location:blurred tag
     items.select do |item|
       item.user_tags.none? do |user_tag|

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -123,14 +123,16 @@ class SearchApiTest < ActiveSupport::TestCase
   end
 
   test 'search Tag Nearby People functionality' do
-    get '/api/srch/nearbyPeople?query=31.00,40.00'
+    get '/api/srch/nearbyPeople?nwlat=31.0&selat=0.0&nwlng=0.0&selng=40.0'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
-            query: '31.00,40.00',
-            seq: nil
+            nwlat: 31.0,
+            nwlng: 0.0,
+            selat: 0.0,
+            selng: 40.0
         }.ignore_extra_keys!
     }.ignore_extra_keys!
 
@@ -145,14 +147,16 @@ class SearchApiTest < ActiveSupport::TestCase
   end
 
   test 'search Tag Nearby People functionality wth sort_by=recent' do
-    get '/api/srch/nearbyPeople?query=31.00,40.00&sort_by=recent'
+    get '/api/srch/nearbyPeople?nwlat=31.0&selat=0.0&nwlng=0.0&selng=40.0&sort_by=recent'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
-            query: '31.00,40.00',
-            seq: nil
+          nwlat: 31.0,
+          nwlng: 0.0,
+          selat: 0.0,
+          selng: 40.0,
         }.ignore_extra_keys!
     }.ignore_extra_keys!
 
@@ -163,19 +167,24 @@ class SearchApiTest < ActiveSupport::TestCase
     assert_equal "/profile/steff2",     json['items'][0]['doc_url']
     assert_equal "/profile/steff3",     json['items'][1]['doc_url']
 
+    puts matcher.inspect
+    puts json.inspect
+
     assert matcher =~ json
   end
 
   test 'search Tag Nearby People functionality with tag=awesome' do
-    get '/api/srch/nearbyPeople?query=31.00,40.00&tag=awesome'
+    get '/api/srch/nearbyPeople?nwlat=31.0&selat=0.0&nwlng=0.0&selng=40.0&tag=awesome'
     assert last_response.ok?
 
     # Expected search pattern
     pattern = {
         srchParams: {
-            query: '31.00,40.00',
-            tag: 'awesome',
-            seq: nil
+          nwlat: 31.0,
+          nwlng: 0.0,
+          selat: 0.0,
+          selng: 40.0,
+          tag: 'awesome'
         }.ignore_extra_keys!
     }.ignore_extra_keys!
 

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -167,9 +167,6 @@ class SearchApiTest < ActiveSupport::TestCase
     assert_equal "/profile/steff2",     json['items'][0]['doc_url']
     assert_equal "/profile/steff3",     json['items'][1]['doc_url']
 
-    puts matcher.inspect
-    puts json.inspect
-
     assert matcher =~ json
   end
 


### PR DESCRIPTION
Fixes #4037

Bounding rectangle logic (from #4128) for people location endpoint (/api/srch/nearbyPeople).