### PR TITLE
Deleting lat/lon values from node table

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -342,6 +342,15 @@ class TagController < ApplicationController
     # only admins, mods, and tag authors can delete other peoples' tags
     if node_tag.uid == current_user.uid || current_user.role == 'admin' || current_user.role == 'moderator' || node.uid == current_user.uid
 
+      tagname = Tag.joins(:node_tag)
+                   .select('term_data.name')
+                   .where(tid: params[:tid])
+                   .first
+
+      if (tagname.name.split(':')[0] == "lat") || (tagname.name.split(':')[0] == "lon")
+        node.delete_coord(tagname.name)
+      end
+
       node_tag.delete
       respond_with do |format|
         format.html do

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -777,6 +777,15 @@ class Node < ActiveRecord::Base
     end
   end
 
+  def delete_coord(tagname)
+    if (tagname.split(':')[0] == "lat")
+      table_updated = update_attributes(:latitude => nil, :precision => nil)
+    else
+      table_updated = update_attributes(:longitude => nil)
+    end
+    return table_updated
+  end
+
   def mentioned_users
     usernames = body.scan(Callouts.const_get(:FINDER))
     User.where(username: usernames.map { |m| m[1] }).uniq


### PR DESCRIPTION
Fixes #4183

Synchronize deletion between the two means of storing lat/lon