### PR TITLE
[WIP] Adding sorting and ordering options to nearby people/nodes

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -228,7 +228,7 @@ module Srch
                                                                                             nickname: 'search_tag_locations'
 
       params do
-        use :geographical, :additional
+        use :geographical, :additional, :sorting, :ordering
       end
       get :taglocations do
         search_request = SearchRequest.fromRequest(params)
@@ -259,7 +259,7 @@ module Srch
                                                                        is_array: false,
                                                                        nickname: 'search_nearby_people'
       params do
-        use :geographical, :sorting, :additional
+        use :geographical, :additional, :sorting, :ordering
       end
       get :nearbyPeople do
         search_request = SearchRequest.fromRequest(params)

--- a/app/api/srch/shared_params.rb
+++ b/app/api/srch/shared_params.rb
@@ -21,7 +21,7 @@ module Srch
     end
 
     params :ordering do
-      optional :order_direction, type: String, documentation: { example: 'desc' }
+      optional :order_direction, type: String, documentation: { example: 'DESC' }
     end
 
     params :sorting do

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -23,9 +23,9 @@ class ExecuteSearch
      when :peoplelocations
        sservice.people_locations(search_criteria.query, search_criteria.tag)
      when :taglocations
-       sservice.tagNearbyNodes(search_criteria.coordinates, search_criteria.tag, search_criteria.limit)
+       sservice.tagNearbyNodes(search_criteria.coordinates, search_criteria.tag, search_criteria.limit, search_criteria.sort_by, search_criteria.order_direction)
      when :nearbyPeople
-       sservice.tagNearbyPeople(search_criteria.coordinates, search_criteria.tag, search_criteria.sort_by, search_criteria.limit)
+       sservice.tagNearbyPeople(search_criteria.coordinates, search_criteria.tag, search_criteria.sort_by, search_criteria.order_direction, search_criteria.limit)
      else
        sresult = []
      end

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -23,7 +23,7 @@ class ExecuteSearch
      when :peoplelocations
        sservice.people_locations(search_criteria.query, search_criteria.tag)
      when :taglocations
-       sservice.tagNearbyNodes(search_criteria.coordinates, search_criteria.tag, search_criteria.limit, search_criteria.sort_by, search_criteria.order_direction)
+       sservice.tagNearbyNodes(search_criteria.coordinates, search_criteria.tag, search_criteria.sort_by, search_criteria.order_direction, search_criteria.limit)
      when :nearbyPeople
        sservice.tagNearbyPeople(search_criteria.coordinates, search_criteria.tag, search_criteria.sort_by, search_criteria.order_direction, search_criteria.limit)
      else

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -81,7 +81,7 @@ class SearchService
   end
 
   # Search nearby nodes with respect to given latitude, longitute and tags
-  def tagNearbyNodes(coordinates, tag, sort_by, order_direction, limit = 10)
+  def tagNearbyNodes(coordinates, tag, sort_by = nil, order_direction = nil, limit = 10)
     raise("Must contain all four coordinates") if coordinates["nwlat"].nil?
     raise("Must contain all four coordinates") if coordinates["nwlng"].nil?
     raise("Must contain all four coordinates") if coordinates["selat"].nil?
@@ -129,7 +129,7 @@ class SearchService
 
   # Search nearby people with respect to given latitude, longitute and tags
   # and package up as a DocResult
-  def tagNearbyPeople(coordinates, tag, sort_by, order_direction, limit = 10)
+  def tagNearbyPeople(coordinates, tag, sort_by = nil, order_direction = nil, limit = 10)
     raise("Must contain all four coordinates") if coordinates["nwlat"].nil?
     raise("Must contain all four coordinates") if coordinates["nwlng"].nil?
     raise("Must contain all four coordinates") if coordinates["selat"].nil?

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -81,7 +81,7 @@ class SearchService
   end
 
   # Search nearby nodes with respect to given latitude, longitute and tags
-  def tagNearbyNodes(coordinates, tag, limit = 10, sort_by, order_direction)
+  def tagNearbyNodes(coordinates, tag, sort_by, order_direction, limit = 10)
     raise("Must contain all four coordinates") if coordinates["nwlat"].nil?
     raise("Must contain all four coordinates") if coordinates["nwlng"].nil?
     raise("Must contain all four coordinates") if coordinates["selat"].nil?
@@ -175,10 +175,10 @@ class SearchService
             else if sort_by == "content"
               ids = items.collect(&:id).uniq || []
               User.select('`rusers`.*, count(`node`.uid) AS ord')
-                .joins(:node)
-                .where('rusers.id IN (?)', ids)
-                .group('`node`.`uid`')
-                .order("ord #{order_direction}")
+                  .joins(:node)
+                  .where('rusers.id IN (?)', ids)
+                  .group('`node`.`uid`')
+                  .order("ord #{order_direction}")
             else
               items.order("created_at #{order_direction}")
                    .limit(limit)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -168,21 +168,22 @@ class SearchService
     end
 
     # sort users by their recent activities if the sort_by==recent
-    items = if sort_by == "recent"
-              items.joins(:revisions).where("node_revisions.status = 1")\
-                   .order("node_revisions.timestamp #{order_direction}")
-                   .distinct
-            else if sort_by == "content"
-              ids = items.collect(&:id).uniq || []
-              User.select('`rusers`.*, count(`node`.uid) AS ord')
-                  .joins(:node)
-                  .where('rusers.id IN (?)', ids)
-                  .group('`node`.`uid`')
-                  .order("ord #{order_direction}")
-            else
-              items.order("created_at #{order_direction}")
-                   .limit(limit)
-            end
+    items =
+      if sort_by == "recent"
+        items.joins(:revisions).where("node_revisions.status = 1")\
+             .order("node_revisions.timestamp #{order_direction}")
+             .distinct
+      else if sort_by == "content"
+        ids = items.collect(&:id).uniq || []
+        User.select('`rusers`.*, count(`node`.uid) AS ord')
+            .joins(:node)
+            .where('rusers.id IN (?)', ids)
+            .group('`node`.`uid`')
+            .order("ord #{order_direction}")
+      else
+        items.order("created_at #{order_direction}")
+              .limit(limit)
+      end
     end
   end
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -94,6 +94,11 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   `tag=[string]`: the search can be refined by passing a tag field.
 
+  `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
+
+  `sort_by=[string]`: It accepts `recent`. It sorts the nodes by the most recent activity. If no value
+     provided, the results are then sorted by node creation (desc).
+
 ### NearbyPeople:
 
 * **URL**:  `https://publiclab.org/api/srch/nearbyPeople?nwlat=200.0&selat=0.0&nwlng=0.0&selng=200.0`
@@ -106,6 +111,10 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
   **Optional:**
 
   `tag=[string]`: the search can be refined by passing a tag field.
+
+  `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
+
+  `sort_by=[string]`: It accepts `recent` and `content`. Sort the profiles by the most recent activity or most nodes created. If no value provided, the results are then sorted by signup date (desc).
 
 ### PeopleLocations
 

--- a/test/functional/api/search_api_test.rb
+++ b/test/functional/api/search_api_test.rb
@@ -140,8 +140,8 @@ class SearchApiTest < ActiveSupport::TestCase
 
     json = JSON.parse(last_response.body)
 
-    assert_equal "/profile/steff3",     json['items'][0]['doc_url']
-    assert_equal "/profile/steff2",     json['items'][1]['doc_url']
+    assert_equal "/profile/steff2",     json['items'][0]['doc_url']
+    assert_equal "/profile/steff3",     json['items'][1]['doc_url']
 
     assert matcher =~ json
   end


### PR DESCRIPTION
Fixes #4558 

Adding options to `/api/srch/taglocations`:
- `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
- `sort_by=[string]`: It accepts `recent`. It sorts the profiles by the most recent activity. If no value
   provided, the results are then sorted by node creation (desc).

Adding options to `/api/srch/nearbyPeople`:
- `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
- `sort_by=[string]`: It accepts `recent` and `content`. Sort the profiles by the most recent activity or most nodes created. If no value provided, the results are then sorted by signup date (desc).