### PR TITLE
Test correction for PR #4599 which is failing travis builds

### DIFF
--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -284,9 +284,8 @@ class UserTest < ActiveSupport::TestCase
 
   test 'username should not be updated' do
     user = users(:bob)
-    UserSession.create(user)
     user.username = 'newval'
-    user.save
+    user.save!
     user.reload
     assert_equal user.username, 'Bob'
     assert_raises ActiveRecord::ActiveRecordError do


### PR DESCRIPTION
Fixes #4599  

The test added in PR #4599 was trying to create a user session without activating the Authlogic. The test passed through travis and so I merged the PR but after the merging of code, the builds were showing the below error, which should be shown in PR build #4599 but wasn't shown. So, this PR is attempt to correct the test added in that PR.
 
```ruby
You must activate the Authlogic::Session::Base.controller with a controller object before creating objects
```

Sorry for the inconvenience to all! 