### PR TITLE
Fixing minor css changes in multitag subscription button

### DIFF
--- a/app/views/tag/_subscribe_button.html.erb
+++ b/app/views/tag/_subscribe_button.html.erb
@@ -7,10 +7,8 @@
 <style>
   .sub{
     border-radius: 5px;
-    margin-left: 20px;
     margin-bottom: 12px;
     padding: 5px;
-    padding-right: 10px;
   }
 
 </style>

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -1,6 +1,6 @@
 <!-- This is the sidebar tagging display, also renders Subscribe button for multiple subscription -->
 <div>
-  <h1 style="display: inline-block;">Tags</h1>
+  <h1 style="display: inline-block; margin-right: 20px;">Tags</h1>
   <% if @node && !@node.node_tags.empty? && ((current_user && @node.liked_by(current_user.uid)) || !current_user) %>
     <%= render partial: 'tag/subscribe_button', locals:{tags: @node.node_tags} %>
   <% end %>


### PR DESCRIPTION
Fixes #4647 

Making the button more independent of default CSS.

![image](https://user-images.githubusercontent.com/40794215/51343902-770d1d00-1abd-11e9-871c-a6efbae8f313.png)

