### PR TITLE
Adding multitag-subscribe button to blog page

### DIFF
--- a/app/views/tag/blog.html.erb
+++ b/app/views/tag/blog.html.erb
@@ -60,7 +60,7 @@
             <% end %>
           </small></p>
           <p><%= raw auto_link(insert_extras(node.latest.render_body), :sanitize => false) %></p>
-          <p><a href="<%= node.path %>"><%= t('tag.blog.read_more') %> &raquo;</a></p>
+          <p><a href="<%= node.path %>"><%= t('tag.blog.read_more') %> &raquo;</a><%= render partial: 'tag/subscribe_button', locals:{tags: node.tags} %></p>
           <p>
             <%= render :partial => "like/like", :locals => {:node => node, :tagnames => node.tags.collect(&:name) } %>
             <% node.tags[0..3].each do |tag| %>


### PR DESCRIPTION
Fixes part of #4131

Adding multitag-subscribe button to blog page:

![image](https://user-images.githubusercontent.com/40794215/51348573-1552b000-1ac9-11e9-993f-af58b4b9c8d5.png)

![image](https://user-images.githubusercontent.com/40794215/51348588-1daaeb00-1ac9-11e9-98e8-e0f1b5a3d8f1.png)

