### PR TITLE
[WIP] Adding user.watching_location() method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -383,8 +383,7 @@ class User < ActiveRecord::Base
     self.username = registration['nickname'] if username.blank?
   end
 
-  def self.watching_location(nwlat,selat,nwlng,selng)
-
+  def self.watching_location( nwlat, selat, nwlng, selng)
     raise("Must contain all four coordinates") if nwlat.nil?
     raise("Must contain all four coordinates") if nwlng.nil?
     raise("Must contain all four coordinates") if selat.nil?
@@ -399,7 +398,6 @@ class User < ActiveRecord::Base
     uids = TagSelection.where('tag_selections.tid IN (?)', tids).collect(&:user_id).uniq || []
 
     User.where("id IN (?)", uids)
-
   end
 
   def self.find_by_username_case_insensitive(username)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ActiveRecord::Base
   has_many :images, foreign_key: :uid
   has_many :node, foreign_key: 'uid'
   has_many :node_selections, foreign_key: :user_id
-  has_many :tag_selections, foreign_key: :user_id
+  has_many :revision, foreign_key: 'uid'
   has_many :user_tags, foreign_key: 'uid', dependent: :destroy
   has_many :active_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -383,7 +383,7 @@ class User < ActiveRecord::Base
     self.username = registration['nickname'] if username.blank?
   end
 
-  def self.watching_location( nwlat, selat, nwlng, selng)
+  def self.watching_location(nwlat, selat, nwlng, selng)
     raise("Must contain all four coordinates") if nwlat.nil?
     raise("Must contain all four coordinates") if nwlng.nil?
     raise("Must contain all four coordinates") if selat.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -384,20 +384,12 @@ class User < ActiveRecord::Base
   end
 
   def self.watching_location(nwlat, selat, nwlng, selng)
-    raise("Must contain all four coordinates") if nwlat.nil?
-    raise("Must contain all four coordinates") if nwlng.nil?
-    raise("Must contain all four coordinates") if selat.nil?
-    raise("Must contain all four coordinates") if selng.nil?
-
-    raise("Must be a float") unless nwlat.is_a? Float
-    raise("Must be a float") unless nwlng.is_a? Float
-    raise("Must be a float") unless selat.is_a? Float
-    raise("Must be a float") unless selng.is_a? Float
+    raise("Must be a float") unless (nwlat.is_a? Float) && (nwlng.is_a? Float) && (selat.is_a? Float) && (selng.is_a? Float)
 
     tids = Tag.where("SUBSTRING_INDEX(term_data.name,':',1) = ? AND SUBSTRING_INDEX(SUBSTRING_INDEX(term_data.name, ':', 2),':',-1)+0 <= ? AND SUBSTRING_INDEX(SUBSTRING_INDEX(term_data.name, ':', 3),':',-1)+0 <= ? AND SUBSTRING_INDEX(SUBSTRING_INDEX(term_data.name, ':', 4),':',-1)+0 <= ? AND SUBSTRING_INDEX(term_data.name, ':', -1) <= ?", 'subscribed', nwlat, nwlng, selat, selng).collect(&:tid).uniq || []
     uids = TagSelection.where('tag_selections.tid IN (?)', tids).collect(&:user_id).uniq || []
 
-    User.where("id IN (?)", uids)
+    User.where("id IN (?)", uids).order(:id)
   end
 
   def self.find_by_username_case_insensitive(username)

--- a/test/fixtures/tag_selections.yml
+++ b/test/fixtures/tag_selections.yml
@@ -72,3 +72,13 @@ selection_eleven:
   user_id: 10
   tid: 20
   following: true
+
+SubLatitudeLongitude:
+  user_id: 16
+  tid: 22
+  following: true
+
+SubLatitudeLongitude2:
+  user_id: 17
+  tid: 25
+  following: true

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -86,7 +86,7 @@ kites:
 
 SubLatitudeLongitude:
   tid: 22
-  name: subscribed:202.0:0.0:0.0:200.0
+  name: subscribed:80.0:2.123456:0.0:72.0
 
 latitude:
   tid: 23
@@ -98,7 +98,7 @@ longitude:
 
 SubLatitudeLongitude2:
   tid: 25
-  name: subscribed:302.0:0.0:0.0:200.0
+  name: subscribed:98.0:0.0:0.0:-14.0
 
 balloon:
   tid: 26

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -84,9 +84,9 @@ kites:
   tid: 21
   name: kites
 
-balloon:
-  tid: 25
-  name: balloon
+SubLatitudeLongitude:
+  tid: 22
+  name: subscribed:202.0:0.0:0.0:200.0
 
 latitude:
   tid: 23
@@ -95,3 +95,11 @@ latitude:
 longitude:
   tid: 24
   name: lon:52.0
+
+SubLatitudeLongitude2:
+  tid: 25
+  name: subscribed:302.0:0.0:0.0:200.0
+
+balloon:
+  tid: 26
+  name: balloon

--- a/test/unit/subscription_location_test.rb
+++ b/test/unit/subscription_location_test.rb
@@ -3,10 +3,45 @@ require 'test_helper'
 class SubscriptionLocationTest < ActionMailer::TestCase
   test 'return collection of User records subscribed to a area inside nwlat/selat/nwlng/selng' do
 
-    response_user = User.watching_location(250.0,0.0,0.0,250.0)
+    # Params order: watching_location(nwlat, selat, nwlng, selng)
+    response_user = User.watching_location(90.0,34.10,12.7,178.0)
     user = users(:steff2)
 
     assert_equal 1, response_user.length
     assert_equal user, response_user[0]
+  end
+
+  test 'return collection of User records subscribed to a area inside nwlat/selat/nwlng/selng with negative values' do
+
+    # Params order: watching_location(nwlat, selat, nwlng, selng)
+    response_user = User.watching_location(100.0,34.10,12.7,-10.0)
+    user = users(:steff3)
+
+    assert_equal 1, response_user.length
+    assert_equal user, response_user[0]
+  end
+
+  test 'return collection of User records subscribed to a area inside nwlat/selat/nwlng/selng with multiple users' do
+
+    # Params order: watching_location(nwlat, selat, nwlng, selng)
+    response_user = User.watching_location(100.0,2.10,20.0,80.0)
+    user = users(:steff2, :steff3)
+
+    assert_equal 2, response_user.length
+    assert_equal user[0], response_user[0]
+    assert_equal user[1], response_user[1]
+  end
+
+  test 'location with no user subscribed' do
+
+    # Params order: watching_location(nwlat, selat, nwlng, selng)
+    response_user = User.watching_location(-10.0,2.4,0.0,80.0)
+
+    assert_equal 0, response_user.length
+  end
+
+  test 'using wrong parameters: not a float' do
+    exception = assert_raises(Exception) { User.watching_location('lat',0.0,0.0,80.0) }
+    assert_equal( "Must be a float", exception.message )
   end
 end

--- a/test/unit/subscription_location_test.rb
+++ b/test/unit/subscription_location_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class SubscriptionLocationTest < ActionMailer::TestCase
+  test 'return collection of User records subscribed to a area inside nwlat/selat/nwlng/selng' do
+
+    response_user = User.watching_location(250.0,0.0,0.0,250.0)
+    user = users(:steff2)
+
+    assert_equal 1, response_user.length
+    assert_equal user, response_user[0]
+  end
+end


### PR DESCRIPTION
Fixes #4551 

>Start by developing a test fixture with a 2-coordinate subscription user tag, and then see if we can properly detect overlap using User.watchingLocation(lat, lon, lat2, lon2) which should return a collection of User records.

`user.watching_location(nwlat, selat, nwlng, selng)` returns all the users that are subscribed to an area **inside** (nwlat, selat, nwlng, selng)`.