### PR TITLE
Adding `field` option to `/api/srch/nearbyPeople`

### DIFF
--- a/app/api/srch/search.rb
+++ b/app/api/srch/search.rb
@@ -259,7 +259,7 @@ module Srch
                                                                        is_array: false,
                                                                        nickname: 'search_nearby_people'
       params do
-        use :geographical, :additional, :period, :sorting, :ordering
+        use :geographical, :additional, :field, :period, :sorting, :ordering
       end
       get :nearbyPeople do
         search_request = SearchRequest.fromRequest(params)

--- a/app/services/execute_search.rb
+++ b/app/services/execute_search.rb
@@ -25,7 +25,7 @@ class ExecuteSearch
      when :taglocations
        sservice.tagNearbyNodes(search_criteria.coordinates, search_criteria.tag, search_criteria.period, search_criteria.sort_by, search_criteria.order_direction, search_criteria.limit)
      when :nearbyPeople
-       sservice.tagNearbyPeople(search_criteria.coordinates, search_criteria.tag, search_criteria.period, search_criteria.sort_by, search_criteria.order_direction, search_criteria.limit)
+       sservice.tagNearbyPeople(search_criteria.coordinates, search_criteria.tag, search_criteria.field, search_criteria.period, search_criteria.sort_by, search_criteria.order_direction, search_criteria.limit)
      else
        sresult = []
      end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -139,7 +139,7 @@ class SearchService
 
   # Search nearby people with respect to given latitude, longitute and tags
   # and package up as a DocResult
-  def tagNearbyPeople(coordinates, tag, period = nil, sort_by = nil, order_direction = nil, limit = 10)
+  def tagNearbyPeople(coordinates, tag, field, period = nil, sort_by = nil, order_direction = nil, limit = 10)
     raise("Must contain all four coordinates") if coordinates["nwlat"].nil?
     raise("Must contain all four coordinates") if coordinates["nwlng"].nil?
     raise("Must contain all four coordinates") if coordinates["selat"].nil?
@@ -160,16 +160,23 @@ class SearchService
                          .distinct
 
     if tag.present?
-      user_locations = User.joins(:user_tags)
-                           .where('user_tags.value LIKE ?', tag)
-                           .where(id: user_locations.select("rusers.id"))
+      if field.present? && field == 'node_tag'
+        tids = Tag.where("term_data.name = ?", tag).collect(&:tid).uniq || []
+        uids = TagSelection.where('tag_selections.tid IN (?)', tids).collect(&:user_id).uniq || []
+      else
+        uids = User.joins(:user_tags)
+                   .where('user_tags.value LIKE ?', tag)
+                   .where(id: user_locations.select("rusers.id"))
+                   .collect(&:id).uniq || []
+      end
+      user_locations = user_locations.where('rusers.id IN (?)', uids).distinct
     end
 
-    ids = user_locations.collect(&:id).uniq || []
+    uids = user_locations.collect(&:id).uniq || []
 
     items = User.where('rusers.status <> 0')
       .joins(:user_tags)
-      .where('rusers.id IN (?)', ids)
+      .where('rusers.id IN (?)', uids)
       .where('user_tags.value LIKE ?', 'lon%')
       .where('REPLACE(user_tags.value, "lon:", "") BETWEEN ' + coordinates["nwlng"].to_s + ' AND ' + coordinates["selng"].to_s)
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -165,7 +165,7 @@ class SearchService
         uids = TagSelection.where('tag_selections.tid IN (?)', tids).collect(&:user_id).uniq || []
       else
         uids = User.joins(:user_tags)
-                   .where('user_tags.value LIKE ?', tag)
+                   .where('user_tags.value = ?', tag)
                    .where(id: user_locations.select("rusers.id"))
                    .collect(&:id).uniq || []
       end

--- a/doc/API.md
+++ b/doc/API.md
@@ -33,11 +33,11 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `query=[string]`: search the profiles (users) that have the query on their `username` and `bio` profile info.
+  `query=[string]`: Search the profiles (users) that have the query on their `username` and `bio` profile info.
 
   **Optional:**
 
-  `sort_by=[string]`: sort the profiles by the most recent activity. If no value
+  `sort_by=[string]`: Sort the profiles by the most recent activity. If no value
    provided, the results are then sorted by user id (desc).
 
   `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
@@ -52,7 +52,7 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
  **Required:**
 
- `query=[string]`: search for notes that have the passed string on their content.
+ `query=[string]`: Search for notes that have the passed string on their content.
 
 ### Wikis
 
@@ -61,7 +61,7 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `query=[string]`: search for wikis that have the passed string on their content.
+  `query=[string]`: Search for wikis that have the passed string on their content.
 
 ### Questions
 
@@ -70,7 +70,7 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `query=[string]`: search for notes that have the `question:query` on their tags list.
+  `query=[string]`: Search for notes that have the `question:query` on their tags list.
 
 ### Tags
 
@@ -79,7 +79,7 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `query=[string]`: search the notes that have the query on their tags list.
+  `query=[string]`: Search the notes that have the query on their tags list.
 
 ### TagLocations:
 
@@ -88,11 +88,11 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `nwlat=[northwest latitude],selat=[southeast latitude],nwlng=[northwest longitude],selng=[southeast longitude]`: search notes within the rectangle boundary made by these diagonally opposite coordinates.
+  `nwlat=[northwest latitude],selat=[southeast latitude],nwlng=[northwest longitude],selng=[southeast longitude]`: Search notes within the rectangle boundary made by these diagonally opposite coordinates.
 
   **Optional:**
 
-  `tag=[string]`: the search can be refined by passing a tag field.
+  `tag=[string]`: The search can be refined by passing a tag field.
 
   `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
 
@@ -110,11 +110,13 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `nwlat=[northwest latitude],selat=[southeast latitude],nwlng=[northwest longitude],selng=[southeast longitude]`: search notes within the rectangle boundary made by these diagonally opposite coordinates.
+  `nwlat=[northwest latitude],selat=[southeast latitude],nwlng=[northwest longitude],selng=[southeast longitude]`: Search users within the rectangle boundary made by these diagonally opposite coordinates.
 
   **Optional:**
 
-  `tag=[string]`: the search can be refined by passing a tag field.
+  `tag=[string]`: The search can be refined by passing a user tag field.
+
+  `field=[string]`: Accepts the value `node_tag` for searching users following the node tag (topic).
 
   `order_direction=[string]`: It accepts `ASC` or `DESC` (the latter is the default).
 
@@ -131,11 +133,11 @@ All the endpoints have the optional parameter `limit` (10 by default) where you 
 
   **Required:**
 
-  `query=[integer]`: search the the users with most recent activity that have coordinates(lat and lon values) on their user tags.
+  `query=[integer]`: Search the the users with most recent activity that have coordinates(lat and lon values) on their user tags.
 
   **Optional:**
 
-  `tag=[string]`: the search can be refined by passing a tag field.
+  `tag=[string]`: The search can be refined by passing a tag field.
 
 ## API code
 

--- a/test/unit/api/search_service_test.rb
+++ b/test/unit/api/search_service_test.rb
@@ -101,7 +101,7 @@ class SearchServiceTest < ActiveSupport::TestCase
   end
 
   test 'running search nearby people with invalid period' do
-    exception_1 = assert_raises(Exception) { SearchService.new.tagNearbyPeople({ "nwlat" => 180.0, "nwlng" => 0.0, "selat" => 0.0, "selng" =>180.0 }, nil, period = { "from" => nil, "to" => 'date'}, sort_by = nil, order_direction = nil, limit = 10) }
+    exception_1 = assert_raises(Exception) { SearchService.new.tagNearbyPeople({ "nwlat" => 180.0, "nwlng" => 0.0, "selat" => 0.0, "selng" =>180.0 }, nil, nil, period = { "from" => nil, "to" => 'date'}, sort_by = nil, order_direction = nil, limit = 10) }
     assert_equal( "If 'to' is not null, must contain date", exception_1.message )
   end
 end


### PR DESCRIPTION
Fixes #4659

`field=[string]`: Accepts the value `node_tag` for searching users following the node tag (topic).

`/api/srch/nearbyPeople?nwlat=100&selat=0&nwlng=0&selng=100&tag=water&field=node_tag`