### PR TITLE
Removing icons from navbar tabs

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,7 +30,7 @@
       <ul class="nav navbar-nav navbar-left">
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-            Get Involved <i class="fa fa-white fa-caret-down"></i>
+            Get Involved
           </a>
           <ul class="dropdown-menu">
             <li><a href="/events">Attend an event</a></li>
@@ -49,7 +49,7 @@
 
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-            <%= t('layout._header.about.about_title') %> <i class="fa fa-white fa-caret-down"></i>
+            <%= t('layout._header.about.about_title') %>
           </a>
           <ul class="dropdown-menu">
             <li><a href="/wiki/stories"><%= t('layout._header.about.stories') %></a></li>
@@ -77,7 +77,7 @@
       <ul class="nav navbar-nav navbar-right">
         <% if current_user %>
           <li class="hidden-sm hidden-md">
-            <a rel="tooltip" title="<%= t('layout._header.your_dashboard') %>" data-placement="bottom" href="/dashboard">Dashboard <i class="fa fa-white fa-home" aria-hidden="true"></i></a>
+            <a rel="tooltip" title="<%= t('layout._header.your_dashboard') %>" data-placement="bottom" href="/dashboard">Dashboard</a>
           </li>
         <% else %>
         <li class="hidden-sm hidden-md"> <!-- signup button -->
@@ -91,7 +91,7 @@
           <% unless params[:action] == "register" || params[:action] == "signup" %>
             <% if current_user %>
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                 Profile  <i class="fa fa-white fa-user" aria-hidden="true" ></i>
+                 Profile 
               </a>
               <ul class="dropdown-menu">
                 <div class="dropdown-header">


### PR DESCRIPTION
#4690 temporary solution by removing fa-icons from navbar tabs:

![header](https://user-images.githubusercontent.com/40794215/51804280-d1a83500-2284-11e9-9dab-e32d1bd3566d.gif)

