### PR TITLE
Set a typeahead delay to prevent overloading server

### DIFF
--- a/app/assets/javascripts/post.js
+++ b/app/assets/javascripts/post.js
@@ -28,6 +28,7 @@ jQuery(document).ready(function() {
   $('#taginput').typeahead({
     items: 8,
     minLength: 3,
+    delay: 450,
     source: function (query, process) {
       var term = query.split(',').pop()
       if (term.length > 2) {


### PR DESCRIPTION
This is meant to alleviate https://github.com/publiclab/plots2/issues/4661 perhaps avoid recent outages caused by it!

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below
