### PR TITLE
Remove newline to show FB and Twitter buttons on same line #4821

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -211,6 +211,11 @@
   margin: 18px 0 2px;
 }
 
+.dashboard .fb-like, 
+.dashboard .fb-like > span{
+  display: inline;
+}
+
 .note-default {
 
 }

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -211,9 +211,9 @@
   margin: 18px 0 2px;
 }
 
-.dashboard .fb-like, 
-.dashboard .fb-like > span{
-  display: inline;
+.dashboard .social-media-btn {
+  float: left;
+  margin-right: 5px;
 }
 
 .note-default {

--- a/app/views/sidebar/_dashboard.html.erb
+++ b/app/views/sidebar/_dashboard.html.erb
@@ -39,9 +39,8 @@
     <% cache('feature_dashboard-sidebar', skip_digest: true) do %>
       <%= feature('dashboard-sidebar') %>
     <% end %>
-    <!-- Twitter follow bitton, options can be adjusted here: https://publish.twitter.com/# -->
+    <!-- Twitter follow button, options can be adjusted here: https://publish.twitter.com/# -->
     <a href="https://twitter.com/PublicLab?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @PublicLab</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-    <br>
     <!-- Facebook like button, options can be adjusted here: https://developers.facebook.com/docs/plugins/like-button/  -->
     <div class="fb-like" data-href="https://www.facebook.com/PublicLab/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
   </div>

--- a/app/views/sidebar/_dashboard.html.erb
+++ b/app/views/sidebar/_dashboard.html.erb
@@ -40,8 +40,12 @@
       <%= feature('dashboard-sidebar') %>
     <% end %>
     <!-- Twitter follow button, options can be adjusted here: https://publish.twitter.com/# -->
-    <a href="https://twitter.com/PublicLab?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @PublicLab</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <div class="social-media-btn">
+      <a href="https://twitter.com/PublicLab?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @PublicLab</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    </div>
     <!-- Facebook like button, options can be adjusted here: https://developers.facebook.com/docs/plugins/like-button/  -->
-    <div class="fb-like" data-href="https://www.facebook.com/PublicLab/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
+    <div class="social-media-btn">  
+      <div class="fb-like" data-href="https://www.facebook.com/PublicLab/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
+    </div
   </div>
 </div>

--- a/app/views/sidebar/_dashboard.html.erb
+++ b/app/views/sidebar/_dashboard.html.erb
@@ -46,6 +46,6 @@
     <!-- Facebook like button, options can be adjusted here: https://developers.facebook.com/docs/plugins/like-button/  -->
     <div class="social-media-btn">  
       <div class="fb-like" data-href="https://www.facebook.com/PublicLab/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
-    </div
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #4821

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

~~Removing \<br> tag was not simply enough, since facebook button root node is a div with display block.
I am not that happy with this solution, because it relies on how Facebook renders its button, which can change at any time.
Other solution I came up with was adding float:left and margin-right to twitter button, then it does not matter that Facebook button is block element, but still it relies on how twitter's script renders its button in iframe.
Last solution I came up, but could not make work was wrapping both of them in divs and then position them based on our containers div with no regard what is inside.~~

I have managed to implement this feature with wrapping both buttons in divs. Not it **is** independent from the way twitter or facebook renders its buttons.

![remove newline to show fb and twitter buttons on same line 4821](https://user-images.githubusercontent.com/6883643/53162888-3f6a2700-35cd-11e9-81e5-4a71c4d97d82.png)


![remove newline to show fb and twitter buttons on same line 4821](https://user-images.githubusercontent.com/6883643/53184134-ce426800-35fc-11e9-8095-c13be1a0a8be.gif)
