### PR TITLE
Fixing broken images

### DIFF
--- a/app/views/subscription_mailer/send_digest.html.erb
+++ b/app/views/subscription_mailer/send_digest.html.erb
@@ -30,7 +30,11 @@
           <div style="padding-bottom: 30px;">
             <img src="<%= n.main_image.path(:default) %>" style="width: 90px;height: 90px;border-radius: 5px;margin-left: 14px;">
           </div>
-         <% end %>
+        <% elsif n.scraped_image %>
+          <div style="padding-bottom: 30px;">
+            <img src="<%= n.scraped_image %>" style="width: 90px;height: 90px;border-radius: 5px;margin-left: 14px;">
+          </div>
+        <% end %>
         <div colspan="2" style="padding-bottom: 32px;">
           <hr style="border: none;height: 1px;background-color: #e2e2e2;width: 140px;">
         </div>


### PR DESCRIPTION
Fixes #4732 

Broken images in emails fixed:

![image](https://user-images.githubusercontent.com/40794215/53287407-b0face80-37a1-11e9-802a-a441a97de154.png)
