### PR TITLE
Alert message changed, solves #4915

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -67,7 +67,7 @@ class UserSessionsController < ApplicationController
           @user = user
           # send key to user email
           PasswordResetMailer.reset_notify(user, key).deliver_now unless user.nil? # respond the same to both successes and failures; security
-          redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password via a link sent to you via e-mail"
+          redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
         else # email exists so link the identity with existing user and log in the user
           user = User.where(email: auth["info"]["email"])
           # If no identity was found, create a brand new one here

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -48,7 +48,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_not_nil request.env['omniauth.auth']
     #Sign Up for a new user
     post :create
-    assert_equal "You have successfully signed in. Please change your password via a link sent to you via e-mail",  flash[:notice]
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
     #Log Out
     post :destroy
     assert_equal "Successfully logged out.",  flash[:notice]
@@ -105,7 +105,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_not_nil request.env['omniauth.auth']
     #Sign Up for a new user
     post :create
-    assert_equal "You have successfully signed in. Please change your password via a link sent to you via e-mail",  flash[:notice]
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
     #Log Out
     post :destroy
     assert_equal "Successfully logged out.",  flash[:notice]
@@ -162,7 +162,7 @@ class UserSessionsControllerTest < ActionController::TestCase
       assert_not_nil request.env['omniauth.auth']
       #Sign Up for a new user
       post :create
-      assert_equal "You have successfully signed in. Please change your password via a link sent to you via e-mail",  flash[:notice]
+      assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
       #Log Out
       post :destroy
       assert_equal "Successfully logged out.",  flash[:notice]
@@ -218,7 +218,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_not_nil request.env['omniauth.auth']
     #Sign Up for a new user
     post :create
-    assert_equal "You have successfully signed in. Please change your password via a link sent to you via e-mail",  flash[:notice]
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
     #Log Out
     post :destroy
     assert_equal "Successfully logged out.",  flash[:notice]


### PR DESCRIPTION
Fixes #4915 (<=== Add issue number here)

The Screenshot after the change:
![improve-the-alert-msg](https://user-images.githubusercontent.com/30488330/54022371-5b1e2180-41b8-11e9-8770-c4ab185154ae.PNG)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
