### PR TITLE
Remove requirement for mysql2 adapter when mysql database is not in use

### DIFF
--- a/config/initializers/abstract_mysql2_adapter.rb
+++ b/config/initializers/abstract_mysql2_adapter.rb
@@ -1,10 +1,12 @@
-begin
-  require 'active_record/connection_adapters/mysql2_adapter'
+if ActiveRecord::Base.connection.adapter_name == "Mysql2"
+  begin
+    require 'active_record/connection_adapters/mysql2_adapter'
 
-  class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-    NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    end
+  rescue Exception => e
+    raise
+    e.message
   end
-rescue Exception => e
-  raise
-  e.message
 end


### PR DESCRIPTION
Fixes #4936 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
