### PR TITLE
open popover on hover instead of click

### DIFF
--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -2,7 +2,7 @@
   <% tags.each do |tag| %>
     <% if tag.class == NodeTag %>
       <% if power_tag ^ tag.name.include?(':') # XOR operator??? %>
-        <li style="width: 100%;"><span id="tag_<%= tag.tid %>" class="label <%= label_name %>" style="cursor:pointer" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p> <div style='text-align:center;'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
+        <li style="width: 100%;"><span id="tag_<%= tag.tid %>" class="label <%= label_name %> pop" style="cursor:pointer" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p> <div style='text-align:center;'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
           <%= tag.name %>
           <% if current_user && ( current_user.uid ==  @node.uid || current_user.uid == tag.uid  || current_user.role == "admin" || current_user.role == "moderator") %>
             <% if tag.name.include? ':' %>
@@ -16,7 +16,7 @@
 
     <% elsif tag.class == UserTag && (tag.name[0..4] != "oauth" || (current_user && (current_user.uid == tag.uid || current_user.role == "admin"))) %>
 
-        <li style="width: 100%;"><span id="tag_<%= tag.id %>" class="label <%= label_name %>" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
+        <li style="width: 100%;"><span id="tag_<%= tag.id %>" class="label <%= label_name %> pop" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
           <% if tag.name[0..4] != "oauth" %>
             <%= tag.name %>
           <% else %>
@@ -31,3 +31,23 @@
 
   <% end %>
 </ul>
+
+<script type="text/javascript">
+
+$(".pop").popover({ trigger: "manual" , html: true, animation:false})
+    .on("mouseenter", function () {
+        var _this = this;
+        $(this).popover("show");
+        $(".popover").on("mouseleave", function () {
+            $(_this).popover('hide');
+        });
+    }).on("mouseleave", function () {
+        var _this = this;
+        setTimeout(function () {
+            if (!$(".popover:hover").length) {
+                $(_this).popover("hide");
+            }
+        }, 300);
+});
+
+</script>


### PR DESCRIPTION
Fixes #5072 (<=== Add issue number here)

Earlier I made a issue #4987 on the popover which closes if it's clicked anywhere on the screen. But after that I saw various other popovers in the code. And also the issue #5019 I realised that even for the tags the popover should open on hover instead of click. 

![hover](https://user-images.githubusercontent.com/26685258/54379156-db5bef80-46ae-11e9-91dc-41d9d6d26258.gif)

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
