### PR TITLE
Fix missing styling on profile comments page

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -8,7 +8,7 @@ var Profile = {
   display_comments: function(){
     $('a#comments-tab').on('shown.bs.tab',function (e) {
       $.ajax({
-        url : '/profile/comments/' + Profile.value.user_id,
+        url : `/profile/comments/${Profile.value.user_id}`,
         type: 'GET',
         success: function(response){
           $('#comments').html(response);

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -278,11 +278,16 @@ class UsersController < ApplicationController
   end
 
   def comments
-    @comments = Comment.limit(20)
+    comments = Comment.limit(20)
                              .order("timestamp DESC")
-                             .where(status: 1, uid: params[:id])
+                             .where(uid: params[:id])
                              .paginate(page: params[:page])
-    render partial: 'comments/comments', locals: { comments: @comments }
+
+    @normal_comments = comments.where('comments.status = 1')
+    if current_user && (current_user.role == 'moderator' || current_user.role == 'admin')
+      @moderated_comments = comments.where('comments.status = 4')
+    end
+    render template: 'comments/index'
   end
 
   def photo

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -97,7 +97,7 @@
     </div>
 
     <div class="tab-pane" id="comments">
-      <h2 style="text-align:center;"><i class="fa fa-spinner fa fa-spin"></i></h2>
+      <%= render partial: 'comments/comments', locals: { comments: current_user &.can_moderate? ? @all_comments : @normal_comments } %>
     </div>
 
     <div class="tab-pane" id="likes">
@@ -323,7 +323,6 @@
     (function () {
         var profile = Object.create(Profile);
         profile.value.user_id = "<%= @profile_user.uid %>"
-        profile.display_comments();
 
         <% if @profile_user %>
         var notes = <%= @profile_user.daily_note_tally.to_a.sort %>

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -152,7 +152,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_equal selector.size, 1
   end
 
-  test 'should get comments' do
+  test 'should get comments and render comments/index template' do
     user = users(:jeff)
     get :comments, params: { id: user.id }
     assert_response :success

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -156,8 +156,10 @@ class UsersControllerTest < ActionController::TestCase
     user = users(:jeff)
     get :comments, params: { id: user.id }
     assert_response :success
-    assert_not_nil assigns(:comments)
-    assert_template partial: 'comments/_comments'
+    normal_comments = assigns(:normal_comments)
+    assert_not_nil normal_comments
+    assert_nil assigns(:moderated_comments)
+    assert_template 'comments/index'
   end
 
   test 'creating new account' do


### PR DESCRIPTION
Fixes #4174 (<=== Add issue number here)

Before:
<img width="1447" alt="Screenshot 2019-03-15 at 3 17 36 AM" src="https://user-images.githubusercontent.com/7345686/54403644-14a55700-46d1-11e9-8a4f-fe29f4dd6138.png">

After:
_(as user)_
<img width="1447" alt="Screenshot 2019-03-15 at 3 17 09 AM" src="https://user-images.githubusercontent.com/7345686/54403665-2b4bae00-46d1-11e9-9e9a-ee5c8559594d.png">

_(as moderator/admin)_
<img width="1447" alt="Screenshot 2019-03-15 at 2 25 30 AM" src="https://user-images.githubusercontent.com/7345686/54402538-a78fc280-46cc-11e9-9094-a404fb74d437.png">
<img width="1447" alt="Screenshot 2019-03-15 at 3 18 40 AM" src="https://user-images.githubusercontent.com/7345686/54403686-45858c00-46d1-11e9-83c9-095c2bf95a78.png">

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below


> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
