### PR TITLE
Accept multiple image size formats in image shortcodes

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -5,7 +5,13 @@ class ImagesController < ApplicationController
   before_action :require_user, only: %i(create new update delete)
 
   def shortlink
+    params[:size] = params[:size] || params[:s]
     params[:size] = params[:size] || :large
+    params[:size] = :thumb if (params[:size].to_s == "t")
+    params[:size] = :thumb if (params[:size].to_s == "thumbnail")
+    params[:size] = :medium if (params[:size].to_s == "m")
+    params[:size] = :large if (params[:size].to_s == "l")
+    params[:size] = :original if (params[:size].to_s == "o")
     image = Image.find(params[:id])
     redirect_to URI.parse(image.path(params[:size])).path
   end

--- a/test/functional/images_controller_test.rb
+++ b/test/functional/images_controller_test.rb
@@ -11,6 +11,12 @@ class ImagesControllerTest < ActionController::TestCase
     assert_redirected_to Image.last.path(:large)
     get :shortlink, params: { id: Image.last.id, size: 'medium' }
     assert_redirected_to Image.last.path(:medium)
+    get :shortlink, params: { id: Image.last.id, size: 'm' }
+    assert_redirected_to Image.last.path(:medium)
+    get :shortlink, params: { id: Image.last.id, size: 'thumbnail' }
+    assert_redirected_to Image.last.path(:thumb)
+    get :shortlink, params: { id: Image.last.id, s: 'thumbnail' }
+    assert_redirected_to Image.last.path(:thumb)
   end
 
   #  test "normal user should not delete image" do


### PR DESCRIPTION

Currently:

https://publiclab.org/i/29443.png?size=thumb
https://publiclab.org/i/29443.png?size=medium
https://publiclab.org/i/29443.png?size=large (default)
https://publiclab.org/i/29443.png?size=original

Also you can leave out `.png`: https://publiclab.org/i/29443?size=medium

Added:

https://publiclab.org/i/29443?size=thumbnail
https://publiclab.org/i/29443?size=t
https://publiclab.org/i/29443?size=m
https://publiclab.org/i/29443?size=l
https://publiclab.org/i/29443?size=o
https://publiclab.org/i/29443?s=thumbnail
https://publiclab.org/i/29443?s=t
https://publiclab.org/i/29443?s=m
https://publiclab.org/i/29443?s=l
https://publiclab.org/i/29443?s=o