### PR TITLE
Dividing the tags page to make it two-column and add graph in second column

### DIFF
--- a/app/views/tag/index.html.erb
+++ b/app/views/tag/index.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag('async_tag_subscriptions.js') %>
-<div class="col-md-12">
+<div class="col-md-6">
   <h1 style="font-family:Junction Light;"><%= t('tag.index.popular_tags') %></h1>
 
   <% cache('feature_tags-header', skip_digest: true) do %> 
@@ -53,7 +53,7 @@
 
   <hr />
 
+<div class="text-center"> <%= will_paginate @tags, :renderer => BootstrapPagination::Rails if @paginated %></div>
 </div>
 
-<div class="text-center"> <%= will_paginate @tags, :renderer => BootstrapPagination::Rails if @paginated %></div>
 

--- a/app/views/tag/index.html.erb
+++ b/app/views/tag/index.html.erb
@@ -56,4 +56,7 @@
 <div class="text-center"> <%= will_paginate @tags, :renderer => BootstrapPagination::Rails if @paginated %></div>
 </div>
 
-
+<div class="col-md-6">
+<br><br>
+<iframe src="stats/graph.html?limit=50" height="500" width="100%" frameborder="0" ></iframe>
+</div>


### PR DESCRIPTION
Fixes #5090 first part and second part (<=== Add issue number here)

## Description 
For building the new tags page, the first step was to divide the tags page into two column.
And second was to add an iframe to second column.

![Screenshot from 2019-03-19 09-22-13](https://user-images.githubusercontent.com/26685258/54579310-e1442e80-4a28-11e9-9553-6b1b1c3f6bc1.png)



* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] PR is descriptively titled 📑
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
