### PR TITLE
Updates _node_comment partial

### DIFF
--- a/app/views/dashboard/_node_comment.html.erb
+++ b/app/views/dashboard/_node_comment.html.erb
@@ -3,9 +3,9 @@
 
     <div class="header-icon">
      <% if node.aid == 0 %>
-      <a href="<% if node.parent.has_power_tag('question') %><%= node.parent.path(:question) %>#anwer-0-comment<% else %><%= node.parent.path %>#comments<% end %>"> <i class="fa fa-comment-o"> <%= node.parent.comments.count %> </i> </a>
+      <a href="<% if node.parent.has_power_tag('question') %><%= node.parent.path(:question) %>#answer-0-comment<% else %><%= node.parent.path %>#comments<% end %>"> <i class="fa fa-comment-o"> <%= node.parent.fetch_comments(current_user).count %></i> </a>
       <% else %>
-      <a href="<%= node.parent.path(:question) %>#answer-<%= node.answer.id %>-comment"> <i class="fa fa-comment-o"> 
+      <a href="<%= node.parent.path(:question) %>#answer-<%= node.answer.id %>-comment"> <i class="fa fa-comment-o"> </i>
       <% end %> 
       </a>
       <a href="/n/<%= node.parent.id %>"><i class="fa fa-link"></i></a>


### PR DESCRIPTION
Fixes #5111
I made the required change in L6. Now it uses the function fetch_comments() to find the number of comments of the current user only instead of total number of comments. In L8, the tag is closed.

