### PR TITLE
Create visual difference between notes/wiki

### DIFF
--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -2,12 +2,6 @@
   <div class="alert alert-warning"><%= raw t('wiki.show.page_has_no_tags', url: 'javascript: $(".tag-input").focus();') %></div>
 <% end %>
 
-<% if @node.main_image && !@presentation %>
-  <a style="margin-bottom:10px;" href="<%= @node.main_image.path(:original) %>">
-    <img style="max-width:100%;max-height:600px;margin-bottom:10px;" class="img-rounded" src="<%= @node.main_image.path(:large) %>" />
-  </a>
-<% end %>
-
 <div style="margin-top:10px;" class="hidden-print">
   <%= render partial: "like/like", locals: {node: @node, tagnames: @tagnames } %>
 </div>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -18,6 +18,12 @@
   </div>
 <% end %>
 
+<% if @node.main_image && !@presentation %>
+  <a style="margin-bottom:10px;" href="<%= @node.main_image.path(:original) %>">
+    <img style="max-width:100%; width:100%; max-height:500px;margin-bottom:10px;" class="img-rounded" src="<%= @node.main_image.path(:large) %>" />
+  </a>
+<% end %>
+
 <div class="row">
 
 <div class="col-md-9">


### PR DESCRIPTION
Fixes #152 First part
## Description 
The design change is not major rather a minor one.
This is the first part of the changes towards the difference in between both pages. 
The image section was taken out of div of col-md-9 which had the data. So that instead of being inside grid column, the image would be outside it.
And the image width was set to 100%, so that it would take whole screen-with.

## Earlier 
![Screenshot from 2019-03-17 11-33-41 (1)](https://user-images.githubusercontent.com/26685258/54486223-6275b700-48ab-11e9-8d77-a8923226b076.png)
![Screenshot from 2019-03-17 11-52-35](https://user-images.githubusercontent.com/26685258/54486224-6275b700-48ab-11e9-91ce-1d4f0405fae4.png)


## After changes
![Screenshot from 2019-03-17 11-33-41 (1)](https://user-images.githubusercontent.com/26685258/54486184-acaa6880-48aa-11e9-81ee-ca51c3330efc.png)
![Screenshot from 2019-03-17 11-33-03](https://user-images.githubusercontent.com/26685258/54555552-01e69700-49dd-11e9-8242-c7af68e96f7b.png)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
