### PR TITLE
Remove assets not present deprecation warning

### DIFF
--- a/app/views/admin/assets.html.erb
+++ b/app/views/admin/assets.html.erb
@@ -5,7 +5,7 @@
 <%= javascript_include_tag  'comment_expand' %>
 <%= javascript_include_tag  'dashboard' %>
 <%= javascript_include_tag  'dragdrop' %>
-# <%= javascript_include_tag  'dynamic_search' %>
+<%= javascript_include_tag  'dynamic_search' %>
 <%= javascript_include_tag  'editor' %>
 <%= javascript_include_tag  'graph' %>
 <%= javascript_include_tag  'grids' %>

--- a/app/views/admin/assets.html.erb
+++ b/app/views/admin/assets.html.erb
@@ -5,7 +5,7 @@
 <%= javascript_include_tag  'comment_expand' %>
 <%= javascript_include_tag  'dashboard' %>
 <%= javascript_include_tag  'dragdrop' %>
-# <%= javascript_include_tag  'dynamic_search' %>
+
 <%= javascript_include_tag  'editor' %>
 <%= javascript_include_tag  'graph' %>
 <%= javascript_include_tag  'grids' %>

--- a/app/views/admin/assets.html.erb
+++ b/app/views/admin/assets.html.erb
@@ -5,7 +5,7 @@
 <%= javascript_include_tag  'comment_expand' %>
 <%= javascript_include_tag  'dashboard' %>
 <%= javascript_include_tag  'dragdrop' %>
-<%= javascript_include_tag  'dynamic_search' %>
+# <%= javascript_include_tag  'dynamic_search' %>
 <%= javascript_include_tag  'editor' %>
 <%= javascript_include_tag  'graph' %>
 <%= javascript_include_tag  'grids' %>

--- a/app/views/admin/assets.html.erb
+++ b/app/views/admin/assets.html.erb
@@ -5,7 +5,6 @@
 <%= javascript_include_tag  'comment_expand' %>
 <%= javascript_include_tag  'dashboard' %>
 <%= javascript_include_tag  'dragdrop' %>
-
 <%= javascript_include_tag  'editor' %>
 <%= javascript_include_tag  'graph' %>
 <%= javascript_include_tag  'grids' %>


### PR DESCRIPTION
Fixes #5126  (<=== Add issue number here)

I managed to fix the Fix asset "dynamic_search.js not present deprecation warning .

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
