### PR TITLE
html cards for people section

### DIFF
--- a/app/views/map/_peopleLeaflet.html.erb
+++ b/app/views/map/_peopleLeaflet.html.erb
@@ -2,7 +2,7 @@
 <% unique_id = rand(1000) %>
 
   <style>
-  	#map<%= unique_id %> { width:100%; height:300px; margin: 0; position: relative;}
+  	#map<%= unique_id %> { width:100%; height:500px; margin: 0; position: relative;}
   </style>
 
 <div>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -1,56 +1,113 @@
+<div class="container">
+<div class="row">
+<div class="col-md-6" style="font-family:Junction Regular;">
+<% if current_user && (current_user.role == "admin" || current_user.role == "moderator")%>
+<h3><%= t('users.list.user_moderation') %></h3>
+<p><%= t('users.list.admins_ban_spam') %> </p>
+<% end %>
+  <h2><%= raw t('People') %></h2>
+  <h5><%= t('Recently active on Publiclab') =%></h5>
+    <div>
+    <br>
+      <p style="width: 100%; font-size:14px; text-align: center; border-bottom: 1px solid #ccc; line-height:2px; margin: 10px 0 20px;">
+      <span style="background-color: #fff; padding: 0 10px; color: #808080;">Sort by:
+      <a href = "<%= people_path %>?sort=username" style="text-decoration: underline; color: #808080;"> <%= t('users.list.username') %></a><span> | </span>
+      <a href = "<%= people_path %>?sort=last_activity"style="text-decoration: underline; color: #808080;"> <%= t('users.list.last_activity') %></a><span> | </span>
+      <a href = "<%= people_path %>?sort=joined" style="text-decoration: underline; color: #808080;"><%= t('users.list.joined') %></a><span> | </span>
+      </span>
+      </p>
+      <br/>
+    </div>
+  <div class="row" id="user_cards">
 
-<div class="col-lg-3">
-	<div class='row'>
-		<div class='col-lg-12'>
-			<p> This page shows a list of all Public Lab contributors and is sorted by those who have posted most recently. Click the profile link to view their posting activity. </p>
-		</div>
-	</div>
-  <% if logged_in_as(['admin', 'moderator']) %>
-    <h2><%= t('users.list.user_moderation') %></h2>
-    <p><%= t('users.list.admins_ban_spam') %> </p>
-  <% end %>
-</div>
-<div class="col-lg-9">
-  <h2><%= raw t('users.list.members_last_activity') %></h2>
-  <%= render :partial => "map/peopleLeaflet" , locals: {people: true , lat:23 , lon: 4} %>
-  <table class="table">
-    <tr>
-      <th class="d-lg-none"></th>
-
-      <th style="text-align: center;"><a href = "<%= people_path %>?sort=username"> <%= t('users.list.username') %></a> <i class="fa fa-arrows-v"></i></th>
-      <th><a href = "<%= people_path %>?sort=last_activity"> <%= t('users.list.last_activity') %></a> <i class="fa fa-arrows-v"></i></th>
-      <th><%= t('users.list.history') %></th>
-      <th><a href = "<%= people_path %>?sort=joined"> <%= t('users.list.joined') %></a> <i class="fa fa-arrows-v"></i></th>
-
-      <% if logged_in_as(['admin', 'moderator']) %>
-        <th><%= t('users.list.moderation') %></th>
-      <% end %>
-    </tr>
     <% @users.each do |user| %>
-    <tr>
-      <td class="d-lg-none" style="padding-top: 16px;">
-        <img class="rounded-circle" id="profile-photo" style="width:40px;margin-right:8px;border: 1px solid lightgrey;" src="<%= user.profile_image %>" />
-      </td>
-      <td style="display: flex; align-items: center;">
-        <div class="d-lg-none">
-          <img class="rounded-circle" id="profile-photo" style="width:40px;margin-right:8px;border: 1px solid lightgrey;" src="<%= user.profile_image %>" />
+      <div class ="col-md-6" id="user">
+        <div class="card">
+           <div class="card-body">
+            <div class="profile-image text-center">
+                <img class="rounded-circle img-fluid" id="profile-photo" src="<%= user.profile_image %>" />
+            </div>
+            <br>
+            <div class="card-info">
+            <a href="/profile/<%= user.username %>"><%= user.username %></a>
+              <div class="sub-info">
+                <div>Last Activity : <%= t = user.revisions.order(timestamp: :desc).first.try(:created_at);time_ago_in_words(t) if (t) %></div>
+                <div>History : <%= user.nodes.count %> <%= t('users.list.notes_and_edits') %></div>
+                <div> Joined : <%= distance_of_time_in_words(user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></div>
+              </div>
+              <% if current_user && (current_user.role == "admin" || current_user.role == "moderator") %>
+                <div style="padding-top:16px; text-align:center;">
+                  <% if user.status == 0 %>
+                    <i class='fa fa-ban' style="color:#a00;font-size:1em"></i> <%= t('users.list.banned') %>
+                  <% elsif user.status == 1 %>
+                    <a class="btn btn-outline-secondary btn-sm" style="font-size:1em;" data-confirm="<%= t('users.list.are_you_sure') %>" href="/ban/<%= user.uid %>" ><i class='fa fa-ban'></i> <%= t('users.list.ban') %></a>
+                  <% end %>
+                </div>
+               <% end %>
+            </div>
+            </div>
+          </div>
         </div>
-        <a style="margin-left: 12px;" href="/profile/<%= user.username %>"><%= user.username %></a>
-      </td>
-      <td style="padding-top:16px;"><%= t = user.revisions.order(timestamp: :desc).first.try(:created_at);time_ago_in_words(t) if (t) %></td>
-      <td style="padding-top:16px;"><%= user.nodes.count %> <%= t('users.list.notes_and_edits') %></td>
-      <td style="padding-top:16px;"><%= distance_of_time_in_words(user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></td>
-      <% if logged_in_as(['admin', 'moderator']) %>
-      <td style="padding-top:16px;">
-        <% if user.status == 0 %>
-          <i class='fa fa-ban' style="color:#a00;"></i> <%= t('users.list.banned') %>
-        <% elsif user.status == 1 %>
-          <a class="btn btn-outline-secondary btn-sm" data-confirm="<%= t('users.list.are_you_sure') %>" href="/ban/<%= user.uid %>" ><i class='fa fa-ban'></i> <%= t('users.list.ban') %></a>
-        <% end %>
-      </td>
       <% end %>
-     </tr>
-    <% end %>
-  </table>
+  </div>
   <%= will_paginate @users, renderer: WillPaginate::ActionView::BootstrapLinkRenderer unless @unpaginated %>
 </div>
+<div class="col-md-6 d-none d-md-block" style="margin-top:2em;">
+<%= render :partial => "map/peopleLeaflet" , locals: {people: true , lat:23 , lon: 4} %>
+</div>
+<div class="col-md-6 d-md-none" style="margin-top:2em;">
+<%= render :partial => "map/peopleLeaflet" , locals: {people: true , lat:23 , lon: 4} %>
+</div>
+</div>
+</div>
+<style>
+#user {
+  padding:10px 8px 10px 8px
+}
+
+h5 {
+  color: #666;
+}
+.card {
+  background-color: #fff;
+  border: 1px solid;
+  border-color: #D3D3D3;
+  border-radius: 6px;
+}
+
+.card-body {
+  margin-bottom:0.3em;
+}
+
+.profile-image {
+  margin-top: 0.5em;
+}
+
+#profile-photo {
+  width: 6.5em;
+  border-color:#555;
+  border: 1px solid lightgrey;
+}
+
+.card-info {
+  padding-left: 1em;
+  padding-right:1em;
+}
+
+.card-info a{
+  font-size:1.2em;
+  margin-bttom:1em;
+  color:#222;
+}
+
+.sub-info {
+  color:#666;
+  font-size:0.8em;
+}
+
+.affix {
+    top:50px;
+    right:0;
+    position:fixed;
+}
+</style>

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -242,16 +242,6 @@ class I18nTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'should choose i18n for user/list' do
-    available_testing_locales.each do |lang|
-      get '/change_locale/' + lang.to_s
-      follow_redirect!
-
-      get '/people'
-      assert_select 'th', I18n.t('users.list.username')
-    end
-  end
-
   test 'should choose i18n for user/map' do
     available_testing_locales.each do |lang|
       get '/change_locale/' + lang.to_s

--- a/test/integration/public_pages_test.rb
+++ b/test/integration/public_pages_test.rb
@@ -96,4 +96,12 @@ class PublicPagesTest < ActionDispatch::IntegrationTest
     get '/assets'
     assert_response :success
   end
+
+  test 'browse people page' do
+    get '/people'
+    assert_response :success
+  end
+
 end
+
+


### PR DESCRIPTION
Fixes #4922 (<=== Add issue number here)

## Earlier Description
~~People page will be redesigned soon. And one the requirements was that all the users should be listed down in grid card format instead rows in table. I started off with the basic structure of cards for users. And soon the further improvements will be done.~~

![Screenshot from 2019-04-03 19-34-10](https://user-images.githubusercontent.com/26685258/55487413-ac9cbd80-564b-11e9-919e-f8fe1c440fe3.png)

![h](https://user-images.githubusercontent.com/26685258/55487324-837c2d00-564b-11e9-9b9e-f3ab7d195f0a.gif)

## Update
This is the new redesign of people's page.
I made it two column and map on right. The map remain stick on scrolling.
I showed the users on left
On md and lg scrrens - 
![h](https://user-images.githubusercontent.com/26685258/55497323-c398db00-565e-11e9-9dc6-7d2a98f2e194.gif)


On small screens - 
![hh](https://user-images.githubusercontent.com/26685258/55497354-d27f8d80-565e-11e9-8909-2b40c4d8a8be.gif)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below


Thanks!
