### PR TITLE
Skip notifying commenters with bad UID records

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -131,6 +131,7 @@ class Comment < ApplicationRecord
       # notify other commenters, revisers, and likers, but not those already @called out
       already = mentioned_users.collect(&:uid) + [parent.uid]
       uids = uids_to_notify - already
+      uids = uids.select { |i| i != 0 } # remove bad comments (some early ones lack uid)
 
       notify_users(uids, current_user)
       notify_tag_followers(already + uids)

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -22,7 +22,11 @@
         <% else %>
           <div style="vertical-align:middle;display:inline-block;height:32px;width:32px;margin-right:6px;background:#ccc;" class="img-circle"></div>
         <% end %>
-        <a href="/profile/<%= comment.author.name %>"><%= comment.author.name %></a>
+        <% if comment.author.name != "" %>
+          <a href="/profile/<%= comment.author.name %>"><%= comment.author.name %></a>
+        <% else %>
+          <%= comment.name %>
+        <% end %>
       <% end %>
       <span class="hidden-xs"><%= t('notes._comment.commented') %></span>
       <a style="color:#aaa;" href="#c<%= comment.cid %>"><%= distance_of_time_in_words(comment.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></a>


### PR DESCRIPTION
Some very old comment records have no user records associated. Instead of dealing with it, i'm just working around it, but their CIDs are here: https://gist.github.com/jywarren/c8e7ddcf7e906d24402731b33dfcc8d1