### PR TITLE
Add a sentence no notes liked if the no of notes liked is zero

### DIFF
--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -21,7 +21,13 @@
   <h3 style="margin-top:0;"><i class="fa fa-star-o"></i> <%= t('users.likes.liked_by') %> <a href="/profile/<%= @user.name %>"><%= @user.name %></a></h3>
 
   <hr />
-
-  <%= render :partial => "notes/notes" %>
+<% if @notes && @notes.length == 0 %>
+  <% if current_user && (current_user.id == @user.uid) %>
+    No notes liked by you.
+  <% else %>
+    <%= @user.name %> hasn't liked any notes.
+  <% end %>
+<% end %>
+ <%= render :partial => "notes/notes" %>
 
 </div>


### PR DESCRIPTION
Fixes #5188 (<=== Add issue number here)

User logged in or logged out.
![noteskjbjkadbvkl](https://user-images.githubusercontent.com/26685258/54661253-73b70180-4aff-11e9-8251-8569e26c824c.gif)

Accessing other user's notes_liked_by info
![dddddddddd](https://user-images.githubusercontent.com/26685258/54661398-f9d34800-4aff-11e9-9732-8dcf52408771.gif)

## Description
I provide a check that if the notes liked is zero then 
     * If the notes of user accessed and current user is same then the info provided is `No notes liked by you`
    * If the other user's notes_liked_by is being accessed then the info provided is `No notes liked by username of user `
    * If the user is logged out then user's own notes_liked by and other user's notes_liked by section would provide info `No notes liked by username of user `

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
