### PR TITLE
Add shortcut key '/' to focus on searchform

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -53,3 +53,4 @@
 //= require graph.js
 //= require wikis.js
 //= require header_footer.js
+//= require keybindings.js

--- a/app/assets/javascripts/keybindings.js
+++ b/app/assets/javascripts/keybindings.js
@@ -1,0 +1,8 @@
+$(document).ready(function () {
+    $(window).on('keypress', function (e) {
+        if (e.which === 47) {
+            $('#searchform_input').focus();
+            e.preventDefault();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #5174 (<=== Add issue number here)

After I pressed '/', the focus was on searchform input section.
![keypress](https://user-images.githubusercontent.com/26685258/54667976-c26e9680-4b13-11e9-91c2-411b44647c43.gif)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
