### PR TITLE
Fixes broken links for sorting the table on tag wiki pages

### DIFF
--- a/app/views/wiki/_wikis.html.erb
+++ b/app/views/wiki/_wikis.html.erb
@@ -1,12 +1,12 @@
 <% wikis = wikis || @wikis #accept local if present, default to instance %>
 <table class="table">
   <tr>
-    <th><a href = "<%= wiki_path %>?sort=title"> <%= t('wiki._wikis.title') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+    <th><a href = "?sort=title"> <%= t('wiki._wikis.title') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
     <th>URL</th>
-    <th><a href = "<%= wiki_path %>?sort=last_edited"> <%= t('wiki._wikis.last_edited') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
-    <th><a href = "<%= wiki_path %>?sort=edits"> <%= t('wiki._wikis.edits') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
-    <th><a href = "<%= wiki_path %>?sort=page_views"> <%= t('wiki._wikis.page_views') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
-    <th><a href = "<%= wiki_path %>?sort=likes"> <%= t('wiki._wikis.likes') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+    <th><a href = "?sort=last_edited"> <%= t('wiki._wikis.last_edited') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+    <th><a href = "?sort=edits"> <%= t('wiki._wikis.edits') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+    <th><a href = "?sort=page_views"> <%= t('wiki._wikis.page_views') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+    <th><a href = "?sort=likes"> <%= t('wiki._wikis.likes') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
   </tr>
   <% wikis.each do |wiki| %>
     <tr>
@@ -21,4 +21,3 @@
   <% end %>
 </table>
 <div class="text-center"><%= will_paginate wikis, :renderer => BootstrapPagination::Rails if @paginated %></div>
-


### PR DESCRIPTION
Fixes #5200

Before the change, these links linked to `/wiki?sort=<sort_param>`.

![wiki-tag-before](https://user-images.githubusercontent.com/451791/54681442-b7643800-4b0c-11e9-9ce5-0d937acefe95.gif)

After the change: `/wiki/tag/<tag_name>?sort=<sort_param>`.

![wiki-tag-after](https://user-images.githubusercontent.com/451791/54681459-be8b4600-4b0c-11e9-80f6-fa54879a4faa.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
