### PR TITLE
Fixing heading display in search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -39,7 +39,7 @@ class SearchController < ApplicationController
     @profiles = @nodes[:profiles]
     @questions = @nodes[:questions]
     @tags = @nodes[:tags]
-    @heading =search_heading
+    @heading = search_heading
   end
 
   private

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -39,6 +39,7 @@ class SearchController < ApplicationController
     @profiles = @nodes[:profiles]
     @questions = @nodes[:questions]
     @tags = @nodes[:tags]
+    @heading =search_heading
   end
 
   private
@@ -49,5 +50,14 @@ class SearchController < ApplicationController
 
   def search_params
     params.require(:search).permit(:query, :order)
+  end
+
+  def search_heading
+    heading=""
+    a=params[:query].split("+")
+    a.each do |b|
+      heading = heading+b+" "
+    end
+    return heading
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -53,11 +53,11 @@ class SearchController < ApplicationController
   end
 
   def search_heading
-    heading=""
-    a=params[:query].split("+")
+    heading = ""
+    a = params[:query].split("+")
     a.each do |b|
-      heading = heading+b+" "
+      heading = heading + b + " "
     end
-    return heading
+    heading
   end
 end

--- a/app/views/search/all_content.html.erb
+++ b/app/views/search/all_content.html.erb
@@ -3,12 +3,12 @@
 <div class="container">
   <% if  @nodes.all?{|k,v| v.blank?} %>
     <h4>
-      No Content found for <%= params[:query] %> :-(
+      No Content found for <%= @heading %> :-(
       </br></br>
       Try searching <a href="/search">for another topic</a>
     </h4>
   <% else %>
-    <h2> Results for <%= params[:query] %></h2>
+    <h2> Results for <%= @heading %></h2>
     <% unless @notes.blank? %>
       <h3> NOTES</h3>
       <table class="table inline-grid">


### PR DESCRIPTION
Fixes #5156 

The heading is now space separated instead of "+" separated for all content tab on both first and multiple results (ie selecting the tab after selecting another tab, say notes, will now yield the same heading)

![image](https://user-images.githubusercontent.com/40794215/54862688-69e20800-4d64-11e9-9ed4-45957fa82467.png)



