### PR TITLE
Direct user to profile page instead of Dashboard

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
           session[:openid_return_to] = nil
           redirect_to return_to
         else
-          flash[:notice] = I18n.t('users_controller.successful_updated_profile') + "<a href='/dashboard'>" + I18n.t('users_controller.return_dashboard') + " &raquo;</a>"
+          flash[:notice] = I18n.t('users_controller.successful_updated_profile') + "<a href='/profile'>" + I18n.t('users_controller.return_profile') + " &raquo;</a>"
           return redirect_to "/profile/" + @user.username + "/edit"
         end
       else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,7 +799,7 @@ en:
       you registered in order to use <b>SpectralWorkbench.org</b> or <b>MapKnitter.org</b>,
       <a href='%{url1}'>click here to continue &raquo;</a>"
     successful_updated_profile: "Successfully updated profile."
-    return_dashboard: "Return to your dashboard"
+    return_profile: "Return to your Profile Page"
     only_user_edit_profile: "Only <b>%{user}</b> can edit their profile."
     user_has_been_banned: "That user has been banned."
     user_has_been_moderated: "That user has been placed <a href='/wiki/moderation'>in


### PR DESCRIPTION
Fixes #5287  (<=== Add issue number here)

When user edit their bio, the flash message directs the user to the dashboard, instead a user should be directed to their profile page in order to view the changes.

![Screen Shot 2019-03-28 at 5 10 52 PM](https://user-images.githubusercontent.com/35326753/55154973-29c3c080-517c-11e9-9b7d-ed20df014de6.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
