### PR TITLE
wiki index sorting bug and styling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ script:
   - docker-compose exec web bash -c "mv chromedriver /usr/local/bin/chromedriver"
   - docker-compose exec web bash -c "chmod +x /usr/local/bin/chromedriver"
   - docker-compose exec web bash -c "CI=TRUE GENERATE_REPORT=true rake test:all"
-  - docker-compose exec web bash -c "CI=TRUE GENERATE_REPORT=true rails test -d"
-  - docker-compose exec web bash -c "CI=TRUE GENERATE_REPORT=true rails test:system"
+  - docker-compose exec web bash -c "CI=TRUE GENERATE_REPORT=true rails test:system test"
   - echo -e '<?xml version="1.0" encoding="UTF-8"?>' > output.xml
   - tail -n +2 -q ./test/reports/TEST*.xml >> output.xml
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then danger --verbose; fi'

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -309,7 +309,7 @@ class WikiController < ApplicationController
     when 'edits'
       order_string = 'drupal_node_revisions_count DESC'
     when 'page_views'
-      order_string = 'node.vid DESC'
+      order_string = 'node.views DESC'
     when 'likes'
       order_string = 'cached_likes DESC'
     end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -309,7 +309,7 @@ class WikiController < ApplicationController
     when 'edits'
       order_string = 'drupal_node_revisions_count DESC'
     when 'page_views'
-      order_string = 'drupal_node_revisions_count DESC'
+      order_string = 'node.vid DESC'
     when 'likes'
       order_string = 'cached_likes DESC'
     end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -301,15 +301,16 @@ class WikiController < ApplicationController
     sort_param = params[:sort]
     order_string = 'node_revisions.timestamp DESC'
 
-    if sort_param == 'title'
-      order_string = 'node_revisions.title ASC'
-    elsif sort_param == 'last_edited'
+    case sort_param
+    when 'title' 
+      order_string = 'node_revisions.body ASC'
+    when 'last_edited'
       order_string = 'node_revisions.timestamp DESC'
-    elsif sort_param == 'edits'
+    when 'edits'
       order_string = 'drupal_node_revisions_count DESC'
-    elsif sort_param == 'page_views'
-      order_string = 'views DESC'
-    elsif sort_param == 'likes'
+    when 'page_views'
+      order_string = 'drupal_node_revisions_count DESC'
+    when 'likes'
       order_string = 'cached_likes DESC'
     end
 

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -303,7 +303,7 @@ class WikiController < ApplicationController
 
     case sort_param
     when 'title' 
-      order_string = 'node_revisions.body ASC'
+      order_string = 'node.slug ASC'
     when 'last_edited'
       order_string = 'node_revisions.timestamp DESC'
     when 'edits'

--- a/app/views/wiki/_wikis.html.erb
+++ b/app/views/wiki/_wikis.html.erb
@@ -2,7 +2,6 @@
 <table class="table">
   <tr>
     <th><a href = "?sort=title"> <%= t('wiki._wikis.title') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
-    <th>URL</th>
     <th><a href = "?sort=last_edited"> <%= t('wiki._wikis.last_edited') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
     <th><a href = "?sort=edits"> <%= t('wiki._wikis.edits') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
     <th><a href = "?sort=page_views"> <%= t('wiki._wikis.page_views') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
@@ -11,7 +10,6 @@
   <% wikis.each do |wiki| %>
     <tr>
       <td style="width:50%"><i class="fa fa-file"></i> <a href="<%= wiki.path %>"><%= wiki.latest.title %></a></td>
-      <td><i><%= wiki.path %></i></td>
       <td><%= distance_of_time_in_words(Time.at(wiki.latest.created_at), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %> <%= raw t('wiki._wikis.by') %>
       <a href="/profile/<%= wiki.latest.author.name %>"><%= wiki.latest.author.name %></a></td>
       <td><%= wiki.revisions.length %></td>


### PR DESCRIPTION
Fixes #5317 

![all-sorted](https://user-images.githubusercontent.com/17080976/55389806-9b19bf80-553e-11e9-8732-648162dcc686.gif)

**Managed**
- wikis can now be sorted by any of the columns.

**Peculiar**
- last-edited column sorts perfectly locally but doesn't seem to work in production. So I can't reproduce the bug for sorting by last-edited.


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
