### PR TITLE
Use node views cache

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -166,12 +166,10 @@ class Node < ActiveRecord::Base
 
   public
 
-  is_impressionable counter_cache: true, column_name: :views
+  is_impressionable counter_cache: true, column_name: :views, unique: :ip_address
 
   def totalviews
-    # this doesn't filter out duplicate ip addresses as the line below does:
-    # self.views + self.legacy_views
-    impressionist_count(filter: :ip_address) + legacy_views
+    views + legacy_views
   end
 
   def self.weekly_tallies(type = 'note', span = 52, time = Time.now)

--- a/db/migrate/20190401093400_update_node_view_count.rb
+++ b/db/migrate/20190401093400_update_node_view_count.rb
@@ -1,0 +1,11 @@
+class UpdateNodeViewCount < ActiveRecord::Migration[5.2]
+  def up
+    Node.ids.each do |id|
+      node = Node.find(id)
+      node.update_columns(views: node.impressionist_count(filter: :ip_address))
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb.example
+++ b/db/schema.rb.example
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_30_043340) do
+ActiveRecord::Schema.define(version: 2019_04_01_093400) do
 
   create_table "answer_selections", force: true do |t|
     t.integer "user_id"

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -81,7 +81,7 @@ class NotesControllerTest < ActionController::TestCase
     assert_equal '0.0.0.0', Impression.last.ip_address
     Impression.last.update_attribute('ip_address', '0.0.0.1')
 
-    assert_difference 'note.totalviews', 1 do
+    assert_difference 'note.reload.totalviews', 1 do
       get :show,
           params: {
           author: note.author.name,
@@ -90,10 +90,10 @@ class NotesControllerTest < ActionController::TestCase
           }
     end
 
-    assert_equal 2, note.totalviews
+    assert_equal 2, note.reload.totalviews
 
     # same IP won't add to views twice
-    assert_difference 'note.totalviews', 0 do
+    assert_difference 'note.reload.totalviews', 0 do
       get :show,
           params: {
           author: note.author.name,

--- a/test/integration/node_unique_views_test.rb
+++ b/test/integration/node_unique_views_test.rb
@@ -12,7 +12,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
 
-    assert_difference 'nodes(:about).totalviews', 0 do
+    assert_difference 'nodes(:about).reload.totalviews', 0 do
       assert_difference 'Impression.count', 0 do
         get "/wiki/#{nodes(:about).slug}"
         assert_response :success
@@ -22,7 +22,7 @@ class NodeInsertExtrasTest < ActionDispatch::IntegrationTest
     assert_equal '127.0.0.1', Impression.last.ip_address
     assert Impression.last.update_attributes(ip_address: '0.0.0.0')
 
-    assert_difference 'nodes(:about).totalviews', 1 do
+    assert_difference 'nodes(:about).reload.totalviews', 1 do
       assert_difference 'Impression.count', 1 do
         get "/wiki/#{nodes(:about).slug}"
         assert_response :success


### PR DESCRIPTION
Fixes #1196

This should improve performance of various page loads, as it avoids
running COUNT() queries on the impressions table, and instead uses the
views value, which the impressions gem keeps up-to-date.

Notice that I update the tests to `.reload` the node before reading values,
because ActiveRecord caches those, which is why tests fail without it.

---

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
