### PR TITLE
Fixing query string in search results

### DIFF
--- a/app/views/search/_nav.html.erb
+++ b/app/views/search/_nav.html.erb
@@ -1,5 +1,5 @@
 <div class="list-group">
   <ul class="nav nav-pills">
-    <%= create_nav_links(section, CGI.escape(params[:query])) %>
+    <%= create_nav_links(section, url_encode(params[:query])) %>
   </ul>
 </div>

--- a/app/views/search/all_content.html.erb
+++ b/app/views/search/all_content.html.erb
@@ -3,12 +3,12 @@
 <div class="container">
   <% if  @nodes.all?{|k,v| v.blank?} %>
     <h4>
-      No Content found for <%= url_encode(params[:query]).gsub!('%2B',' ') %> :-(
+      No Content found for <%= CGI.unescape(params[:query]) %> :-(
       </br></br>
       Try searching <a href="/search">for another topic</a>
     </h4>
   <% else %>
-    <h2> Results for <%= url_encode(params[:query]).gsub!('%2B',' ') %></h2>
+    <h2> Results for <%= CGI.unescape(params[:query]) %></h2>
     <% unless @notes.blank? %>
       <h3> NOTES</h3>
       <table class="table inline-grid">

--- a/app/views/search/all_content.html.erb
+++ b/app/views/search/all_content.html.erb
@@ -3,12 +3,12 @@
 <div class="container">
   <% if  @nodes.all?{|k,v| v.blank?} %>
     <h4>
-      No Content found for <%= params[:query] %> :-(
+      No Content found for <%= url_encode(params[:query]).gsub!('%2B',' ') %> :-(
       </br></br>
       Try searching <a href="/search">for another topic</a>
     </h4>
   <% else %>
-    <h2> Results for <%= params[:query] %></h2>
+    <h2> Results for <%= url_encode(params[:query]).gsub!('%2B',' ') %></h2>
     <% unless @notes.blank? %>
       <h3> NOTES</h3>
       <table class="table inline-grid">

--- a/app/views/search/all_content.html.erb
+++ b/app/views/search/all_content.html.erb
@@ -3,12 +3,12 @@
 <div class="container">
   <% if  @nodes.all?{|k,v| v.blank?} %>
     <h4>
-      No Content found for <%= CGI.unescape(params[:query]) %> :-(
+      No Content found for <%= params[:query] %> :-(
       </br></br>
       Try searching <a href="/search">for another topic</a>
     </h4>
   <% else %>
-    <h2> Results for <%= CGI.unescape(params[:query]) %></h2>
+    <h2> Results for <%= params[:query] %></h2>
     <% unless @notes.blank? %>
       <h3> NOTES</h3>
       <table class="table inline-grid">


### PR DESCRIPTION
Fixes #5156 

Closing #5236 and moving to this one. 

Using url_encode to achieve the required string for displaying search results.

![image](https://user-images.githubusercontent.com/40794215/55410714-f325e580-5581-11e9-8120-51f609e10698.png)


