### PR TITLE
Add exact username search in user search query API.

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -224,9 +224,8 @@ class SearchService
             elsif ActiveRecord::Base.connection.adapter_name == 'Mysql2'
               type == 'username' ? User.search_by_username(query).where('rusers.status = ?', 1) : User.search(query).where('rusers.status = ?', 1)
             else
-              User.where('username LIKE ? AND rusers.status = 1', '%' + query + '%')
+              User.where('username LIKE ? OR username = ? AND rusers.status = 1', '%' + query + '%', query)
             end
-
     users.limit(limit)
   end
 end


### PR DESCRIPTION
Fixes: #5262

I checked which code block was getting executed and found that the `else` block is being exectued. I guess the `mysql` part already has `search with username`. This PR adds an `OR` clause with `exact` username search so that if the username exists then it is returned in the response.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 


## Screenshots
![Screenshot from 2019-04-05 16-56-35](https://user-images.githubusercontent.com/21174572/55624576-0aecac00-57c4-11e9-895c-9702f7ae7ffe.png)

Thanks!