### PR TITLE
power tag alert for the node

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -6,6 +6,11 @@
   <% if @node.has_power_tag('replication') %><div class="alert alert-info"><%= raw t('notes.show.replication') %> <a href="/n/<%= @node.power_tag('replication') %>"><%= raw t('notes.show.replication_link') %></a>.</div><% end %>
   <% if @node.has_power_tag('series') %><div class="alert alert-info"><%= raw t('notes.show.series') %> <a href="/tag/series:<%= @node.power_tag('series') %>"><%= @node.power_tag('series') %></a>.</div><% end %>
   <% if @node.has_power_tag('build') %><div class="alert alert-info"><%= raw t('notes.show.build') %> <a href="/n/<%= @node.power_tag('build') %>"><%= raw t('notes.show.build_link') %></a>.</div><% end %>
+  <% if @node.has_power_tag('alert') %>
+  <% cache('feature_alert-tags', skip_digest: true) do %>
+    <%= feature('alert-tags') %>
+<% end %>
+<% end %>
   <% if @node.has_power_tag('with') && current_user && @node.coauthors.collect(&:username).include?(current_user.username) %> <div class="alert alert-success"> You are a coauthor of this post. This attributes your contribution, and gives you edit access to the note. <a href="https://publiclab.org/wiki/power-tags#Coauthorship"> Learn more </a></div><% end %>
   <% if @node.has_power_tag('upgrade') %><div class="alert alert-success"> This is an upgrade for <a href="/<%= @node.power_tag('upgrade') %>"><%= @node.power_tag('upgrade') %></a>. Try building it and <a href="/n/<%= @node.power_tag('upgrade') %>"> report back </a>how it goes.</div><% end %>
 


### PR DESCRIPTION
Fixes #5327 (<=== Add issue number here)

If a admin add a powertag `alert:featurename` then the feature will be shown as alert on that node.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
