### PR TITLE
Add error message when email is nil or of a different pattern

### DIFF
--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -75,10 +75,12 @@
       <script>
         (function() {
           $('.btn-save').click(function onClick(e) {
-            if(document.form.email.text_field != "" || document.form.email.pattern == '[^@]+@[^@]+\.[a-zA-Z]{2,6}')
-                   {   $(this).addClass("disabled") // disable the button after it is clicked
-                     .html("<i class='fa fa-spinner fa-spin'></i>");} // make a spinner that spins when clicked
-          })
+            if(document.form.email.text_field != "" && document.form.email.pattern == '[^@]+@[^@]+\.[a-zA-Z]{2,6}')
+                   {
+                     $(this).addClass("disabled") // disable the button after it is clicked
+                     .html("<i class='fa fa-spinner fa-spin'></i>"); // make a spinner that spins when clicked
+                   }
+            })
         })();
       </script>
     </div>

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -75,9 +75,9 @@
       <script>
         (function() {
           $('.btn-save').click(function onClick(e) {
-            $(this).addClass("disabled") // disable the button after it is clicked
             if(document.form.email.text_field != "" || document.form.email.pattern == '[^@]+@[^@]+\.[a-zA-Z]{2,6}')
-                   {.html("<i class='fa fa-spinner fa-spin'></i>");} // make a spinner that spins when clicked
+                   {   $(this).addClass("disabled") // disable the button after it is clicked
+                     .html("<i class='fa fa-spinner fa-spin'></i>");} // make a spinner that spins when clicked
           })
         })();
       </script>

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -76,7 +76,7 @@
         (function() {
           $('.btn-save').click(function onClick(e) {
             $(this).addClass("disabled") // disable the button after it is clicked
-            if(document.form.email.text_field != "" || document.form.email.pattern != '[^@]+@[^@]+\.[a-zA-Z]{2,6}')
+            if(document.form.email.text_field != "" || document.form.email.pattern == '[^@]+@[^@]+\.[a-zA-Z]{2,6}')
                    {.html("<i class='fa fa-spinner fa-spin'></i>");} // make a spinner that spins when clicked
           })
         })();

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -26,7 +26,7 @@
       <div class="form-group col-sm-6">
 
         <label for="email"><%= t('users._form.email') %></label>
-        <%= f.text_field :email, { tabindex: 3, placeholder: "you@email.com", class: 'form-control', id: 'email' } %>
+        <%= f.text_field :email, { tabindex: 3, required: true, pattern: '[^@]+@[^@]+\.[a-zA-Z]{2,6}', placeholder: "you@email.com", class: 'form-control', id: 'email' } %>
       </div>
 
     </div>
@@ -76,7 +76,8 @@
         (function() {
           $('.btn-save').click(function onClick(e) {
             $(this).addClass("disabled") // disable the button after it is clicked
-                   .html("<i class='fa fa-spinner fa-spin'></i>"); // make a spinner that spins when clicked
+            if(document.form.email.text_field != "" || document.form.email.pattern != '[^@]+@[^@]+\.[a-zA-Z]{2,6}')
+                   {.html("<i class='fa fa-spinner fa-spin'></i>");} // make a spinner that spins when clicked
           })
         })();
       </script>


### PR DESCRIPTION
Fixes #5397  (<=== Add issue number here)

Adds an error message to the text field when the email field is blank or of a different pattern. 
Also, prevents the save button to be disabled when the email field entered is invalid. 

![Screen Shot 2019-04-07 at 4 34 47 PM](https://user-images.githubusercontent.com/35326753/55682675-45854e80-5954-11e9-84c8-3c6b7c9020ab.png)

![Screen Shot 2019-04-07 at 4 35 01 PM](https://user-images.githubusercontent.com/35326753/55682678-4ae29900-5954-11e9-97b8-cc30bfb05354.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
