### PR TITLE
fix the bug of traceback error of server on webpage

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -291,7 +291,7 @@ class TagController < ApplicationController
       if Tag.exists?(tagname, nid)
         @output[:errors] << I18n.t('tag_controller.tag_already_exists')
 
-      elsif tagname.include?(":") && tagname.split(':').length < 2 # cant tag empty power tags
+      elsif tagname.include?(":") && tagname.split(':').length < 2
         if tagname.split(':')[0] == "barnstar" || tagname.split(':')[0] == "with"
           @output[:errors] << I18n.t('tag_controller.cant_be_empty')
         end

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -287,25 +287,33 @@ class TagController < ApplicationController
     node = Node.find nid
     tagnames.each do |tagname|
       # this should all be done in the model:
-
+      tagname = tagname.strip
       if Tag.exists?(tagname, nid)
         @output[:errors] << I18n.t('tag_controller.tag_already_exists')
+
+      elsif tagname.include?(":") && tagname.split(':').length < 2 # cant tag empty power tags
+        if tagname.split(':')[0] == "barnstar" || tagname.split(':')[0] == "with"
+          @output[:errors] << I18n.t('tag_controller.cant_be_empty')
+        end
+
       elsif node.can_tag(tagname, current_user) === true || current_user.role == 'admin' # || current_user.role == "moderator"
         saved, tag = node.add_tag(tagname.strip, current_user)
-        if tagname.split(':')[0] == "barnstar"
-          CommentMailer.notify_barnstar(current_user, node)
-          barnstar_info_link = '<a href="//' + request.host.to_s + '/wiki/barnstars">barnstar</a>'
-          node.add_comment(subject: 'barnstar',
-                           uid: current_user.uid,
-                           body: "@#{current_user.username} awards a #{barnstar_info_link} to #{node.user.name} for their awesome contribution!")
+        if tagname.include?(":") && tagname.split(':').length == 2
+          if tagname.split(':')[0] == "barnstar"
+            CommentMailer.notify_barnstar(current_user, node)
+            barnstar_info_link = '<a href="//' + request.host.to_s + '/wiki/barnstars">barnstar</a>'
+            node.add_comment(subject: 'barnstar',
+                             uid: current_user.uid,
+                             body: "@#{current_user.username} awards a #{barnstar_info_link} to #{node.user.name} for their awesome contribution!")
 
-        elsif tagname.split(':')[0] == "with"
-          user = User.find_by_username_case_insensitive(tagname.split(':')[1])
-          CommentMailer.notify_coauthor(user, node)
-          node.add_comment(subject: 'co-author',
-                           uid: current_user.uid,
-                           body: " @#{current_user.username} has marked @#{tagname.split(':')[1]} as a co-author. ")
+          elsif tagname.split(':')[0] == "with"
+            user = User.find_by_username_case_insensitive(tagname.split(':')[1])
+            CommentMailer.notify_coauthor(user, node)
+            node.add_comment(subject: 'co-author',
+                             uid: current_user.uid,
+                             body: " @#{current_user.username} has marked @#{tagname.split(':')[1]} as a co-author. ")
 
+          end
         end
 
         if saved

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -862,6 +862,7 @@ en:
   tag_controller:
     tags: "Tags"
     tag_already_exists: "Error: that tag already exists."
+    cant_be_empty: "Error: Power Tag can't be empty."
     barnstar_not_created: "The barnstar could not be created."
     barnstar_awarded: "You awarded the <a href='%{url1}'>%{star} barnstar</a> to <a
       href='%{url2}'>%{awardee}</a>"


### PR DESCRIPTION
Fixes #5378 https://github.com/publiclab/plots2/issues/5404(<=== Add issue number here)

The changes - 
* If the user adds with tag like `with`,then  there won't be a traceback error like earlier
* If the user adds `with:` or `barnstars:` tag, then it won't show the traceback error rather it would show that the power tag can't be empty.
* The tagname is stripped of whitepaces in ends. As for admin, the code doesn't check condition to find username rather adds it directly. So In such cases the whitespace might be added. 

**Before changes**
![error](https://user-images.githubusercontent.com/26685258/55793164-e81e0880-5adf-11e9-8003-bdbb9fa41d19.gif)


**After changes**
![ff](https://user-images.githubusercontent.com/26685258/55792969-6f1eb100-5adf-11e9-9359-75d7cdd9936e.gif)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
