### PR TITLE
add routes, tests, views for CSV tag and node_tag stats downloads

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -100,6 +100,16 @@ class StatsController < ApplicationController
     format(data, 'answers')
   end
 
+  def tag
+    data = Tag.select(:tid, :name, :parent, :count).all
+    format(data, 'tag')
+  end
+
+  def node_tag
+    data = NodeTag.select(:tid, :nid, :uid).where(date: start.to_i...fin.to_i).all
+    format(data, 'node_tag')
+  end
+
   def comments
     data = Comment.where(status: 1, timestamp: start.to_i...fin.to_i).all
     format(data, 'comment')

--- a/app/views/stats/_range.html.erb
+++ b/app/views/stats/_range.html.erb
@@ -84,15 +84,20 @@
                 <%= link_to "Comments", stats_comments_path(format: 'csv', start: params[:start], end: params[:end]) %>
             </li>
             <li>
-                <li>
-                    <%= link_to "Users", stats_users_path(format: 'csv', start: params[:start], end: params[:end]) %>
-                </li>
-                <li>
-                    <%= link_to "Questions Asked", stats_questions_path(format: 'csv', start: params[:start], end: params[:end]) %>
-                </li>
-                <li>
-                    <%= link_to "Questions Answered", stats_answers_path(format: 'csv', start: params[:start], end: params[:end]) %>
-                </li>
+                <%= link_to "Users", stats_users_path(format: 'csv', start: params[:start], end: params[:end]) %>
+            </li>
+            <li>
+                <%= link_to "Questions Asked", stats_questions_path(format: 'csv', start: params[:start], end: params[:end]) %>
+            </li>
+            <li>
+                <%= link_to "Questions Answered", stats_answers_path(format: 'csv', start: params[:start], end: params[:end]) %>
+            </li>
+            <li>
+                <%= link_to "Tags (all)", stats_tags_path(format: 'csv') %>
+            </li>
+            <li>
+                <%= link_to "Node Tags", stats_node_tags_path(format: 'csv'), start: params[:start], end: params[:end] %>
+            </li>
         </ul>
     </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,9 @@ Plots2::Application.routes.draw do
   get 'stats/questions/:start/:end' => 'stats#questions'
   get 'stats/answers' => 'stats#answers'
   get 'stats/answers/:start/:end' => 'stats#answers'
+  get 'stats/tags' => 'stats#tags'
+  get 'stats/node_tags' => 'stats#node_tags'
+  get 'stats/node_tags/:start/:end' => 'stats#node_tags'
   get 'feed' => 'notes#rss'
   get 'rss.xml' => 'legacy#rss'
 

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -5,7 +5,7 @@ class StatsControllerTest < ActionController::TestCase
   def setup
     @start = 1.month.ago.to_time
     @end = Date.today.to_time
-    @stats =  [:notes, :comments, :users, :wikis, :questions, :answers]
+    @stats =  [:notes, :comments, :users, :wikis, :questions, :answers, :tags, :node_tags]
   end
 
   test 'should assign correct value to graph_notes on GET stats' do


### PR DESCRIPTION
Relates to #5412, providing routes, tests, and views. I tried to open this as a single first-timers-only issue but the issue at #5412 resulted in only one file's changes, so this is the rest. 