### PR TITLE
Extend #5372 BSTRP Check Box fix to all check boxes

### DIFF
--- a/app/assets/stylesheets/activity.css
+++ b/app/assets/stylesheets/activity.css
@@ -1,0 +1,4 @@
+#refreshA {
+  margin-right: 2px;
+}
+

--- a/app/assets/stylesheets/activity.css
+++ b/app/assets/stylesheets/activity.css
@@ -1,4 +1,0 @@
-#refreshA {
-  margin-right: 2px;
-}
-

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,6 +19,7 @@
  *= require_self
  *= require style
  *= require login_modal
+ *= require activity
  *= require feature
  *= require btsp_checkbox_override
  *= require editor

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,7 +19,6 @@
  *= require_self
  *= require style
  *= require login_modal
- *= require activity
  *= require feature
  *= require btsp_checkbox_override
  *= require editor

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,7 @@
  *= require leaflet/dist/leaflet.css
  *= require_self
  *= require style
+ *= require login_modal
  *= require feature
  *= require btsp_checkbox_override
  *= require editor

--- a/app/assets/stylesheets/btsp_checkbox_override.css.scss
+++ b/app/assets/stylesheets/btsp_checkbox_override.css.scss
@@ -26,7 +26,7 @@ div.form-check {
     margin-bottom: 0 !important; /* Override btsp's default `<label>` bottom margin */
   }
 
-  input[type=checkbox].form-check-input {
+  input[type=checkbox] {
     margin: 0 !important; /* zero out btsp's margin declaration */
     margin-top: 0 !important; 
     position: absolute !important;
@@ -39,3 +39,24 @@ div.form-check {
   }
 }
 
+div.form-check-inline {
+  position: relative !important;
+  display: inline-block;
+  padding-left: 1.75rem !important; /* btsp's default */ 
+
+  label.form-check-label {
+    margin-bottom: 0 !important; /* Override btsp's default `<label>` bottom margin */
+  }
+
+  input[type=checkbox] {
+    margin: 0 !important; /* zero out btsp's margin declaration */
+    margin-top: 0 !important; 
+    position: absolute !important;
+    margin-left: -1.75rem !important; /* btsp's default */
+    top: 50% !important;
+    -webkit-transform: translateY(-50%);
+    -moz-transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%) !important;
+  }
+}

--- a/app/assets/stylesheets/btsp_checkbox_override.css.scss
+++ b/app/assets/stylesheets/btsp_checkbox_override.css.scss
@@ -17,7 +17,7 @@ this is v.4 usage as well.
 - !important declarations ensure a Bootstrap update wont override these immediately
 */
 
-div.form-check {
+div.form-check, li.form-check {
   position: relative !important;
   display: block !important;
   padding-left: 1.75rem !important; /* btsp's default */
@@ -39,7 +39,7 @@ div.form-check {
   }
 }
 
-div.form-check-inline {
+div.form-check-inline, li.form-check-inline {
   position: relative !important;
   display: inline-block;
   padding-left: 1.75rem !important; /* btsp's default */ 

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -386,3 +386,15 @@
     margin-top:10px;
   }
 }
+
+#refreshA {
+  margin-right: 2px;
+}
+
+.topics-span {
+  font-size: 18px;
+}
+
+#subscribe {
+  margin-top: 10px;
+}

--- a/app/assets/stylesheets/editor.css
+++ b/app/assets/stylesheets/editor.css
@@ -106,7 +106,3 @@
   margin:3px 10px 10px;
   width:30%;
 }
-
-.checkbox-text-align { 
-  float:left;
-}

--- a/app/assets/stylesheets/login_modal.css.scss
+++ b/app/assets/stylesheets/login_modal.css.scss
@@ -1,0 +1,19 @@
+#socialIcons {
+  display:flex; 
+  justify-content: center;
+}
+
+.form-grey {
+  color:#888;
+}
+
+.login-form {
+  padding: 0 30px; 
+}
+
+#visibility {
+  color:#888;
+  pointer-events: auto;
+  line-height: 2.2em;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/login_modal.css.scss
+++ b/app/assets/stylesheets/login_modal.css.scss
@@ -3,10 +3,6 @@
   justify-content: center;
 }
 
-.form-grey {
-  color:#888;
-}
-
 .login-form {
   padding: 0 30px; 
 }

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -89,6 +89,7 @@ a .fa-white,
 
 .alert h2 {
   font-size:1.2em;
+  font-weight: 800;
 }
 
 .visible-print {

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -484,3 +484,7 @@ textarea, input {
     font-weight: normal;
     text-decoration: inherit;
 }
+
+.form-grey {
+  color:#888;
+}

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -139,7 +139,7 @@
         Cancel
       </a>
 
-    <span style="color:#888;"> &nbsp;
+    <span class="form-grey"> &nbsp;
       <br class="visible-xs" /><%= raw t('comments._edit.logged_in', :username => current_user.username) %> |
       <a target="_blank" href="/wiki/authoring-help#Formatting"><%= t('comments._edit.formatting') %></a> |
       <a onClick="$('#who-is-notified').toggle()"><%= t('comments._edit.notifications') %></a>

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -68,13 +68,13 @@
       <li><a href="#"><a href="#">Post date</a></li>
       <li><a href="#"><a href="#">Recent activity</a></li>
       -->
-      
+
     </ul>
 
   </div> &nbsp;
   <span class="hidden-xs"><%= t('dashboard._activity.from_other') %> <a href=""><%= t('dashboard._activity.community_scientists') %></a></span> <%= t('dashboard._activity.past_week') %>
   <% if current_user %>
-    <span class="hidden-xs">|<a href="/profile/<%= current_user.username %>"><%= t('dashboard._activity.your_work') %></a></span>
+    <span class="hidden-xs">| <a href="/profile/<%= current_user.username %>"><%= t('dashboard._activity.your_work') %></a></span>
   <% end %>
   <!-- (2 responses) -->
 </div>
@@ -83,14 +83,14 @@
 <%= feature('dashboard-activity-feature') %>
 
 <div>
-  <small><a href="/tags" style="color: #888;">Trending topics:</a></small>
-  <span style="font-size: 18px;">
+  <small><a href="/tags" class="form-grey">Trending topics:</a></small>
+  <span class="topics-span">
    <% cache('trending-tags', expires_in: 24.hours, skip_digest: true) do %>
       <% Tag.trending.each do |i| %>
         <span class="label label-primary"><a href="/tag/<%= i.name %>"><%= i.name %></a></span>
       <% end %>
     <% end %>
-</span>
+  </span>
 </div>
 <%= render partial: 'tag/subscribe_button', locals:{tags: Tag.trending} %>
 <div class="activity">

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -1,30 +1,65 @@
 <h3 id="activity-header"><i><%= t('dashboard._activity.activity') %></i></h3>
 
 <div class="activity-menu">
-  <a style="margin-right:2px;" href="/dashboard" class="btn btn-sm btn-default pull-right" type="button"><i class="fa fa-refresh"></i></a>
+  <a id="refreshA" href="/dashboard" class="btn btn-sm btn-default pull-right" type="button">
+    <i class="fa fa-refresh"></i>
+  </a>
 </div>
 
 <div class="meta activity-dropdown">
   <div class="btn-group">
 
-    <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button 
+      class="btn btn-default btn-sm dropdown-toggle" 
+      type="button" 
+      data-toggle="dropdown" 
+      aria-haspopup="true" 
+      aria-expanded="false"
+    >
       <span class="node-type-filter"><%= t('dashboard._activity.all_updates') %></span>
       <span class="caret"></span>
     </button>
 
     <ul class="dropdown-menu">
-
-      <li><a href="#"><label><input data-type="all"      class="node-type-all"      type="checkbox" checked="checked" /> <%= t('dashboard._activity.dropdown.all') %>           </label></a></li>
+      <li class="form-check"><a href="#">
+        <label class="form-check-label">
+          <input data-type="all" class="node-type-all" type="checkbox" checked="checked" /> 
+          <%= t('dashboard._activity.dropdown.all') %>
+        </label></a>
+      </li>
 
       <li class="divider"></li>
 
-      <li><a href="#"><label><input data-type="note"     class="node-type node-type-note"     type="checkbox" checked="checked" /> <%= t('dashboard._activity.dropdown.research_notes') %></label></a></li>
-      <li><a href="#"><label><input data-type="question" class="node-type node-type-question" type="checkbox" checked="checked" /> <%= t('dashboard._activity.dropdown.question') %>     </label></a></li>
-      <li><a href="#"><label><input data-type="event"    class="node-type node-type-event"    type="checkbox" checked="checked" /> <%= t('dashboard._activity.dropdown.events') %>        </label></a></li>
-      <li><a href="#"><label><input data-type="comment"  class="node-type node-type-comment"  type="checkbox" checked="checked" /> <%= t('dashboard._activity.dropdown.comments') %>      </label></a></li>
+      <li class="form-check"><a href="#">
+        <label class="form-check-label">
+          <input data-type="note" class="node-type node-type-note" type="checkbox" checked="checked" /> 
+          <%= t('dashboard._activity.dropdown.research_notes') %>
+        </label></a>
+      </li>
+      <li class="form-check"><a href="#">
+        <label class="form-check-label">
+          <input data-type="question" class="node-type node-type-question" type="checkbox" checked="checked" /> 
+          <%= t('dashboard._activity.dropdown.question') %>
+        </label></a>
+      </li>
+      <li class="form-check"><a href="#">
+        <label class="form-check-label">
+          <input data-type="event" class="node-type node-type-event" type="checkbox" checked="checked" /> 
+          <%= t('dashboard._activity.dropdown.events') %>
+        </label></a>
+      </li>
+      <li class="form-check"><a href="#">
+        <label class="form-check-label">
+          <input data-type="comment" class="node-type node-type-comment" type="checkbox" checked="checked" /> 
+          <%= t('dashboard._activity.dropdown.comments') %>
+        </label></a>
+      </li>
 
-      <li class="visible-sm visible-xs">
-          <a href="#"><label><input data-type="wiki"     class="node-type node-type-wiki"     type="checkbox" checked="checked" /> <%= t('dashboard._activity.dropdown.wiki') %>          </label></a>
+      <li class="visible-sm visible-xs"><a href="#">
+        <label>
+          <input data-type="wiki" class="node-type node-type-wiki" type="checkbox" checked="checked" /> 
+          <%= t('dashboard._activity.dropdown.wiki') %>
+        </label></a>
       </li>
 
       <!--
@@ -33,7 +68,7 @@
       <li><a href="#"><a href="#">Post date</a></li>
       <li><a href="#"><a href="#">Recent activity</a></li>
       -->
-
+      
     </ul>
 
   </div> &nbsp;

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -1,19 +1,25 @@
 <% if current_user && Time.now - current_user.created_at < 1.week %>
-    <div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">×</button>
 
-        <h2 style="font-weight: 800">Hello, welcome to Public Lab!</h2>
+  <div class="alert alert-success">
+    <button type="button" class="close" data-dismiss="alert">×</button>
 
-        This is your dashboard, where recent updates from other community members show up. It'll keep you updated with recent progress, news and developments.
-        <br>
-        To get started at Public Lab, try:
-        <br><br>
-      <p>
-      <a class="btn btn-sm btn-default" href="/questions" target="_blank">Asking a question</a>
+    <h2>Hello, welcome to Public Lab!</h2>
 
-      <a class="btn btn-sm btn-default" href="https://publiclab.org/methods" target="_blank">Exploring projects</a>
-      </p>
-    </div>
+    This is your dashboard, where recent updates from other community members show up. It'll keep you updated with recent progress, news and developments.
+    <br>
+    To get started at Public Lab, try:
+    <br><br>
+    <p>
+      <a class="btn btn-sm btn-default" href="/questions" target="_blank">
+        Asking a question
+      </a>
 
+      <a class="btn btn-sm btn-default" href="https://publiclab.org/methods" target="_blank">
+        Exploring projects
+      </a>
+    </p>
+  </div>
+  
 <% end %>
 
 <div class="dashboard container">

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -29,10 +29,15 @@
 <div class="pl-editor">
 
   <div class="ple-header">
-
     <h1>Share</h1>
-    <p><i>Or use the <a target="_blank" href="?<%= request.env['QUERY_STRING'] %>&legacy=true">legacy editor</a></i></p>
-
+    <p>
+      <i>
+        Or use the 
+        <a target="_blank" href="?<%= request.env['QUERY_STRING'] %>&legacy=true">
+          legacy editor
+        </a>
+      </i>
+    </p>
   </div>
 
   <div class="ple-content">
@@ -49,7 +54,11 @@
       </div>
 
       <div class="ple-module-content col-md-9">
-        <input class="form-control input-lg" type="text" placeholder="Title" value="<%= if @node then @node.title else params[:title] end %>" />
+        <input 
+          class="form-control input-lg" 
+          type="text" placeholder="Title" 
+          value="<%= if @node then @node.title else params[:title] end %>" 
+        />
       </div>
 
     </div>
@@ -64,18 +73,31 @@
       </div>
 
       <div class="ple-module-content col-md-9 container">
-        <div class="ple-drag-drop col-md-6">
-          Drag an image here to upload.
-        </div>
+        <div class="ple-drag-drop col-md-6">Drag an image here to upload.</div>
         <div class="col-md-6 help">
-
           <div style="display:none;" class="progress">
-            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div>
+            <div 
+              class="progress-bar progress-bar-striped active" 
+              role="progressbar" 
+              aria-valuenow="0" 
+              aria-valuemin="0" 
+              aria-valuemax="100" 
+              style="width: 0%;">
+            </div>
           </div>
-
-          <p><input type="file"  accept=".png, .jpg, .jpeg" name="image[photo]" value="<% if @node && @node.main_image(:rails) %><%= @node.main_image(:rails).id %><% else %><%= params[:main_image] %><% end %>" /></p>
-          <p class="ple-help"><span class="ple-help-minor">Select an optional main image for your post.</span></p>
-
+          <p>
+            <input 
+              type="file"  
+              accept=".png, .jpg, .jpeg" 
+              name="image[photo]" 
+              value="<% if @node && @node.main_image(:rails) %><%= @node.main_image(:rails).id %><% else %><%= params[:main_image] %><% end %>" 
+            />
+          </p>
+          <p class="ple-help">
+            <span class="ple-help-minor">
+              Select an optional main image for your post.
+            </span>
+          </p>
         </div>
       </div>
 
@@ -90,56 +112,93 @@
       </div>
 
       <div class="ple-module-content col-md-9">
-        <button id="location_button" class="btn btn-lg btn-default"><i class="fa fa-map-marker" aria-hidden="true"></i> Add a location</button>
-        <p class="ple-help"><span class="ple-help-minor">Search the map by entering a location's name or its latitude & longitude coordinates. You can also pan the map directly.</span></p>
+        <button id="location_button" class="btn btn-lg btn-default">
+          <i class="fa fa-map-marker" aria-hidden="true"></i> 
+          Add a location
+        </button>
+        <p class="ple-help">
+          <span class="ple-help-minor">
+            Search the map by entering a location's name or its latitude & longitude coordinates. You can also pan the map directly.
+          </span>
+        </p>
 
         <div id="map_content">    
           <div class="row">
             <div class="col-md-6"> 
-              <div id="map" class="leaflet-map" style="width: 100% ; height: 300px; margin-bottom:8px;"></div>
+              <div 
+                id="map" 
+                class="leaflet-map" 
+                style="width: 100% ; height: 300px; margin-bottom:8px;">
+              </div>
             </div>
 
             <div class="col-md-6">
               <label>By place name</label>
-                <p>
-                  <input id="placenameInput" type="text" class="form-control" />
-                </p>
-                <p>
-                  <label>Or by entering coordinates</label>
-                  <div class="row">
-                    <div class="col-md-6">
-                      <p><label>
+              <p>
+                <input id="placenameInput" type="text" class="form-control" />
+              </p>
+              <p><label>Or by entering coordinates</label></p>
+
+              <div class="row">
+                <div class="col-md-6">
+                  <p>
+                    <label>
                       Latitude
-                      <input id="lat" type="text" class="form-control" placeholder="Latitude" />
-                      </label></p>
-                    </div>  
-                    <div class="col-md-6">
-                      <p><label>
-                        Longitude
-                        <input id="lng" type="text" class="form-control" placeholder="Longitude" />
-                      </label></p>
-                    </div>
-                  </div>
-                </p>
-
-                <br>
-
-                <p><button class="btn btn-lg btn-default" onclick="editor.mapModule.blurredLocation.geocodeWithBrowser(true);">
-                  <div id="ldi-geocode-button">          
-                    <i class="fa fa-compass"></i> Use current location
-                  </div>
-                </button></p>
-
-                <br>
-                
-                <div class="form-check">
-                  <label class="form-check-label">
-                    <input id="obscureLocation" type="checkbox" class="form-check-input" onchange='editor.mapModule.blurredLocation.setBlurred(document.getElementById("obscureLocation").checked);'>
-                    Blur my location
-                  </label>
-                  <a href="https://publiclab.org/location-privacy">Learn more</a>
+                      <input 
+                        id="lat" 
+                        type="text" 
+                        class="form-control" 
+                        placeholder="Latitude" 
+                      />
+                    </label>
+                  </p>
                 </div>
-            </div>   
+
+                <div class="col-md-6">
+                  <p>
+                    <label>
+                      Longitude
+                      <input 
+                        id="lng" 
+                        type="text" 
+                        class="form-control" 
+                        placeholder="Longitude" 
+                      />
+                    </label>
+                  </p>
+                </div>
+              </div>
+
+              <br>
+
+              <p>
+                <button 
+                  class="btn btn-lg btn-default" 
+                  onclick="editor.mapModule.blurredLocation.geocodeWithBrowser(true);" 
+                >
+                  <div id="ldi-geocode-button">          
+                    <i class="fa fa-compass"></i> 
+                    Use current location
+                  </div>
+                </button>
+              </p>
+
+              <br>
+              
+              <div class="form-check">
+                <label class="form-check-label">
+                  <input 
+                    id="obscureLocation" 
+                    type="checkbox" 
+                    class="form-check-input" 
+                    onchange='editor.mapModule.blurredLocation.setBlurred(document.getElementById("obscureLocation").checked);'
+                  />
+                  Blur my location
+                </label>
+                <a href="https://publiclab.org/location-privacy">Learn more</a>
+              </div>
+
+            </div> 
           </div>
         </div>
       </div>
@@ -155,7 +214,9 @@
       </div>
 
       <div class="ple-module-content col-md-9 container">
-        <textarea id="text-input" class="ple-textarea form-control"><% if @node && @node.latest && @node.latest.body_rich %><%= @node.latest.body %><% else %><%= params[:body] %><% end %></textarea>
+        <textarea id="text-input" class="ple-textarea form-control">
+          <% if @node && @node.latest && @node.latest.body_rich %><%= @node.latest.body %><% else %><%= params[:body] %><% end %>
+        </textarea>
       </div>
 
     </div>
@@ -170,7 +231,12 @@
       </div>
 
       <div class="ple-module-content col-md-9">
-        <input class="form-control input-lg" type="text" placeholder="balloon-mapping, water-quality..." value="<% if params[:tags] || (@node && @node.tagnames) %><%= params[:tags] || @node.tagnames.join(',') %><% end %>" />
+        <input 
+          class="form-control input-lg" 
+          type="text" 
+          placeholder="balloon-mapping, water-quality..." 
+          value="<% if params[:tags] || (@node && @node.tagnames) %><%= params[:tags] || @node.tagnames.join(',') %><% end %>" 
+        />
       </div>
 
     </div>
@@ -212,21 +278,25 @@
 
     <div class="ple-menu-more" style="display:none;">
       <b>History</b>
-      <div class="ple-history">
-      </div>
+      <div class="ple-history"></div>
       <hr />
       <!--
       <div class="form-control input-md ple-history">
         <option selected value="">recent edits</option>
       </div>
       -->
-  </div>
+    </div>
 
     <button class="btn btn-lg btn-default btn-more">...</button>
 
-    <span> &nbsp; By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a><span class="hidden-xs"> so that others may use it.</span></span>
+    <span> &nbsp; By publishing, you agree to 
+      <a href="https://publiclab.org/licenses">open source your work</a>
+      <span class="hidden-xs"> so that others may use it.</span>
+    </span>
 
-    <button class="ple-publish btn btn-lg btn-primary pull-right disabled"><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
+    <button class="ple-publish btn btn-lg btn-primary pull-right disabled">
+      <% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %>
+    </button>
     <span class="ple-help pull-right">
       <% if controller.action_name != "edit" && !current_user.first_time_poster %>
         <span id="newOpts" style="display: inline-block;">

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -31,12 +31,7 @@
   <div class="ple-header">
     <h1>Share</h1>
     <p>
-      <i>
-        Or use the 
-        <a target="_blank" href="?<%= request.env['QUERY_STRING'] %>&legacy=true">
-          legacy editor
-        </a>
-      </i>
+      <i>Or use the <a target="_blank" href="?<%= request.env['QUERY_STRING'] %>&legacy=true">legacy editor</a></i>
     </p>
   </div>
 
@@ -56,7 +51,8 @@
       <div class="ple-module-content col-md-9">
         <input 
           class="form-control input-lg" 
-          type="text" placeholder="Title" 
+          type="text" 
+          placeholder="Title" 
           value="<%= if @node then @node.title else params[:title] end %>" 
         />
       </div>
@@ -94,9 +90,7 @@
             />
           </p>
           <p class="ple-help">
-            <span class="ple-help-minor">
-              Select an optional main image for your post.
-            </span>
+            <span class="ple-help-minor">Select an optional main image for your post.</span>
           </p>
         </div>
       </div>
@@ -117,9 +111,7 @@
           Add a location
         </button>
         <p class="ple-help">
-          <span class="ple-help-minor">
-            Search the map by entering a location's name or its latitude & longitude coordinates. You can also pan the map directly.
-          </span>
+          <span class="ple-help-minor">Search the map by entering a location's name or its latitude & longitude coordinates. You can also pan the map directly.</span>
         </p>
 
         <div id="map_content">    
@@ -288,15 +280,9 @@
     </div>
 
     <button class="btn btn-lg btn-default btn-more">...</button>
-
-    <span> &nbsp; By publishing, you agree to 
-      <a href="https://publiclab.org/licenses">open source your work</a>
-      <span class="hidden-xs"> so that others may use it.</span>
-    </span>
-
-    <button class="ple-publish btn btn-lg btn-primary pull-right disabled">
-      <% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %>
-    </button>
+   
+    <span> &nbsp; By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a><span class="hidden-xs"> so that others may use it.</span></span>
+    <button class="ple-publish btn btn-lg btn-primary pull-right disabled"><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
     <span class="ple-help pull-right">
       <% if controller.action_name != "edit" && !current_user.first_time_poster %>
         <span id="newOpts" style="display: inline-block;">

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -206,9 +206,7 @@
       </div>
 
       <div class="ple-module-content col-md-9 container">
-        <textarea id="text-input" class="ple-textarea form-control">
-          <% if @node && @node.latest && @node.latest.body_rich %><%= @node.latest.body %><% else %><%= params[:body] %><% end %>
-        </textarea>
+        <textarea id="text-input" class="ple-textarea form-control"><% if @node && @node.latest && @node.latest.body_rich %><%= @node.latest.body %><% else %><%= params[:body] %><% end %></textarea>
       </div>
 
     </div>

--- a/app/views/tag/_subscribe_button.html.erb
+++ b/app/views/tag/_subscribe_button.html.erb
@@ -1,13 +1,18 @@
 <!-- This button is used to display tags in a popover and subscribe to multiple tags using a single button -->
 <% if current_user %>
-  <a id="popover_button" class="btn btn-default btn-xs sub" > Subscribe <i class="fa fa-plus"></i> </a>
+  <a id="popover_button" class="btn btn-default btn-xs sub" >Subscribe 
+    <i class="fa fa-plus"></i> 
+  </a>
 
   <div id="mypopcontent" class="hidden">
   	<%= render partial: "tag/tags_popover", locals: {tags: tags} %>
   </div>
 
 <% else %>
-  <a class="btn btn-primary btn-xs sub" data-toggle="modal" data-target="#loginModal" role="button" aria-pressed="true"> Subscribe <i style="color:#ffffff;" class="fa fa-plus"></i> </a>
+  <a class="btn btn-primary btn-xs sub" data-toggle="modal" data-target="#loginModal" role="button" aria-pressed="true"> 
+    Subscribe 
+    <i style="color:#ffffff;" class="fa fa-plus"></i> 
+  </a>
 <% end %>
 
 <style>

--- a/app/views/tag/_tags_popover.html.erb
+++ b/app/views/tag/_tags_popover.html.erb
@@ -2,11 +2,13 @@
   <p class="small_heading"> Follow related tags: </p>
   <%= form_with remote: true, url: '/subscribe/multiple/tag' do |f| %>
     <% tags.each do |tag| %>
-    <div>
-      <input type="checkbox" id="<%= tag.id %>" name="tagnames[]" value="<%= tag.name %>" <% if current_user.following(tag.name) %> checked <% end %> ><span class="<% if tag.name.include?(':') %> label label-primary <% else %> label label-default <% end %>" style="margin-left: 3px; margin-right: 10px; display: inline-block;"> <%= tag.name %></span>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input type="checkbox" id="<%= tag.id %>" name="tagnames[]" value="<%= tag.name %>" <% if current_user.following(tag.name) %> checked <% end %> ><span class="<% if tag.name.include?(':') %> label label-primary <% else %> label label-default <% end %>" style="margin-left: 3px; margin-right: 10px; display: inline-block;"> <%= tag.name %></span>
+      </label>
     </div>
     <% end %>
-      <%= f.submit 'Subscribe', class: "btn btn-primary btn-sm", style: 'margin-top: 10px;' %>
+      <%= f.submit 'Subscribe', id: "subscribe", class: "btn btn-primary btn-sm" %>
   <% end %>
 </div>
 <style>

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -36,9 +36,10 @@
     <input type="hidden" name="hash_params" value="" />
 
     <div class="input-group-inline">
-
       <button class="btn btn-primary btn-lg" type="submit" tabindex="3"><%= t('user_sessions.new.log_in') %></button>
-      <label class="checkbox-inline" style="margin-left:12px;">
+
+      <div class="form-check-inline">
+      <label class="form-check-label" style="margin-left:12px;">
       <%= f.check_box :remember_me %> <%= t('user_sessions.new.remember_me') %>
       </label>
 

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -1,17 +1,22 @@
 <%= form_for :user_session, :as => :user_session, :url => "/user_sessions", :html => {:class => "form user-sessions-form"} do |f| %>
 
-  <input type="hidden" name="return_to" class="login-modal-redirect" value="<%= request.fullpath %>" />
+  <input 
+    type="hidden" 
+    name="return_to" 
+    class="login-modal-redirect" 
+    value="<%= request.fullpath %>" 
+  />
 
   <center>
     <h2><%= raw t('user_sessions.new.log_in') %></h2>
-    <p style="color:#888;" id="toSignup">or <a href="/signup"><%= raw t('user_sessions.new.sign_up') %></a> <%= raw t('user_sessions.new.to_join') %></p>
+    <p class="form-grey" id="toSignup">or <a href="/signup"><%= raw t('user_sessions.new.sign_up') %></a> <%= raw t('user_sessions.new.to_join') %></p>
   </center>
 
   <% if f.error_messages != "" %><div class="alert alert-danger"><%= f.error_messages %></div><% end %>
  
   <br style="clear:both;"/>
 
-  <div class='col-lg-12 col-md-12 col-sm-12' style="display:flex; justify-content: center;">
+  <div id="socialIcons" class='col-lg-12 col-md-12 col-sm-12'>
     <%= render :partial => "layouts/social_icons" %>
   </div>
 
@@ -19,19 +24,22 @@
 
   <br style="clear:both;"/>
 
-  <div id="toggle" style="padding-left: 30px; padding-right: 30px;">
-      
-      <div class="form-group">
-      
+  <div id="toggle" class="login-form">
+
+    <div class="form-group">
       <label for="username"><%= t('user_sessions.new.username') %></label>
       <%= f.text_field :username, { tabindex: 1, placeholder: "Username", class: 'form-control', id: 'username-login', required: true } %>
-      <div class="form-group has-feedback">
-      <label class="control-label" for="password"><%= t('user_sessions.new.password') %></label>
-        <%= f.password_field :password, { tabindex: 2,placeholder: "Password",class: 'form-control', id: 'password-signup', onpaste: 'return false;' , required: true } %>
-  <a id="visibility" class="fa fa-eye form-control-feedback" aria-hidden="true" style="color:#888;pointer-events: auto;line-height: 2.2em;text-decoration: none;"></a>
-</div>
 
-  </div>
+      <div class="form-group has-feedback">
+        <label class="control-label" for="password"><%= t('user_sessions.new.password') %></label>
+        <%= f.password_field :password, { tabindex: 2,placeholder: "Password",class: 'form-control', id: 'password-signup', onpaste: 'return false;' , required: true } %>
+        <a 
+          id="visibility" 
+          class="fa fa-eye form-control-feedback" 
+          aria-hidden="true">
+        </a>
+      </div> 
+    </div>
 
     <input type="hidden" name="hash_params" value="" />
 
@@ -39,16 +47,15 @@
       <button class="btn btn-primary btn-lg" type="submit" tabindex="3"><%= t('user_sessions.new.log_in') %></button>
 
       <div class="form-check-inline">
-      <label class="form-check-label" style="margin-left:12px;">
-      <%= f.check_box :remember_me %> <%= t('user_sessions.new.remember_me') %>
-      </label>
+        <label class="form-check-label" style="margin-left:12px;">
+        <%= f.check_box :remember_me %> <%= t('user_sessions.new.remember_me') %>
+        </label>
+      </div>
 
-    </div>
-
-  <br />
+      <br />
     
-  <p style="color: #888;"><%= raw t('user_sessions.new.reset_by_clicking_here', :url1 => "/reset/") %></p>
-  </div>
+      <p class="form-grey"><%= raw t('user_sessions.new.reset_by_clicking_here', :url1 => "/reset/") %></p>
+    </div>
 
   <% end %>
   

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -31,8 +31,7 @@
       <%= f.text_field :username, { tabindex: 1, placeholder: "Username", class: 'form-control', id: 'username-login', required: true } %>
 
       <div class="form-group has-feedback">
-        <label class="control-label" for="password">
-        <%= t('user_sessions.new.password') %></label>
+        <label class="control-label" for="password"><%= t('user_sessions.new.password') %></label>
         <%= f.password_field :password, { tabindex: 2,placeholder: "Password",class: 'form-control', id: 'password-signup', onpaste: 'return false;' , required: true } %>
         <a 
           id="visibility" 
@@ -45,9 +44,7 @@
     <input type="hidden" name="hash_params" value="" />
 
     <div class="input-group-inline">
-      <button class="btn btn-primary btn-lg" type="submit" tabindex="3">
-      <%= t('user_sessions.new.log_in') %>
-      </button>
+      <button class="btn btn-primary btn-lg" type="submit" tabindex="3"><%= t('user_sessions.new.log_in') %></button>
 
       <div class="form-check-inline">
         <label class="form-check-label" style="margin-left:12px;">
@@ -57,10 +54,10 @@
 
       <br />
     
-      <p class="form-grey">
-      <%= raw t('user_sessions.new.reset_by_clicking_here', :url1 => "/reset/") %>
-      </p>
+      <p class="form-grey"><%= raw t('user_sessions.new.reset_by_clicking_here', :url1 => "/reset/") %></p>
     </div>
+  
+  </div>
 
   <% end %>
   

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -31,7 +31,8 @@
       <%= f.text_field :username, { tabindex: 1, placeholder: "Username", class: 'form-control', id: 'username-login', required: true } %>
 
       <div class="form-group has-feedback">
-        <label class="control-label" for="password"><%= t('user_sessions.new.password') %></label>
+        <label class="control-label" for="password">
+        <%= t('user_sessions.new.password') %></label>
         <%= f.password_field :password, { tabindex: 2,placeholder: "Password",class: 'form-control', id: 'password-signup', onpaste: 'return false;' , required: true } %>
         <a 
           id="visibility" 
@@ -44,7 +45,9 @@
     <input type="hidden" name="hash_params" value="" />
 
     <div class="input-group-inline">
-      <button class="btn btn-primary btn-lg" type="submit" tabindex="3"><%= t('user_sessions.new.log_in') %></button>
+      <button class="btn btn-primary btn-lg" type="submit" tabindex="3">
+      <%= t('user_sessions.new.log_in') %>
+      </button>
 
       <div class="form-check-inline">
         <label class="form-check-label" style="margin-left:12px;">
@@ -54,7 +57,9 @@
 
       <br />
     
-      <p class="form-grey"><%= raw t('user_sessions.new.reset_by_clicking_here', :url1 => "/reset/") %></p>
+      <p class="form-grey">
+      <%= raw t('user_sessions.new.reset_by_clicking_here', :url1 => "/reset/") %>
+      </p>
     </div>
 
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,7 +284,7 @@ en:
         events: "Events"
         comments: "Comments"
         wiki: "Wiki"
-      from_other: "from other"
+      from_other: "From other"
       community_scientists: "community scientists"
       past_week: "in the past week"
       your_work: "Your work"


### PR DESCRIPTION
Fixes #5372, #5102    (<=== Add issue number here)

============================================================

Apparently every check-box in our repo is error-prone when it comes cross-browser compatibility in text to box alignment. (See screenshot of log-in check box below)

In this PR I will extend the overrides I made in https://github.com/publiclab/plots2/blob/master/app/assets/stylesheets/btsp_checkbox_override.css.scss#L20-L40 for a checkbox on our editor page to cover all Plots2 checkboxes ☔️

=============================================================

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
