### PR TITLE
Cross-browser compatible styling for input[type=file]

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,12 +11,13 @@
  * If there are other assets (which are not in this file) that are being precompiled by
  * 'stylesheet_link_tag' command in views, then add them on /config/initializers/assets.rb
 
-
+ 
  *= require bootstrap/dist/css/bootstrap.min.css
  *= require bootstrap-datepicker/dist/css/bootstrap-datepicker3.css
  *= require jquery-file-upload/css/jquery.fileupload-ui.css
  *= require leaflet/dist/leaflet.css
  *= require_self
+ *= require cross_browser
  *= require style
  *= require feature
  *= require btsp_checkbox_override

--- a/app/assets/stylesheets/cross_browser.css
+++ b/app/assets/stylesheets/cross_browser.css
@@ -1,0 +1,3 @@
+input[type="file"] {
+  line-height: 0 !important;
+}

--- a/app/assets/stylesheets/cross_browser.css
+++ b/app/assets/stylesheets/cross_browser.css
@@ -1,3 +1,14 @@
+/* 
+================================================================
+We can start using this file to document and fix all cross-browser inconsistencies 
+we find in one place 
+================================================================
+*/
+
+
+/* Firefox ignores line-height for input[type="file"] but Chrome doesn't and the result
+with Bootstrap styling is it gets misaligned in Chrome. This fix is confirmed to create 
+compatible alignment in Chrome, Safari, and Firefox in MacOS */ 
 input[type="file"] {
   line-height: 0 !important;
 }


### PR DESCRIPTION
Fixes #5423  (<=== Add issue number here)

===============================================
After applying a `line-height: 0` globally to `input[type=file]`:

Chrome: improved - now better
<img width="207" alt="chome-fix" src="https://user-images.githubusercontent.com/41092741/55776696-9471d780-5a6b-11e9-9a59-42df0b180542.png">

Firefox: stays the same (perfect)
<img width="223" alt="firefox-fix" src="https://user-images.githubusercontent.com/41092741/55776772-d26efb80-5a6b-11e9-9547-28d7c3f57610.png">

Safari: improved -now perfect
<img width="200" alt="safari-fix" src="https://user-images.githubusercontent.com/41092741/55776857-106c1f80-5a6c-11e9-9520-d3fd4451a36d.png">

===============================================

OLD ones pasted in from original issue for easy reference:
<img width="394" alt="before after " src="https://user-images.githubusercontent.com/41092741/55777017-9d16dd80-5a6c-11e9-9077-f3a9061bdf38.png">


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
