### PR TITLE
Prevent multiple builds for internal PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
 
 before_install:
   - echo -e "repo_token:\n  $COVERALLS_REPO_TOKEN" >> ./.coveralls.yml
+  
+branches:
+  only:
+    - master
+    - unstable
 
 install:
   - cp config/database.yml.example config/database.yml


### PR DESCRIPTION
Fixes #5436 

Fix multiple builds by running travis only on some branches.
This is similar to what has been done for mapknitter https://github.com/publiclab/mapknitter/pull/494
