### PR TITLE
Fixes number of "wiki edits" displayed on Dashboard

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,10 +33,17 @@ class HomeController < ApplicationController
       @note_count = Node.select(%i(created type status))
         .where(type: 'note', status: 1, created: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
         .count(:all)
-      @wiki_count = Revision.select(:timestamp)
+
+      @wiki_count = Revision
+        .includes(:node)
         .where(timestamp: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
-        .count
+        .where('node.type IN (?, ?, ?)', 'page', 'tool', 'place')
+        .where('node_revisions.status = 1')
+        .where('node.status = 1')
+        .distinct.count('nid')
+
       @user_note_count = Node.where(type: 'note', status: 1, uid: current_user.uid).count
+
       @activity, @blog, @notes, @wikis, @revisions, @comments, @answer_comments = activity
       render template: 'dashboard/dashboard'
     else


### PR DESCRIPTION
Fixes #5446

The query used to count recent wiki edits was not limited to counting
only wiki pages, published ones, and distint pages (i.e. do not count
multiple revisions of the same page).

This resulted in a major difference between what the person sees on
their dashboard vs. when they scroll through the list on `/wiki`, which
shows a more accurate number of recent changes.

This commit fixes the problem and adds a test that verifies it.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
