### PR TITLE
Add character limit to wiki titles

### DIFF
--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -99,6 +99,39 @@
         </script>
 
       <% end %>
+
+      <input id="has_main_image" type="hidden" name="has_main_image" value="<% if @node && @node.main_image %>true<% end %>" />
+      <input id="main_image" type="hidden" name="main_image" value="<% if @node && @node.main_image(:rails) %><%= @node.main_image(:rails).id %><% else %><%= params[:main_image] %><% end %>" />
+      <input id="images_input" type="hidden" name="images" value="" />
+
+      <input id="taginput" type="hidden" name="tags" value="<%= params[:tags] %>" />
+
+      <div class="form-group">
+        <input tabindex="1" name="title" type="text" class="form-control" id="title" maxlength="50" value="<% if @node && @node.latest %><%= @node.latest.title %><% else %><%= params[:title] %><% end %>">
+      </div>
+
+      <script>
+        (function(){
+          $D = {
+            uid: <%= current_user.uid %>,
+            type: 'wiki'
+          }
+        })()
+      </script>
+
+      <%= render partial: 'editor/editor' %>
+
+      <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg"><%= t('wiki.edit.publish') %></a>
+      <a tabindex="6" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-default btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
+      <a class="btn btn-default btn-lg" href="/wiki/<%= params["id"] %>">Cancel</a>
+
+    </div>
+
+    <div style="clear:both;">
+      <br />
+      <p class="col-md-12"><%= raw t('wiki.edit.agree_to_open_source_work', :url1 => "/licenses") %></p>
+      <% if @node && @node.latest %><p style="padding:10px 0 0 0;"><i><%= raw t('wiki.edit.last_edited_by', :time => time_ago_in_words(@node.latest.created_at), :url1 => "/profile/"+@node.latest.author.name, :author => @node.latest.author.name) %></i></p><% end %>
+      <br />
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #5426

Added `maxlength="50"` to the input for wiki titiles. 
I ran rails `test:integration` with 0 failures and 0 errors. 

![Screenshot](http://jeremypurser.com/assets/images/plots_ss.png)
I copied a string where the 51st character was "b", but it didn't get pasted because of the character limit.

* [x ] PR is descriptively titled 📑 and links the original issue above 🔗
* [x ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x ] screenshots/GIFs are attached 📎 in case of UI updation
* [x ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
