### PR TITLE
Make spamaway ids unique

### DIFF
--- a/app/views/layouts/_signupLoginModal.html.erb
+++ b/app/views/layouts/_signupLoginModal.html.erb
@@ -12,7 +12,7 @@
         <div class="clearfix"> <!-- clearfix class allows the modal to expand to fit the content of this div -->
           <div id="signupContainer">
             <!-- signup partial -->
-            <%= render partial: "users/create_form" %>
+            <%= render partial: "users/create_form" , locals: {caller: "modal"} %>
           </div>
 
           <div id="loginContainer">

--- a/app/views/users/_create_form.html.erb
+++ b/app/views/users/_create_form.html.erb
@@ -85,7 +85,7 @@
     <% else %>
 
     <div class="col-sm-12">
-      <%= render partial: 'users/spamaway' %>
+      <%= render partial: 'users/spamaway', locals: {caller: caller } %>
     </div>
 
       <script>

--- a/app/views/users/_spamaway.html.erb
+++ b/app/views/users/_spamaway.html.erb
@@ -16,8 +16,8 @@
         <div class="btn-group btn-group-justified" role="group">
           <% [0,1].each_with_index do |s, j| %><% statement = turingtest[i][s] %>
             <div class="btn-group" role="group">
-              <button type="button" class="col-xs-5 btn btn-default" style="font-size:3em;text-align:left;<% if i.odd? %> background:#eef;<% end %>" id="spamaway-<%= i.to_s + j.to_s %>">
-                <%= spam.radio_button vars[i], statement %> <%= statement %>
+              <button type="button" class="col-xs-5 btn btn-default" style="font-size:3em;text-align:left;<% if i.odd? %> background:#eef;<% end %>" id="spamaway-<%= caller %>-<%= i.to_s + j.to_s %>">
+              <%= spam.radio_button vars[i], statement, { id: "spamaway_statement_#{caller}_#{i.to_s}#{j.to_s}" } %> <%= statement %>
               </button>
             </div>
           <% end %>
@@ -33,7 +33,8 @@
     <%= spam.text_area :follow_instructions, { class: "form-control col-md-6",
                                              rows: 8,
                                              tabindex: 7,
-                                             placeholder: I18n.t('users._form.dont_write_here') }
+                                             placeholder: I18n.t('users._form.dont_write_here'),
+                                             id: 'spamaway-'+caller }
     %>
 
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,7 +22,7 @@
 
   <br />
 
-   <%= render 'create_form' %> 
+   <%= render partial: 'users/create_form', locals: {caller: "signup"} %> 
 
   <br style="margin-bottom:20px;" />
 


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/4966 (<=== Add issue number here)

## Description
Earlier , the callers for `create_form` template were `modal` and `/signup` , the ids were only decided by the no of `spamaway` which was leading it to have non-unique ids.
The approach to deal with it was - 
I've passed local variables as the argument. 
The argument tells us about the caller who is calling the `create_form` template which are `loginmodal` form and another for `/signup` form.
The values passed from both of the callers is concatenated in spamaway ids. Thus making the ids unique as both the callers are passing different values. 
<br>   

The gif below shows that there is no more console error regarding spamaway ids.
Though I found there are some other errors for which I opened issue https://github.com/publiclab/plots2/issues/5466


![id](https://user-images.githubusercontent.com/26685258/56051242-9c7f8f00-5d6b-11e9-9b71-5db1c32a3813.gif)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
