### PR TITLE
Fix the inconsistent fields in signup form ui

### DIFF
--- a/app/views/users/_create_form.html.erb
+++ b/app/views/users/_create_form.html.erb
@@ -19,9 +19,8 @@
     </div>
 
     <br style="clear:both;"/>
-    
-      <div class="row col-sm-6">
-     
+      <div class="col-sm-6">
+        <div class="row">
         <div class="form-group col-sm-12" id="username_div">
           <label for="username"><%= t('user_sessions.new.username') %></label>
           <%= f.text_field :username, { tabindex: 1, placeholder: "Username", class: 'form-control', id: 'username-signup' } %>
@@ -31,7 +30,7 @@
           <label for="email"><%= t('users._form.email') %></label>
           <%= f.text_field :email, { tabindex: 3, placeholder: "you@email.com", class: 'form-control', id: 'email' } %>
         </div>
-     
+        </div>
       </div>
      
       <div class="col-sm-6" style="display:flex; justify-content: center;">
@@ -46,7 +45,7 @@
         </div>
       </div>
 
-    <div class="form-group col-sm-12 row">
+    <div class="form-group col-sm-12 nopadding">
       <div class="form-group col-sm-6">
         <label for="password"><%= t('users._form.create_password') %></label>
         <%= f.password_field :password, { placeholder: 'Enter your new password',
@@ -170,4 +169,9 @@
       cursor: inherit;
       display: block;
   }
+  .nopadding {
+    padding: 0 !important;
+    margin: 0 !important;
+ }
+
 </style>


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/5464 one part (<=== Add issue number here)

Signup form had many nested bootstrap classes. And due to bootstrap classes providing padding. The fields were inconsistent.

## Earlier
![Screenshot from 2019-04-15 15-04-01](https://user-images.githubusercontent.com/26685258/56122303-bd282e80-5f8f-11e9-89df-3038c9ee242a.png)

## Now
![Screenshot from 2019-04-15 15-03-10](https://user-images.githubusercontent.com/26685258/56122257-a08bf680-5f8f-11e9-8f68-034f5935c8f5.png)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
