### PR TITLE
 Pages tagged with place get a full-width map across the top of the page (instead of in the sidebar)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,7 +94,11 @@ module ApplicationHelper
 
   # we should move this to the Node model:
   def render_map(lat, lon)
-    render partial: 'map/leaflet', locals: { lat: lat, lon: lon }
+    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, top_map: false }
+  end
+
+  def render_top_map(lat,lon)
+    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, top_map: true }
   end
 
   # we should move this to the Comment model:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,7 +97,7 @@ module ApplicationHelper
     render partial: 'map/leaflet', locals: { lat: lat, lon: lon, top_map: false }
   end
 
-  def render_top_map(lat,lon)
+  def render_top_map(lat, lon)
     render partial: 'map/leaflet', locals: { lat: lat, lon: lon, top_map: true }
   end
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -435,7 +435,7 @@ class Node < ActiveRecord::Base
     end
   end
 
-  # accests a tagname /or/ tagname ending in wildcard such as "tagnam*"
+  # access a tagname /or/ tagname ending in wildcard such as "tagnam*"
   # also searches for other tags whose parent field matches given tagname,
   # but not tags matching given tag's parent field
   def has_tag(tagname)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -106,7 +106,7 @@
   <body>
 
     <%= render :partial => 'layouts/header' %>
-
+    <div id="top_map"> </div>
     <div class="container">
       <div class="row">
 

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -1,19 +1,41 @@
 <%= render :partial => "map/mapDependencies" %>
 
+<% top_map = top_map || false %>
+
   <% unique_id = rand(1000) %>
+
+<% if top_map == true %>
+
+  <style>
+  #top_map { width:100%; height:300px; margin: 0 ; margin-top: -15px ; margin-bottom: 15px ; position: relative;}
+  </style>
+
+<% else %>
   <style>
   #map<%= unique_id %> { width:100%; height:300px; margin: 0; position: relative;}
   </style>
   <div class="leaflet-map" id="map<%= unique_id %>"></div>
   <% if defined? people %><p><i><small>Share your own location on <a href='/profile'>your profile</a>.</small></i></p><% end %>
-  <script>
+<% end %>  
 
+  <script>
     var bounds = new L.LatLngBounds(new L.LatLng(84.67351257 , -172.96875) , new L.LatLng(-54.36775852 , 178.59375)) ;
+
+    <% if top_map == true %>
+
+    var map<%= unique_id %> = L.map('top_map' , {
+      maxBounds: bounds ,
+      maxBoundsViscosity: 0.75
+    }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
+
+    <% else %>
 
     var map<%= unique_id %> = L.map('map<%= unique_id %>' , {
       maxBounds: bounds ,
       maxBoundsViscosity: 0.75
     }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
+
+    <% end %>
 
     var markers_hash<%= unique_id %> = new Map() ;
 

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -1,15 +1,11 @@
 <%= render :partial => "map/mapDependencies" %>
-
 <% top_map = top_map || false %>
-
-  <% unique_id = rand(1000) %>
+<% unique_id = rand(1000) %>
 
 <% if top_map == true %>
-
   <style>
   #top_map { width:100%; height:300px; margin: 0 ; margin-top: -15px ; margin-bottom: 15px ; position: relative;}
   </style>
-
 <% else %>
   <style>
   #map<%= unique_id %> { width:100%; height:300px; margin: 0; position: relative;}
@@ -22,23 +18,18 @@
     var bounds = new L.LatLngBounds(new L.LatLng(84.67351257 , -172.96875) , new L.LatLng(-54.36775852 , 178.59375)) ;
 
     <% if top_map == true %>
-
-    var map<%= unique_id %> = L.map('top_map' , {
-      maxBounds: bounds ,
-      maxBoundsViscosity: 0.75
-    }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
-
+      var map<%= unique_id %> = L.map('top_map' , {
+        maxBounds: bounds ,
+        maxBoundsViscosity: 0.75
+      }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
     <% else %>
-
-    var map<%= unique_id %> = L.map('map<%= unique_id %>' , {
-      maxBounds: bounds ,
-      maxBoundsViscosity: 0.75
-    }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
-
+      var map<%= unique_id %> = L.map('map<%= unique_id %>' , {
+        maxBounds: bounds ,
+        maxBoundsViscosity: 0.75
+      }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
     <% end %>
 
     var markers_hash<%= unique_id %> = new Map() ;
-
     var map_lat = <%= lat %> ;
     var map_lon = <%= lon %> ;
 
@@ -132,6 +123,5 @@
            map<%= unique_id %>.spin(false) ;
        });
    }) ;
-
-
+   
   </script>

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -44,7 +44,9 @@
   <% if @node && @node.has_power_tag('response') %>
     <%= render partial: 'sidebar/notes', locals: { notes: @node.responses, title: I18n.t('sidebar._related.responses_to_note'), node: @node } %>
   <% end %>
-  <% if @node && !@node.has_power_tag('place') && @node.lat && @node.lon %>
+  <% if @node  && @node.has_tag("place") && @node.lat && @node.lon %>
+    <%= render_top_map(@node.lat, @node.lon) %>
+  <% elsif @node && @node.lat && @node.lon %>
     <%= render_map(@node.lat, @node.lon) %>
   <% elsif @node&.has_power_tag('place') && !@node.lat && !@node.lon %>
     <div id="map_template" style="position: relative; display: inline-block;">

--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -76,6 +76,12 @@ blog2:
   nid: 13
   date: <%= DateTime.now.to_i %>
 
+place:
+  tid: 27
+  uid: 1
+  nid: 13
+  date: <%= DateTime.now.to_i %>
+
 question3:
   tid: 6
   uid: 2

--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -79,7 +79,7 @@ blog2:
 place:
   tid: 27
   uid: 1
-  nid: 12
+  nid: 13
   date: <%= DateTime.now.to_i %>
 
 question3:

--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -79,7 +79,7 @@ blog2:
 place:
   tid: 27
   uid: 1
-  nid: 13
+  nid: 12
   date: <%= DateTime.now.to_i %>
 
 question3:

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -103,3 +103,7 @@ SubLatitudeLongitude2:
 balloon:
   tid: 26
   name: balloon
+
+place:
+  tid: 27
+  name: place

--- a/test/system/place_tags_test.rb
+++ b/test/system/place_tags_test.rb
@@ -2,13 +2,16 @@ require "application_system_test_case"
 
 class PlaceTagsTest < ApplicationSystemTestCase
 
+  # node blog has lat and lon tag and place tag .	
   test "pages tagged with place get a full-width map across the top of the page" do
-    visit nodes(:map).path
-    assert_select "div.leaflet-layer"
-    assert_select "div#top_map"
+    visit nodes(:blog).path
+    assert_selector('h1', text: 'Blog post')
+    #assert_select "div.leaflet-layer"
+    #assert_select "div#top_map"
   end
 
-  test "pages not tagged with place ges a side map" do
+  # node map has lat and lon tag but no place tag .
+  test "pages not tagged with place gets a side map" do
     visit nodes(:map).path
     assert_select "div#top_map" , :count => 0 
   end

--- a/test/system/place_tags_test.rb
+++ b/test/system/place_tags_test.rb
@@ -6,8 +6,7 @@ class PlaceTagsTest < ApplicationSystemTestCase
   test "pages tagged with place get a full-width map across the top of the page" do
     visit nodes(:blog).path
     assert_selector('h1', text: 'Blog post')
-    assert_select "div"
-    #assert_select "div#top_map"
+    assert_selector('div#top_map')
   end
 
   # node map has lat and lon tag but no place tag .

--- a/test/system/place_tags_test.rb
+++ b/test/system/place_tags_test.rb
@@ -1,0 +1,11 @@
+require "application_system_test_case"
+
+class PlaceTagsTest < ApplicationSystemTestCase
+
+  test "pages tagged with place get a full-width map across the top of the page" do
+    visit nodes(:blog).path
+    assert_select "div#top_map"
+    assert_select "div.leaflet-layer"
+  end
+
+end

--- a/test/system/place_tags_test.rb
+++ b/test/system/place_tags_test.rb
@@ -7,12 +7,14 @@ class PlaceTagsTest < ApplicationSystemTestCase
     visit nodes(:blog).path
     assert_selector('h1', text: 'Blog post')
     assert_selector('div#top_map')
+    assert_selector('div.leaflet-layer')
   end
 
-  # node map has lat and lon tag but no place tag .
+  # one map has no place tag .
   test "pages not tagged with place gets a side map" do
-    visit nodes(:map).path
-    assert_select "div#top_map" , :count => 0 
+    visit nodes(:one).path
+    assert_selector('h1', text: 'Canon A1200 IR conversion at PLOTS Barnraising at LUMCON')
+    assert_selector('div.leaflet-layer' , count: 0)
   end
 
 end

--- a/test/system/place_tags_test.rb
+++ b/test/system/place_tags_test.rb
@@ -6,7 +6,7 @@ class PlaceTagsTest < ApplicationSystemTestCase
   test "pages tagged with place get a full-width map across the top of the page" do
     visit nodes(:blog).path
     assert_selector('h1', text: 'Blog post')
-    #assert_select "div.leaflet-layer"
+    assert_select "div"
     #assert_select "div#top_map"
   end
 

--- a/test/system/place_tags_test.rb
+++ b/test/system/place_tags_test.rb
@@ -3,9 +3,14 @@ require "application_system_test_case"
 class PlaceTagsTest < ApplicationSystemTestCase
 
   test "pages tagged with place get a full-width map across the top of the page" do
-    visit nodes(:blog).path
-    assert_select "div#top_map"
+    visit nodes(:map).path
     assert_select "div.leaflet-layer"
+    assert_select "div#top_map"
+  end
+
+  test "pages not tagged with place ges a side map" do
+    visit nodes(:map).path
+    assert_select "div#top_map" , :count => 0 
   end
 
 end


### PR DESCRIPTION
Continued from https://github.com/publiclab/leaflet-blurred-location-display/issues/64#issuecomment-482655146 😄 !

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

### Screenshots : 

*   **With `place` tag :** 

<img width="1440" alt="Screenshot 2019-04-18 at 2 53 11 PM" src="https://user-images.githubusercontent.com/14952645/56352357-bc400880-61ec-11e9-9af0-7b64255a1d34.png">

*   **Without `place` tag :** 

<img width="1440" alt="Screenshot 2019-04-18 at 3 04 31 PM" src="https://user-images.githubusercontent.com/14952645/56352359-bc400880-61ec-11e9-9198-029357421d16.png">

*   **human-readable placename is already added as a tag via LBL model :** 

<img width="338" alt="Screenshot 2019-04-18 at 3 07 28 PM" src="https://user-images.githubusercontent.com/14952645/56352360-bcd89f00-61ec-11e9-9707-3fd68aa89060.png">


Thanks!
