### PR TITLE
Recently used location in LBL modal .

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -433,7 +433,9 @@ class Node < ActiveRecord::Base
   end
 
   def location_tags
-    if lat && lon
+    if lat && lon && place
+      power_tag_objects('lat') + power_tag_objects('lon') + power_tag_objects('place')
+    elsif lat && lon
       power_tag_objects('lat') + power_tag_objects('lon')
     else
       []
@@ -560,6 +562,14 @@ class Node < ActiveRecord::Base
   def lon
     if has_power_tag('lon')
       power_tag('lon').to_f
+    else
+      false
+    end
+  end
+
+  def place
+    if has_power_tag('place')
+      power_tag('place')
     else
       false
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -444,7 +444,7 @@ class User < ActiveRecord::Base
     end
   end
 
-  def get_latest_used_locations
+  def get_all_used_locations
     latest_locations = [] 
     nodes = self.nodes.order('nid DESC').where(status: 1)
     nodes.each_with_index do |node , i|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -444,6 +444,35 @@ class User < ActiveRecord::Base
     end
   end
 
+  def get_latest_used_locations
+    latest_locations = [] 
+    nodes = self.nodes.order('nid DESC').where(status: 1)
+    nodes.each_with_index do |node , i|
+      location_tags = node.location_tags
+      if location_tags.count > 0
+         latest_locations << location_tags
+      end
+    end
+    latest_locations
+  end
+
+  def get_latest_used_location
+    latest_location = [] 
+    nodes = self.nodes.order('nid DESC').where(status: 1)
+    nodes.each_with_index do |node , i|
+      location_tags = node.location_tags
+      if location_tags.count > 0
+         latest_location << location_tags
+         break
+      end
+    end
+    if latest_location.count > 0
+      latest_location[0][0] = latest_location[0][0].name.split(":")[1].to_f ;
+      latest_location[0][1] = latest_location[0][1].name.split(":")[1].to_f ;
+    end
+    latest_location
+  end
+
   private
 
   def decrease_likes_banned

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -445,30 +445,30 @@ class User < ActiveRecord::Base
   end
 
   def get_all_used_locations
-    latest_locations = [] 
+    latest_locations = []
     nodes = self.nodes.order('nid DESC').where(status: 1)
-    nodes.each_with_index do |node , i|
+    nodes.each do |node|
       location_tags = node.location_tags
       if location_tags.count > 0
-         latest_locations << location_tags
+        latest_locations << location_tags
       end
     end
     latest_locations
   end
 
   def get_latest_used_location
-    latest_location = [] 
+    latest_location = []
     nodes = self.nodes.order('nid DESC').where(status: 1)
-    nodes.each_with_index do |node , i|
+    nodes.each do |node|
       location_tags = node.location_tags
       if location_tags.count > 0
-         latest_location << location_tags
-         break
+        latest_location << location_tags
+        break
       end
     end
     if latest_location.count > 0
-      latest_location[0][0] = latest_location[0][0].name.split(":")[1].to_f ;
-      latest_location[0][1] = latest_location[0][1].name.split(":")[1].to_f ;
+      latest_location[0][0] = latest_location[0][0].name.split(":")[1].to_f
+      latest_location[0][1] = latest_location[0][1].name.split(":")[1].to_f
     end
     latest_location
   end

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -10,7 +10,7 @@
 
   <!-- Not part of LBL library -->
    <% if current_user %>
-      <% latest_locations = current_user.get_latest_used_locations %>
+      <% latest_locations = current_user.get_all_used_locations %>
       <% if latest_locations.count > 0 %>
         <p><b>Your previous used locations...</b></p>
         <div class="row">

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -9,29 +9,29 @@
     </div>
 
   <!-- Not part of LBL library -->
-   <% if current_user %>
-      <% latest_locations = current_user.get_all_used_locations %>
-      <% if latest_locations.count > 0 %>
-        <p><b>Your previous used locations...</b></p>
-        <div class="row">
-         
-            <% latest_locations.each_with_index do |location , index| %>
-              <% if index == 5 %>
-                <% break %>
-              <% end %>
-             <a href="#" onclick="blurredLocation.goTo(<%= location[0].name.split(":")[1] %> , <%= location[1].name.split(":")[1] %>  , 6);"> 
-              <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;">
-                  <p><%= location[0].name %> , <%= location[1].name %><br>
-                  <% if location.count == 3 %>
-                    <%= location[2].name %>
-                  <%end%>
-                </p>
-              </span>
-            </a>
-            <% end %>
-         
-        </div>
-     <% end %>
+  <% if current_user %>
+    <% latest_locations = current_user.get_all_used_locations %>
+    <% if latest_locations.count > 0 %>
+      <p><b>Your previous used locations...</b></p>
+      <div class="row">
+        <% latest_locations.each_with_index do |location , index| %>
+          <% if index == 5 %>
+            <% break %>
+          <% end %>
+          <a href="#" onclick="blurredLocation.goTo(<%= location[0].name.split(":")[1] %> , <%= location[1].name.split(":")[1] %>  , 6);"> 
+            <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;">
+              <p>
+                <% if location.count == 3 %>
+                  <%= location[2].name.split(":")[1] %>
+                <%end%>
+                <span class="badge" style="background-color: white ; color: #337ab7;"><%= location[0].name.split(":")[1] %></span>
+                <span class="badge" style="background-color: white ; color: #337ab7;"><%= location[1].name.split(":")[1] %></span>
+              </p>
+            </span>
+          </a>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 
   <br>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -8,8 +8,34 @@
       <input id="placenameInput" type="text" class="form-control" />
     </div>
 
-  <p><b>By dragging the map</b></p>
+  <!-- Not part of LBL library -->
+   <% if current_user %>
+      <% latest_locations = current_user.get_latest_used_locations %>
+      <% if latest_locations.count > 0 %>
+        <p><b>Your previous used locations...</b></p>
+        <div class="row">
+         
+            <% latest_locations.each_with_index do |location , index| %>
+              <% if index == 5 %>
+                <% break %>
+              <% end %>
+             <a href="#" onclick="blurredLocation.goTo(<%= location[0].name.split(":")[1] %> , <%= location[1].name.split(":")[1] %>  , 6);"> 
+              <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;">
+                  <p><%= location[0].name %> , <%= location[1].name %><br>
+                  <% if location.count == 3 %>
+                    <%= location[2].name %>
+                  <%end%>
+                </p>
+              </span>
+            </a>
+            <% end %>
+         
+        </div>
+     <% end %>
+  <% end %>
 
+  <br>
+  <p><b>By dragging the map</b></p>
   <div id="map" class="leaflet-map" style="width: 100%; height: 300px; margin-bottom:10px;"></div>
   <p>
     <h3><strong>Scale</strong></h3>
@@ -54,8 +80,12 @@
     InterfaceOptions: {
       latId: 'lat',
       lngId: 'lng'
+    },
+    location: {
+      lat: 23 ,
+      lon: 77 
     }
-  }
+  } ;
 
   var blurredLocation;
 
@@ -63,6 +93,14 @@
 
     L.Icon.Default.imagePath = '/lib/leaflet/dist/images/';
     
+    <% if current_user %>
+      <%  latest_location = current_user.get_latest_used_location %>
+      <% if !latest_location.empty? %>
+        options.location.lat = <%= latest_location[0][0] %> ;
+        options.location.lon = <%= latest_location[0][1] %> ;
+      <% end %>
+    <% end %>
+
     blurredLocation = new BlurredLocation(options);
 
     blurredLocation.panMapToGeocodedLocation("placenameInput");

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -19,8 +19,8 @@
             <% break %>
           <% end %>
           <a href="#" onclick="blurredLocation.goTo(<%= location[0].name.split(":")[1] %> , <%= location[1].name.split(":")[1] %>  , 6);"> 
-            <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;">
-              <p>
+            <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;margin-top: 2px; ">
+              <p style="padding-top: 10px;">
                 <% if location.count == 3 %>
                   <%= location[2].name.split(":")[1] %>
                 <%end%>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -20,13 +20,11 @@
           <% end %>
           <a href="#" onclick="blurredLocation.goTo(<%= location[0].name.split(":")[1] %> , <%= location[1].name.split(":")[1] %>  , 6);"> 
             <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;margin-top: 2px; ">
-              <p>
-                <% if location.count == 3 %>
-                  <%= location[2].name.split(":")[1] %>
-                <%end%>
-                <span class="badge" style="background-color: white ; color: #337ab7;"><%= location[0].name.split(":")[1] %></span>
-                <span class="badge" style="background-color: white ; color: #337ab7;"><%= location[1].name.split(":")[1] %></span>
-              </p>
+              <% if location.count == 3 %>
+                <%= location[2].name.split(":")[1] %>
+              <%end%>
+              <span class="badge" style="background-color: white ; color: #337ab7;"><%= location[0].name.split(":")[1] %></span>
+              <span class="badge" style="background-color: white ; color: #337ab7;"><%= location[1].name.split(":")[1] %></span>
             </span>
           </a>
         <% end %>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -20,7 +20,7 @@
           <% end %>
           <a href="#" onclick="blurredLocation.goTo(<%= location[0].name.split(":")[1] %> , <%= location[1].name.split(":")[1] %>  , 6);"> 
             <span class="badge badge-info" style="background-color: #337ab7 ; margin-left: 7px ;margin-top: 2px; ">
-              <p style="padding-top: 10px;">
+              <p>
                 <% if location.count == 3 %>
                   <%= location[2].name.split(":")[1] %>
                 <%end%>

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -71,7 +71,12 @@ class ScreenshotsTest < ApplicationSystemTestCase
   end
   
   test 'blog page with location modal' do
-    visit '/people'
+    visit '/'
+    click_on 'Login'
+    fill_in("username-login", with: "Bob")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
+    visit nodes(:blog).path
     find('a.blurred-location-input').click
     # click_on(class: 'blurred-location-input') # alternative
     fill_in("placenameInput", with: "Pusan")

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -69,4 +69,13 @@ class ScreenshotsTest < ApplicationSystemTestCase
     visit node.path
     take_screenshot
   end
+  
+  test 'blog page with location modal' do
+    visit nodes(:blog).path
+    find('a.blurred-location-input').click
+    # click_on(class: 'blurred-location-input') # alternative
+    fill_in("placenameInput", with: "Pusan")
+    take_screenshot
+  end
+
 end

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -73,7 +73,7 @@ class ScreenshotsTest < ApplicationSystemTestCase
   test 'blog page with location modal' do
     visit '/'
     click_on 'Login'
-    fill_in("username-login", with: "Bob")
+    fill_in("username-login", with: "steff1")
     fill_in("password-signup", with: "secretive")
     click_on "Log in"
     visit nodes(:blog).path

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -71,7 +71,7 @@ class ScreenshotsTest < ApplicationSystemTestCase
   end
   
   test 'blog page with location modal' do
-    visit nodes(:blog).path
+    visit '/people'
     find('a.blurred-location-input').click
     # click_on(class: 'blurred-location-input') # alternative
     fill_in("placenameInput", with: "Pusan")


### PR DESCRIPTION
Continued from https://github.com/publiclab/leaflet-blurred-location-display/issues/64#issuecomment-482655146 😄 !

Fixes https://github.com/publiclab/leaflet-blurred-location-display/issues/73 .

This PR does following : 

- [x]  Adds recently used locations in LBL modal . On clicking those badges , the map will pan to those coordinates  (hence faster use of LBL) .

- [x] The map by default will be at the last used location by the user . 

### Screenshots : 

<img width="910" alt="Screenshot 2019-04-18 at 8 24 05 PM" src="https://user-images.githubusercontent.com/14952645/56371234-5f5b4700-621a-11e9-965d-f10784925af9.png">

### GIF : 

![lbl_recent_location_gif](https://user-images.githubusercontent.com/14952645/56371290-7c901580-621a-11e9-80b3-c19c53e2fc62.gif)
