### PR TITLE
do not revert on current revision

### DIFF
--- a/app/views/wiki/revisions.html.erb
+++ b/app/views/wiki/revisions.html.erb
@@ -31,7 +31,11 @@
 	  | <%= distance_of_time_in_words(revision.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %>
           <div style="display:none;" id="body_<%= @node.revisions.length-1-index %>"><%= raw RDiscount.new(revision.body).to_html %></div>
         </td>
-        <td><small><a class="btn btn-xs btn-default" href="/wiki/revert/<%= revision.vid %>" data-confirm="<%= t('wiki.revisions.are_you_sure') %>"><i class="fa fa-arrow-reload"></i> <%= t('wiki.revisions.revert') %></a></small></td>
+        <% if revision.vid == @node.latest.vid %>
+          <td><small><a class="btn btn-xs btn-warning" data-toggle="tooltip" data-placement="top" title="Already on Current revision"><i class="fa fa-arrow-reload"></i> <%= t('wiki.revisions.revert') %></a></small></td>
+        <% else %>
+          <td><small><a class="btn btn-xs btn-default" href="/wiki/revert/<%= revision.vid %>" data-confirm="<%= t('wiki.revisions.are_you_sure') %>"><i class="fa fa-arrow-reload"></i> <%= t('wiki.revisions.revert') %></a></small></td>
+        <% end %>
         <% if current_user && (current_user.role == "moderator" || current_user.role == "admin") %>
           <% if revision.status == 1 %>
             <td><small><a class='btn btn-xs btn-default' href='/moderate/revision/spam/<%= revision.vid %>' data-confirm="<%= t('wiki.revisions.are_you_sure') %>"><i class='fa fa-ban'></i></a></small></td>


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/5551 (<=== Add issue number here)

## Description
Earlier I tried removing the revert button for current revision but the ui became inconsistent because of this. 
So Instead I made revert button disabled while showing the information on tooltip that already on current revision and can't revert anymore.

![Screenshot from 2019-04-21 16-43-14](https://user-images.githubusercontent.com/26685258/56470701-d71db180-6466-11e9-9c57-63ec612ffc70.png)

<br>

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
