### PR TITLE
Add some primitive system tests #5316

### DIFF
--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -2,12 +2,86 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class SearchTest < ApplicationSystemTestCase
-  test 'searching an item from the homepage' do
-    visit '/'
+    test 'searching an item from the homepage' do
+      visit '/'
+    
+      fill_in("searchform_input", with: "Canon")
+      find('button.btn-default').click
+    
+      assert_selector('h2', text: 'Results for Canon')
+    end
+end
 
-    fill_in("searchform_input", with: "Canon")
-    find('button.btn-default').click
+class LoginSingUpTest < ApplicationSystemTestCase
+    test 'sign up' do
+      visit '/signup'
+    
+      assert_selector('h2', text: 'Sign up to join the Public Lab community')
+    
+      fill_in("username-signup", with: "Bob")
+      fill_in("email", with: "bob@email.com")
+    
+      # The first argument to attach_file is a locator which refers to the name
+      # attribute on the input tag.
+      # attach_file("user[photo]", Rails.root + '/public/images/pl.png')
+    
+      fill_in("password", with: "Bob1234")
+      fill_in("password-confirmation", with: "Bob1234")
+    
+      # Check the RECAPTCHA box
+      # within_frame("a-fa3pgrq3s2ty") do
+      #   check("recaptcha-anchor")
+      # end
+    
+      # find('button.btn.btn-lg.btn-primary.btn-save').click
+    
+      # This method does not require defining a custom matcher.
+      # expect(page).to have_selector(:link_or_button, 'Asking a question')
+      # expect(page).to have_selector(:link_or_button, 'Exploring projects')
+    
+      # assert_selector('h2', text: 'Hello, welcome to Public Lab!')
+    end
+end
 
-    assert_selector('h2', text: 'Results for Canon')
-  end
+class QuestionTest < ApplicationSystemTestCase
+    test 'view questions by topic' do
+      visit '/questions'
+    
+      assert_selector('h4', text: 'View questions by topic')
+      fill_in("taginput", with: "sensor")
+      # expect(page).to have_content("sensor")
+    
+      find_button("View questions with the entered title").click
+      
+      # expect(page).to have_content("sensor")
+      assert_selector('h3', text: 'Notes tagged with ')
+    end
+
+    test 'aske a question' do
+      visit '/questions'
+        
+      assert_selector('h4', text: 'Ask a question here')
+        
+      fill_in("questions_searchform_input", with: "How do I change my username?")
+      find_button("Ask a question with the entered title").click
+      
+      # --Redirect to another page with more details to fill in.
+      # assert_selector('h2', text: 'Ask a question of the PublicLab community')
+      
+      # --Use selector to see if field is pre-filled with correct text.
+      # expect(page).to have_selector("input[value='How do I change my username?']")
+      
+      # find('button.btn-horizontal.btn.btn-default').click
+      # expects(page).to have_selector("hr")
+      # find('button.btn-youtube.btn.btn-default').click
+      # page.driver.browser.switch_to.alert.accept
+      # --Communicate with the javascript prompt dialog.
+      # expect(page). to have_selector("iframe[src='the_youtube_link']")
+      
+      # --Submit the question.
+      # find('button.ple-publish.btn.btn-lg.btn-primary').click
+      # --Pending approval.
+      # expects(page).to have_selector("p[class='alert.alert-warning.moderated']")
+      # expects(page).to have_content("Pending approval by")
+    end
 end


### PR DESCRIPTION
Fixes #5316 
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!

Hello,
I saw the issue #5316 which is to brainstorm a list of critical full-stack system tests we should add and thought that I would like to take a try and help on that. I wrote a few primitive tests (they should pass when run $rails test test/system/search_test.rb). I know that there are still a lot of room for improvements on the code, but any guidance and suggestion would be very much appreciated! Right now the tests are testing click events of the button, and I will keep updating it once I have found more advanced syntax and testing method.
<img width="1116" alt="Screen Shot 2019-04-22 at 7 59 52 PM" src="https://user-images.githubusercontent.com/23229452/56542591-ea9b4c00-653c-11e9-8a64-0297beae4d63.png">
