### PR TITLE
Fixing date issue in subscription mailer

### DIFF
--- a/app/views/subscription_mailer/send_digest.html.erb
+++ b/app/views/subscription_mailer/send_digest.html.erb
@@ -21,7 +21,7 @@
         </div>
         <div style="margin-top: 20px;">
           <b style="font-weight: 500;"><%= n.author.username.capitalize %></b>
-          <p style="margin: 0;color: #999;font-weight: 500;">Published <%= n.created_at %>.strftime("%m/%d")</p>
+          <p style="margin: 0;color: #999;font-weight: 500;">Published <%= n.created_at.strftime("%m/%d") %></p>
         </div>
         <% if n.main_image.present? %>
           <div style="padding-bottom: 30px;">


### PR DESCRIPTION
Fixes #4732 

Publish date was appearing broken:

![image](https://user-images.githubusercontent.com/40794215/57006498-ec30d800-6bfe-11e9-8cf3-1d750e7c4556.png)

Now it is fixed:

![image](https://user-images.githubusercontent.com/40794215/57006511-05398900-6bff-11e9-9c9d-64aa1254fd23.png)
