### PR TITLE
Arranging tags in descending order & Adding link to tags

### DIFF
--- a/app/views/stats/subscriptions.html.erb
+++ b/app/views/stats/subscriptions.html.erb
@@ -21,7 +21,7 @@
 				<td>
 					<% tags.each do |tag| %>
 					<p>
-						<%= tag[0]%>:
+						<a href="/tag/<%= tag[0] %>"> <%= tag[0]%>: </a>
 						<%=tag[1] %>
 					</p>
 					<%end%>

--- a/app/views/stats/subscriptions.html.erb
+++ b/app/views/stats/subscriptions.html.erb
@@ -11,7 +11,7 @@
 				<th>Tags</th>
 			</thead>
 		</tr>
-		<% @tags.each do |range,tags| %>
+		<% @tags.reverse_each do |range,tags| %>
 		<tr>
 			<tbody>
 				<td>


### PR DESCRIPTION
Fixes #5260 

Arranging the stats in desc order for the most used to appear first and adding links to tags:

![image](https://user-images.githubusercontent.com/40794215/57058115-85c5bb80-6ccb-11e9-9c0c-d9aee03f23eb.png)

On clicking on a tag, redirected to tag's page:

![image](https://user-images.githubusercontent.com/40794215/57058140-a55ce400-6ccb-11e9-8fe7-1b8e731dc74f.png)

