### PR TITLE
remove dupe link to wiki on notes page

### DIFF
--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -30,9 +30,6 @@
       <li class="nav-item">
         <a class="nav-link <% if params[:action] == "liked" %> active <% end %> " href="/notes/liked/"> <i class="fa fa-star-o"></i><span class="hidden-sm hidden-xs"> <%= t('notes.index.liked') %></span></a>
       </li>
-      <li class="nav-item">
-        <a class="nav-link" href="/wiki/"> <i class="fa fa-book"></i><span class="hidden-sm hidden-xs"> <%= raw t('notes.index.wiki_pages') %></span></a>
-      </li>
     </ul>
 
   <% end %>


### PR DESCRIPTION
Fixes #5547 

Details on issue: on the notes page, there is a wiki page tab alongside the popular/liked tabs and also, a link on the side bar which says "Browse the Public Lab wiki". Both of them correspond to the wiki page. Therefore, remove the Wiki pages tab by removing lines 33-35.

Lines 33 - 35 removed!

✔️ PR is descriptively titled 📑 and links the original issue above 🔗  
✔️ tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
✔️ code is in uniquely-named feature branch and has no merge conflicts 📁
✔️ screenshots/GIFs are attached 📎 in case of UI updation 
![Screen Shot 2019-05-02 at 7 24 58 PM](https://user-images.githubusercontent.com/41878441/57113980-14aaf600-6d15-11e9-9eb3-f51d8636bc8c.png)

✔️ ask `@publiclab/reviewers` for help, in a comment below

Thank you!