### PR TITLE
Fix #5656: Message "the comment couldn't be saved" appears in dashboard.

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -52,7 +52,7 @@ class CommentController < ApplicationController
         end
       end
     rescue CommentError
-      flash[:error] = 'The comment could not be saved.'
+      flash.now[:error] = 'The comment could not be saved.'
       render plain: 'failure'
     end
   end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -26,7 +26,7 @@
         body = Node.find_by(slug: @node.power_tag('comment-template')).try(:body)
       end
     %>
-    <textarea style="border: 1px solid #bbb;border-bottom-left-radius: 0;border-bottom-right-radius: 0;border-bottom: 0;padding: 10px;" onFocus="editing=true" name="body" class="form-control" id="text-input" rows="6" cols="40" placeholder="<%= placeholder %>"><% if local_assigns[:is_new_answer].blank? %> <%= body %><% end %></textarea>
+    <textarea style="border: 1px solid #bbb;border-bottom-left-radius: 0;border-bottom-right-radius: 0;border-bottom: 0;padding: 10px;" onFocus="editing=true" name="body" class="form-control" id="text-input" rows="6" cols="40" placeholder="<%= placeholder %>"><% if local_assigns[:is_new_answer].blank? %><%= body %><% end %></textarea>
     <div id="imagebar">
 
       <div id="create_progress" style="display:none;" class="progress progress-striped active pull-right">
@@ -64,6 +64,15 @@
   <script>
     jQuery(document).ready(function() {
       $E.initialize();
+      $('button[id="btn-publish"]').attr('disabled', true);
+      $('textarea[class="form-control"]').on('keyup', function () {
+          var value = $(this).val();
+          if (value != '') {
+            $('button[id="btn-publish"]').attr('disabled', false);
+          } else {
+            $('button[id="btn-publish"]').attr('disabled', true);
+          }
+      });
     });
 
     $D = {
@@ -86,7 +95,7 @@
   <%= javascript_include_tag "comment.js" %>
 
   <div class="control-group">
-    <button type="submit" class="btn btn-primary"><%= t('comments._form.publish') %></button>
+    <button type="submit" class="btn btn-primary" id="btn-publish"><%= t('comments._form.publish') %></button>
     <% if local_assigns[:comment] %>
       <a class="btn btn-default preview-btn" onClick="$('#c<%= comment.cid %>preview').toggle();
           $('#c<%= comment.cid %>text-input').toggle();


### PR DESCRIPTION
Fixes #5656 
This fix resolves an issue with a _flag.now_ notification also it resolves the comment section verifying when the text area is empty and disables the button. 

![PR5656](https://user-images.githubusercontent.com/26575531/57252125-4d421c80-7000-11e9-898b-7c767ac38ee6.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
