### PR TITLE
Change/shorten post/question button text for sidebar

### DIFF
--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -4,9 +4,9 @@
 
   <div id="sidebar" class="d-none d-lg-block">
 
-  <a style="margin-bottom:6px;white-space: normal;" rel="tooltip" title="<%= t('sidebar._related.share_your_work') %>" data-placement="bottom" href="/post" class="btn btn-primary btn-lg btn-block d-lg-none d-xl-block write-research-note requireLogin"><i class="fa fa-pencil fa fa-white"></i> <%= t('sidebar._related.write_research_note') %> &raquo;</a>
+  <a style="margin-bottom:6px;white-space: normal;" rel="tooltip" title="<%= t('sidebar._related.share_your_work') %>" data-placement="bottom" href="/post" class="btn btn-primary btn-lg btn-block d-lg-none d-xl-block write-research-note requireLogin"><i class="fa fa-pencil fa fa-white"></i> <%= t('sidebar._related.write_research_note') %></a>
   <% tagnames = (@node.normal_tags.collect(&:name) + @node.location_tags).join(',') if @tagnames %>
-  <a style="white-space: normal;" rel="tooltip" title="Post <% if @tagnames %>about <%= tagnames %><% else %>research<% end %>" data-placement="bottom" href="/post<%= '?template=question&tags=question:general,'+ tagnames if @tagnames %><% if params[:controller] == 'notes' && params[:action] == 'show' %>,response:<%= @node.id %><% end %>" class="btn btn-primary btn-lg btn-block requireLogin"><i class="fa fa-pencil fa fa-white"></i> <%= t('sidebar._related.ask_a_question') %> &raquo;</a>
+  <a style="white-space: normal;" rel="tooltip" title="Post <% if @tagnames %>about <%= tagnames %><% else %>research<% end %>" data-placement="bottom" href="/post<%= '?template=question&tags=question:general,'+ tagnames if @tagnames %><% if params[:controller] == 'notes' && params[:action] == 'show' %>,response:<%= @node.id %><% end %>" class="btn btn-primary btn-lg btn-block requireLogin"><i class="fa fa-pencil fa fa-white"></i> <%= t('sidebar._related.ask_a_question') %></a>
 
   <% cache('related_sidebar-feature', skip_digest: true) do %>
     <%= feature('sidebar') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,9 +693,9 @@ en:
         by <a href='%{url1}'>%{author_name}</a>
       more: "More..."
     _related:
-      write_research_note: "Write a research note"
+      write_research_note: "Write a post"
       share_your_work: "Share your work with others"
-      ask_a_question: "Ask a related question"
+      ask_a_question: "Ask a question"
       translation: "Translation"
       response_to: "This is a response to"
       responses_to_note: "Responses to this note"

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -397,7 +397,7 @@ class I18nTest < ActionDispatch::IntegrationTest
       follow_redirect!
 
       get '/wiki/' + nodes(:organizers).title.parameterize
-      assert_select 'a', "#{I18n.t('sidebar._related.write_research_note')} " + Sanitize.clean('&raquo;')
+      assert_select 'a', I18n.t('sidebar._related.write_research_note')
     end
   end
 


### PR DESCRIPTION
Hi @gauravano I wanted to shorten these button texts, but wasn't sure if I should change the lookup keys too. The templates are:

https://github.com/publiclab/plots2/blob/07490f26b82cf8e14bb612caf86ec9b9f1d52f95/app/views/sidebar/_related.html.erb#L7-L9

What do you think?

![image](https://user-images.githubusercontent.com/24359/57395438-1d2c8200-7196-11e9-8dd0-232022ef47cf.png)
