### PR TITLE
fix #5691 add trigger: 'hover' on the script in subscribe button

### DIFF
--- a/app/views/tag/_subscribe_button.html.erb
+++ b/app/views/tag/_subscribe_button.html.erb
@@ -4,7 +4,7 @@
     <i class="fa fa-plus"></i> 
   </a>
 
-  <div id="mypopcontent" class="d-none">
+  <div id="mypopcontent" class="d-none" onmouseleave="show(this)">
   	<%= render partial: "tag/tags_popover", locals: {tags: tags} %>
   </div>
 
@@ -27,10 +27,9 @@
   $('#popover_button').popover({
   	content: $('#mypopcontent').clone().removeClass('d-none'),
   	placement: 'bottom',
-    html: true,
-    trigger: 'hover'
+  	html: true,
   });
   function show(elem){
-    elem.style.display ="none"
+  $('#popover_button').popover("hide") 
   }
 </script>

--- a/app/views/tag/_subscribe_button.html.erb
+++ b/app/views/tag/_subscribe_button.html.erb
@@ -28,6 +28,6 @@
   	content: $('#mypopcontent').clone().removeClass('d-none'),
   	placement: 'bottom',
   	html: true,
-
+    trigger : 'hover'
   });
 </script>

--- a/app/views/tag/_subscribe_button.html.erb
+++ b/app/views/tag/_subscribe_button.html.erb
@@ -30,4 +30,7 @@
     html: true,
     trigger: 'hover'
   });
+  function show(elem){
+    elem.style.display ="none"
+  }
 </script>

--- a/app/views/tag/_subscribe_button.html.erb
+++ b/app/views/tag/_subscribe_button.html.erb
@@ -27,7 +27,7 @@
   $('#popover_button').popover({
   	content: $('#mypopcontent').clone().removeClass('d-none'),
   	placement: 'bottom',
-  	html: true,
-    trigger : 'hover'
+    html: true,
+    trigger: 'hover'
   });
 </script>


### PR DESCRIPTION
Fixes #5691  
the user needs to do click on subscribe button, then popcontent will apear, when the mouse left the popcontent the popcontent will disapear

I added new function on subscribe button.html.erb, inside it the popcontent is hiden
this function is called by onmouseleave in div of "mypopcontent"
![subscription1](https://user-images.githubusercontent.com/48233860/57476700-65aa7500-7254-11e9-96c0-d3de1285dc54.png)
![subscription2](https://user-images.githubusercontent.com/48233860/57476721-6d6a1980-7254-11e9-8e97-8b2ed3e9dd26.png)


