### PR TITLE
Fix map position to above in mobile responsiveness

### DIFF
--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
 <div class="row">
-<div class="col-md-6" style="font-family:Junction Regular;">
+<div class="col-md-6 order-sm-2 order-1" style="font-family:Junction Regular;">
 <% if current_user && (current_user.role == "admin" || current_user.role == "moderator")%>
 <h3><%= t('users.list.user_moderation') %></h3>
 <p><%= t('users.list.admins_ban_spam') %> </p>
@@ -52,10 +52,10 @@
   </div>
   <%= will_paginate @users, renderer: WillPaginate::ActionView::BootstrapLinkRenderer unless @unpaginated %>
 </div>
-<div class="col-md-6 d-none d-md-block" style="margin-top:2em;">
+<div class="col-md-6 order-2 d-none d-md-block" style="margin-top:2em;">
 <%= render :partial => "map/peopleLeaflet" , locals: {people: true , lat:23 , lon: 4} %>
 </div>
-<div class="col-md-6 d-md-none" style="margin-top:2em;">
+<div class="col-md-6 order-sm-1 d-md-none" style="margin-top:2em;">
 <%= render :partial => "map/peopleLeaflet" , locals: {people: true , lat:23 , lon: 4} %>
 </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/5707 part (<=== Add issue number here)

![abovemap](https://user-images.githubusercontent.com/26685258/58093414-1a954800-7bec-11e9-919f-573c98ef14a2.gif)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below
