### PR TITLE
Alphabetizing the tags on stats subscription page

### DIFF
--- a/app/views/stats/subscriptions.html.erb
+++ b/app/views/stats/subscriptions.html.erb
@@ -17,6 +17,7 @@
       <%= range * 10 %> - <%= range * 10 + 9 %>
     </td>
     <td>
+      <% tags = tags.sort %>
       <% tags.each do |tag| %>
       <a class="badge badge-primary" href="/tag/<%= tag[0] %>">
         <%= tag[0]%> 


### PR DESCRIPTION
Fixes #5260 

Moving from #5648 

@jywarren after alphabetizing the tags, this is how it looks:

![image](https://user-images.githubusercontent.com/40794215/58202547-7ac3e100-7cf5-11e9-960c-1fe3a43de2ef.png)



