### PR TITLE
Add first section for shadow question page

### DIFF
--- a/app/views/questions/index_shadow.html.erb
+++ b/app/views/questions/index_shadow.html.erb
@@ -1,0 +1,17 @@
+<div class="row" style="padding:2em;">
+   <div class="col-md-5">
+     <div class="profile-image text-center">
+       <img class="rounded-circle img-fluid"  style= "width:40%;" id="profile-photo" src="https://avatars2.githubusercontent.com/u/4621650?s=200&v=4" />
+     </div>
+     <h6 class="mt-2 text-center"><strong>@publiclab</strong><h6>
+   </div>
+   <div class="col-md-7" style="text-align: left;">
+     <h5>Get help with your Questions</h5>
+     <h2>Ask the community</h2>
+     <p style="color: #666">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
+       eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+     <a href="https://publiclab.org/wiki/public-lab-q-and-a" style="text-decoration: underline;">Learn More >></a>
+   </div>
+ </div>
+
+ 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -306,6 +306,7 @@ Plots2::Application.routes.draw do
 
   get 'questions/new' => 'questions#new'
   get 'questions' => 'questions#index'
+  get 'questions_shadow' => 'questions#index_shadow'
   get 'question' => 'questions#index'
   get 'questions/:author/:date/:id' => 'questions#show'
   get 'questions/show/:id' => 'questions#show'


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/5733 part

- [X] Added a shadow route
- [X] Added first section 

![Screenshot from 2019-05-24 13-29-03](https://user-images.githubusercontent.com/26685258/58311983-f02fce80-7e27-11e9-8c7c-544de9e7cd75.png)

The screen appears darker due to screenshot but In real, it isn't. 

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below
