### PR TITLE
Align text under graph in tags page (#5773)

### DIFF
--- a/app/views/tag/index.html.erb
+++ b/app/views/tag/index.html.erb
@@ -41,11 +41,11 @@
 <div class="col-lg-6">
   <br><br>
   <iframe id="myImage" src="stats/graph.html?limit=50" height="500" width="100%" frameborder="0" ></iframe>
-  <h6 class="text-right" style="color:#ccc;">Tags most commonly used, linked by how often they are used together.<br>
+  <p class="text-right" style="color:#ccc;">Tags most commonly used, linked by how often they are used together.<br>
     View <a style="cursor: pointer; a:active: color: red;" onclick="document.getElementById('myImage').src='stats/graph.html?limit=50'"><u>50</u></a> |
     <a style="cursor: pointer;" onclick="document.getElementById('myImage').src='stats/graph.html?limit=100'"><u>100</u></a> |
     <a style="cursor: pointer;" onclick="document.getElementById('myImage').src='stats/graph.html?limit=250'"><u>250</u></a> |
     <a style="cursor: pointer;" onclick="document.getElementById('myImage').src='stats/graph.html?limit=500'"><u>500</u></a>
-  </h6>
+  </p>
 
 </div>


### PR DESCRIPTION
Fixes #5773

Changed `h6` tag to `p` for the text under the graph in the tags page. 

**Before**
![5773_before](https://user-images.githubusercontent.com/14910846/58331773-896bde80-7e42-11e9-8999-b782199e9c95.png)

**After**
![5773_after](https://user-images.githubusercontent.com/14910846/58331769-87a21b00-7e42-11e9-973f-73717ab4e053.png)

*  [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
