### PR TITLE
Fix Rubocop performance deprecation warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 # Start with Spotifys style guide as a base then customize from there
 inherit_from:
   - .rubocop_shopify_styleguide.yml

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'rdiscount', '~> 2.2', '>= 2.2.0.1'
 gem "recaptcha", require: "recaptcha/rails"
 gem 'responders', '~> 2.4'
 gem 'rubocop', '~> 0.69.0', require: false
+gem 'rubocop-performance'
 gem "ruby-openid", :require => "openid"
 gem 'sanitize'
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.3.0)
+      rubocop (>= 0.68.0)
     ruby-openid (2.7.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
@@ -586,6 +588,7 @@ DEPENDENCIES
   reverse_markdown
   rspec
   rubocop (~> 0.69.0)
+  rubocop-performance
   ruby-openid
   sanitize
   sassc-rails


### PR DESCRIPTION
Fixes #5795

* [x] `gem 'rubocop-performance'` added to `Gemfile`
* [x] `require: rubocop-performance` added to `.rubocop.yml`
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

![Working Dev Environment](https://i.imgur.com/8ieFqmB.png)

Codeclimate test currently not passing. I am unfamiliar with Codeclimate but the Travis CI is passing.
