### PR TITLE
Add tooltips to follow button and tools dropdown on the like bar

### DIFF
--- a/app/views/like/_like.html.erb
+++ b/app/views/like/_like.html.erb
@@ -10,7 +10,7 @@
     <a rel="tooltip" title="Flag as spam" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= node.id %>" href="mailto:moderators@publiclab.org?subject=Reporting+spam+on+Public+Lab&body=Hi,+I+found+this+item+that+looks+like+spam+or+needs+to+be+moderated:+<%= node.title.gsub(/ /,'+') %>+https://publiclab.org/n/<%= node.id %>+by+https://publiclab.org/profile/<%= node.author.username %>+Thanks!">
       <i class="fa fa-flag"></i>
     </a>
-    <li title="Follow" class="btn btn-outline-secondary btn-sm requireLogin" data-html="true" rel="popover" data-content="<%= "No tags" if tagnames.nil? || tagnames.length == 0 %><% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-outline-secondary btn-sm'><%= tagname %></a></p><% end %><% end %><hr /><i class='fa fa-user'></i><% if current_user && !current_user.following?(node.author) %>&nbsp;<a class='btn btn-sm' href='/relationships?followed_id=<%= node.author.id %>' data-method='post' > <%= node.author.name %></a><% else %><%= node.author.name %><% end %>" title="Follow by tag or author" data-placement="left">
+    <li data-toggle="tooltip" data-placement="top" title="Follow by tag or author" class="btn btn-outline-secondary btn-sm requireLogin" data-html="true" rel="popover" data-content="<%= "No tags" if tagnames.nil? || tagnames.length == 0 %><% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-outline-secondary btn-sm'><%= tagname %></a></p><% end %><% end %><hr /><i class='fa fa-user'></i><% if current_user && !current_user.following?(node.author) %>&nbsp;<a class='btn btn-sm' href='/relationships?followed_id=<%= node.author.id %>' data-method='post' > <%= node.author.name %></a><% else %><%= node.author.name %><% end %>" title="Follow by tag or author" data-placement="left">
       <i class="fa fa-user-plus" aria-hidden="true"></i>
     </li>
   <li rel="tooltip" title="Helpful? Like it and get updates!" class="btn btn-outline-secondary btn-sm btn-like" node-id="<%= node.id %>" id="like-button-<%= node.id %>">
@@ -25,7 +25,7 @@
     <% end %>
   </li>
 
-  <li class="btn btn-outline-secondary btn-sm" rel="popover" data-placement="left" data-html="true" style="overflow: auto; max-height: 500px" data-title="Tools" data-content="
+  <li data-toggle="tooltip" data-placement="top" class="btn btn-outline-secondary btn-sm" rel="popover" data-placement="left" data-html="true" style="overflow: auto; max-height: 500px" data-title="Tools" data-content="
 <p><b>Users who liked this</b></p>
 <% node.likers.each do |user| %>
   <i class='fa fa-star-o'></i> <a href='/profile/<%= user.username %>/'><%= user.username %></a><br />

--- a/app/views/like/_like.html.erb
+++ b/app/views/like/_like.html.erb
@@ -10,10 +10,10 @@
     <a rel="tooltip" title="Flag as spam" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= node.id %>" href="mailto:moderators@publiclab.org?subject=Reporting+spam+on+Public+Lab&body=Hi,+I+found+this+item+that+looks+like+spam+or+needs+to+be+moderated:+<%= node.title.gsub(/ /,'+') %>+https://publiclab.org/n/<%= node.id %>+by+https://publiclab.org/profile/<%= node.author.username %>+Thanks!">
       <i class="fa fa-flag"></i>
     </a>
-    <li data-toggle="tooltip" data-placement="top" title="Follow by tag or author" class="btn btn-outline-secondary btn-sm requireLogin" data-html="true" rel="popover" data-content="<%= "No tags" if tagnames.nil? || tagnames.length == 0 %><% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-outline-secondary btn-sm'><%= tagname %></a></p><% end %><% end %><hr /><i class='fa fa-user'></i><% if current_user && !current_user.following?(node.author) %>&nbsp;<a class='btn btn-sm' href='/relationships?followed_id=<%= node.author.id %>' data-method='post' > <%= node.author.name %></a><% else %><%= node.author.name %><% end %>" title="Follow by tag or author" data-placement="left">
+    <li data-toggle="tooltip" data-placement="top" title="Follow by tag or author" class="btn btn-outline-secondary btn-sm requireLogin" data-html="true" rel="popover" data-placement="left" data-content="    <%= "No tags" if tagnames.nil? || tagnames.length == 0 %>    <% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-outline-secondary btn-sm'><%= tagname %></a></p><% end %><% end %><hr /><i class='fa fa-user'></i><% if current_user && !current_user.following?(node.author) %>&nbsp;<a class='btn btn-sm' href='/relationships?followed_id=<%= node.author.id %>' data-method='post' > <%= node.author.name %></a><% else %>  &nbsp;<%= node.author.name %><% end %>">
       <i class="fa fa-user-plus" aria-hidden="true"></i>
     </li>
-  <li rel="tooltip" title="Helpful? Like it and get updates!" class="btn btn-outline-secondary btn-sm btn-like" node-id="<%= node.id %>" id="like-button-<%= node.id %>">
+  <li data-toggle="tooltip" data-placement="top" rel="tooltip" title="Helpful? Like it and get updates!" class="btn btn-outline-secondary btn-sm btn-like" node-id="<%= node.id %>" id="like-button-<%= node.id %>">
     <% if !current_user %>
       <a id="open-login-like" data-hashparams="like" data-toggle="modal" data-target="#loginModal">
         <span id="like-star-<%= node.id %>" class="fa fa-star"></span>
@@ -25,7 +25,7 @@
     <% end %>
   </li>
 
-  <li data-toggle="tooltip" data-placement="top" class="btn btn-outline-secondary btn-sm" rel="popover" data-placement="left" data-html="true" style="overflow: auto; max-height: 500px" data-title="Tools" data-content="
+  <li data-toggle="tooltip" data-placement="top" title="Print and more tools" class="btn btn-outline-secondary btn-sm" rel="popover" data-placement="left" data-html="true" style="overflow: auto; max-height: 500px" data-content="
 <p><b>Users who liked this</b></p>
 <% node.likers.each do |user| %>
   <i class='fa fa-star-o'></i> <a href='/profile/<%= user.username %>/'><%= user.username %></a><br />


### PR DESCRIPTION
Fixes #5820 
![tools-tooltip](https://user-images.githubusercontent.com/50340123/58768926-72766c00-8567-11e9-9a70-c4545f248f46.png)
![follow-tooltip](https://user-images.githubusercontent.com/50340123/58768927-72766c00-8567-11e9-859b-7ae014831a1d.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
