### PR TITLE
fix individual tags page

### DIFF
--- a/app/views/tag/show/_header.html.erb
+++ b/app/views/tag/show/_header.html.erb
@@ -1,23 +1,13 @@
 <% if @wiki %>
   <div id="wiki-content">
     <% if @wiki.main_image %>
-      <div class="container">
-        <div class="row">
-          <div class="col-lg-6" style="margin-bottom:10px;">
-            <%= image_tag(@wiki.main_image.path, class: "img-responsive") %>
-          </div>
-          <div class="col-lg-6">
-            <h1 style="color:#333;"><%= link_to @wiki.latest.title, "/wiki/#{params[:id]}" %></h1>
-            <%= @wiki.latest.render_body.match(/<p>(.+)<\/p>/).to_a.try(:first).to_s.html_safe %>
-            <% if @wiki.latest.render_body.split('</p>').length > 2 %><a class="btn btn-lg btn-outline-secondary" href="/wiki/<%= params[:id] %>">Learn more on the wiki page</a><% end %>
-          </div>
-        </div>
+      <div class="tag-image" style="margin-bottom:10px;">
+        <%= image_tag(@wiki.main_image.path, :class => "img-fluid") %>
       </div>
-    <% else %>
-      <h1><%= @wiki.latest.title %></h1>
-      <p><%= @wiki.latest.render_body.html_safe.match(/<p>(.+)<\/p>/).to_a.try(:first).to_s.html_safe %></p>
-      <p><%= link_to("Learn more on the wiki page", "/wiki/#{params[:id]}") if @wiki.latest.render_body.html_safe.match(/<p>(.+)<\/p>/).to_a.length > 1 %></p>
     <% end %>
+      <h1><%= @wiki.latest.title%></h1>
+      <p><%= @wiki.latest.render_body.html_safe.match(/<p>(.+)<\/p>/).to_a.try(:first).to_s.html_safe %></p>
+      <p><%= link_to("Learn more on the wiki page>>", "/wiki/#{params[:id]}") if @wiki.latest.render_body.html_safe.match(/<p>(.+)<\/p>/).to_a.length > 1 %></p>
   </div>
 <% elsif @wildcard %>
   <% if @node_type == "questions"%>
@@ -34,3 +24,9 @@
 
   <p><a class="btn btn-primary requireLogin" href="/wiki/new?title=<%= params[:id] %>"><span class="fa fa-plus fa-white"></span> Add one now</a></p>
 <% end %>
+<style>
+  .img-fluid{
+    max-width: 100%;
+    height: auto;
+  }
+</style>


### PR DESCRIPTION
Fixes #0000 (<=== Add issue number here)

Fixes the overwriting of the wiki text on the individual tags image and making the image responsive in bootstrap 4.

![Screen Shot 2019-06-11 at 1 02 12 AM](https://user-images.githubusercontent.com/35326753/59222392-05a64600-8be7-11e9-898e-2391106c69fa.png)

![Screen Shot 2019-06-11 at 1 26 29 AM](https://user-images.githubusercontent.com/35326753/59222636-967d2180-8be7-11e9-88f4-72a46f81d530.png)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
