### PR TITLE
Adds Gray Circle to Topic Card

### DIFF
--- a/app/views/tag/_topicCard.html.erb
+++ b/app/views/tag/_topicCard.html.erb
@@ -14,13 +14,15 @@
                 <img class="rounded-circle" id="profile-photo" style="width:20px; height:20px; margin-right:8px; display: inline-block;" src="<%= node.main_image.path(:default) %>" />
               <% elsif node.scraped_image %>
                 <img class="rounded-circle" id="profile-photo" style="width:20px; height:20px; margin-right:8px; display: inline-block;" src="<%= node.scraped_image %>" />
+              <% else %>
+                <div class="circle"></div>
               <% end %>
               <p style="display: inline-block;"><a style="color: inherit;" <% if @widget %>target="_blank"<% end %> href="<%= node.path %>"><%= (node.type == 'note') ? node.title : node.latest.title %></a></p>
               <p style="display: inline-block; margin-left: 10px;color: #808080;">by <a style="color: #808080;" <% if @widget %>target="_blank"<% end %> href="/profile/<%= node.author.name %>">@<%= node.author.name %></a></p>
             </div>
           <% end %>
         </div>
-      </div>  
+      </div>
       <div class="card-footer" style="background-color: inherit; border:none;">
         <a style="text-decoration: underline; color: #808080; display: inline-block;" href="/tag/<%= tag.name %>"><%= tag.count %> <%= t('tag.index.more_posts') %> <i class="fa fa-angle-double-right"></i></a>
 
@@ -38,3 +40,14 @@
     </div>
   <% end %>
 </div>
+
+<style>
+
+  .circle {
+    background-color: gray;
+    height: 20px;
+    width: 20px;
+    border-radius: 100%;
+  }
+  
+</style>


### PR DESCRIPTION
Fixes #5976 

Adds a gray circle when there is no picture in note as shown in the first topic card: 

<img width="1680" alt="Screen Shot 2019-07-09 at 17 01 18" src="https://user-images.githubusercontent.com/35746593/60899726-3cfe2600-a26b-11e9-8ef9-08083893ab15.png">


