### PR TITLE
Remove bower installation from Prerequisites(#5128)

### DIFF
--- a/doc/PREREQUISITES.md
+++ b/doc/PREREQUISITES.md
@@ -36,18 +36,18 @@ Ruby dependencies, or Gems, are managed with Bundler.
 `gem install bundler` - if it's not already installed, but it should be in a basic RVM ruby. 
 
 
-### YARN 
+### Assets with Yarn 
 
 You'll also need **yarn** to get your JavaScript dependencies.
 
 [The official installation section](https://yarnpkg.com/lang/en/docs/install/#debian-stable) for yarn has installation details for many systems.
 
-The yarn install step replaces the previously used bower install step.
+The `yarn install` step replaces the previously used `bower install` step.
 
 Use `yarn --version` to verify whether the installation is up and running!
 
 **Note**: In case the options described above do not work for you, you can also install yarn using npm,though it is generally not recommended. As a prerequisite, you will have to [install Node.js](https://nodejs.org/en/download/) if not already installed.
-To install yarn using npm, use `npm install --global yarn` and then continue with path setup similar to the usual installation.
+To install yarn using npm, use `npm install --global yarn` and continue with path setup similar to the usual installation.
 
 
 ### phantomjs for javascript tests (optional)

--- a/doc/PREREQUISITES.md
+++ b/doc/PREREQUISITES.md
@@ -36,19 +36,19 @@ Ruby dependencies, or Gems, are managed with Bundler.
 `gem install bundler` - if it's not already installed, but it should be in a basic RVM ruby. 
 
 
-### Assets with Bower
+### YARN 
 
-You'll also need **bower** which is available through `npm`, part of `node.js`.
+You'll also need **yarn** to get your JavaScript dependencies.
 
-[This wiki page from the nodejs repository](https://github.com/nodejs/node/wiki) has comprehensive and up to date installation guides for many systems. 
- 
-Once NPM is installed, you should be able to run:
+[The official installation section](https://yarnpkg.com/lang/en/docs/install/#debian-stable) for yarn has installation details for many systems.
 
-`npm install -g bower`
+The yarn install step replaces the previously used bower install step.
 
-**NOTE:** If you're having permission issues, please see https://docs.npmjs.com/getting-started/fixing-npm-permissions
+Use `yarn --version` to verify whether the installation is up and running!
 
-**WARNING:** Please refrain from using `sudo npm` as it's not only a bad practice, but may also put your security at a risk. For more on this, read https://pawelgrzybek.com/fix-priviliges-and-never-again-use-sudo-with-npm/
+**Note**: In case the options described above do not work for you, you can also install yarn using npm,though it is generally not recommended. As a prerequisite, you will have to [install Node.js](https://nodejs.org/en/download/) if not already installed.
+To install yarn using npm, use `npm install --global yarn` and then continue with path setup similar to the usual installation.
+
 
 ### phantomjs for javascript tests (optional)
 


### PR DESCRIPTION
Fixes #5128 

This fix is to replace bower install with yarn install in the documentation, as referenced in issue #5128 and mentioned by @jywarren [here](https://github.com/publiclab/plots2/issues/3840#issuecomment-436428141).