### PR TITLE
Fix Subscribe tag and subscribe related tag mismatch working add post option when subscribed

### DIFF
--- a/app/views/tag/_dropdown_subscribe.html.erb
+++ b/app/views/tag/_dropdown_subscribe.html.erb
@@ -1,0 +1,20 @@
+<!-- This button is used to display tags in a popover and subscribe to multiple tags using a single button -->
+<% buttonStyle ||= 'btn-primary btn-md' %>
+<a id="popover_button" class="btn rounded-right <%= buttonStyle %>">
+  <i class="fa fa-caret-down" style="color:white;" aria-hidden="true"></i>
+</a>
+
+<div id="mypopcontent" class="d-none" onmouseleave="show(this)">
+  <%= render partial: "tag/tags_popover", locals: {tags: tags} %>
+</div>
+
+<script type="text/javascript">
+  $('#popover_button').popover({
+    content: $('#mypopcontent').clone().removeClass('d-none'),
+    placement: 'bottom',
+    html: true,
+  });
+  function show(elem){
+      $('#popover_button').popover("hide")
+  }
+</script>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -17,13 +17,23 @@
         <p class = "wiki-sub">This topic has no wiki</p>
       <% end %>
       <div class = "tag-buttons">
-        <% if @related_tags %>
-          <a><%= render partial: 'tag/subscribe_button', locals: { tags: @related_tags, buttonStyle: "btn-primary btn-lg", buttonColor: "white" } %></a>
-        <% end %>
+        <div class="btn-group" role="group">
+          <% if current_user && current_user.following(@title) %>
+            <a style="float: right;  width: 100px;" rel="tooltip" title="<%= t('sidebar._post_button.share_your_work') %>" data-placement="bottom" href="/post?tags=<%= tag.name %>" class="btn btn-primary requireLogin">New post <i class="fa fa-plus fa-white"></i></a>
+          <% elsif current_user %>
+            <a class="btn btn-primary" target="_blank" href="/subscribe/tag/<%= @title %>"> Subscribe</a>
+              <% if @related_tags %>
+                <a><%= render partial: 'tag/dropdown_subscribe', locals: { tags: @related_tags, buttonStyle: "btn-primary"} %></a>
+              <% end %>
+          <% else %>
+            <a class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Login to Subscribe" style="color:white;">Subscribe</a>
+            <a class="btn rounded-right btn-primary btn-md"><i class="fa fa-caret-down" style="color:white;" data-toggle="tooltip" data-placement="top" title="Login to Subscribe to related-tags"></i></a>
+          <% end %>
+        </div>
         <% if @wiki %>
-          <a><%= link_to("Learn more &raquo;".html_safe, "/wiki/#{params[:id]}", :class=> "btn btn-outline-secondary btn-lg")%></a>
+          <a><%= link_to("Learn more &raquo;".html_safe, "/wiki/#{params[:id]}", :class=> "btn btn-outline-secondary")%></a>
         <% else %>
-          <a class="btn btn-outline-secondary btn-lg" href="/wiki/new?title=<%= params[:id] %>">Add a wiki page <span class="fa fa-plus"></span></a>
+           <a class="btn btn-outline-secondary" href="/wiki/new?title=<%= params[:id] %>">Add a wiki page <span class="fa fa-plus"></span></a>
         <% end %>
       </div>
   </div>

--- a/app/views/tag/show/_user_controls.html.erb
+++ b/app/views/tag/show/_user_controls.html.erb
@@ -1,7 +1,7 @@
 <% if current_user %>
 <!-- AJAXify -->
   <a class="ellipsis" data-toggle="dropdown">&nbsp<i class="fa fa-ellipsis-h" style="color : #666; font-size:15px; float:right;"></i></a>
-  <ul class="dropdown-menu" style = "font-size:15px;">
+  <ul class="dropdown-menu text-center" style = "font-size:15px;">
     <li>
     <% unless @wildcard %>
       <%= link_to tag_stats_path, id: params[:id] ,title: "Click to view graph" do %>
@@ -12,9 +12,9 @@
     <li><a href="/feed/tag/<%= params[:id] %>.rss"><i class="fa fa-rss"></i> RSS</a></li>
     <% unless @wildcard %>
       <% if current_user.following(params[:id]) %>
-        <li><a rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="active" href="/unsubscribe/tag/<%= params[:id] %>" data-method="delete"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.show.following') %> <b><%= params[:id] %></b></a> </li>
+        <li><a style="width: 100px;" rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="btn btn-light btn-sm active" href="/unsubscribe/tag/<%= params[:id] %>"></i> <%= t('tag.index.unsubscribe') %></a></li>
       <% else %>
-        <li><a href="/subscribe/tag/<%= params[:id] %>"><i class="fa fa-user-plus" aria-hidden="true"></i> <%= t('tag.show.follow') %> <b><%= params[:id] %></b></a> </li>
+        <li><a style="width: 100px;" class="btn btn-outline-secondary btn-sm" href="/subscribe/tag/<%= params[:id] %>" data-remote="true"><%= t('tag.index.subscribe') %></a></li>
       <% end %>
         <li><a tabindex="0" data-toggle="popover" data-trigger = "" data-placement="bottom" data-html="true" data-title="<%= t('tag.show.users_following_tag') %>" data-content="<% Tag.followers(params[:id]).each do |user| %><i class='fa fa-star-o'></i> <a href='/profile/<%= user.username %>'><%= user.username %></a><br /><% end %><% if Tag.follower_count(params[:id]) == 0 %><i><%= t('tag.show.none') %></i><% end %>"><%= Tag.follower_count(params[:id]) %> <i class="fa fa-user"></i> <span class="caret"></span></a></li>
         <li><a href="/tag-pages">How to edit this card</a></li>


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/6097

#### Earlier -
In the one main card of Individual Tag page , we had a subscribe button but when I click on the button, it shows related tag, but not let us subscribe to that particular tag. We are only able to subscribe to related tags and not the main tag whose Individual page we are on.
Instead we have another button below called `Subscribe to answer questions on this topic`. And this button is the one which lets us subscribe to tag.

![Screenshot from 2019-08-03 12-53-11](https://user-images.githubusercontent.com/26685258/62419900-331fe500-b6a8-11e9-926a-010422289b22.png)


#### Now 
Now I have added a subscribe button to subscribe to that particular tag on which page we are and For related tag, I have converted it to dropdown, so we have an option of subscribing to related tags too.

![sub](https://user-images.githubusercontent.com/26685258/62419886-e63c0e80-b6a7-11e9-87d3-f8c9dee72d67.gif)


