### PR TITLE
Add automated-redeploy Make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ redeploy-container:
 	docker-compose exec -T web bundle exec whenever --update-crontab
 	docker-compose exec -T web service cron start
 
+pull-from-stable:
+	git pull --ff-only origin stable
+
+automated-redeploy: pull-from-stable redeploy-container
+
 deploy-container:
 	docker-compose run --rm web yarn install
 	docker-compose run --rm web bash -c "sleep 5 && rake db:migrate && rake assets:precompile"


### PR DESCRIPTION
This is a way to automated and trace our deployment process! It is currently working and triggered manually from Jenkins (must have pushed to `stable` branch first).

Note that currently it uses `Makefile.beta` which is a copy of the Makefile on disk. Makefile on disk has uncommitted changes that could conflict if this is merged (I've not tested what happens in the event of conflicts).

The idea is that Jenkins triggers a specific predefined command in production with the right environment (env vars and directory). This command is defined in this Makefile: `make automated-redeploy` which will:

1. pull from stable branch
2. initiate redeployment process

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
