### PR TITLE
adding selector to delay login/signup screenshot test

### DIFF
--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -11,19 +11,19 @@ class ScreenshotsTest < ApplicationSystemTestCase
   test 'signup modal' do
     visit '/'
     click_on 'Sign up'
+    assert_selector('.signupContainer', visible: true)
     take_screenshot
   end
 
   test 'login modal' do
     visit '/'
     click_on 'Login'
-    assert_selector('.loginContainer')
+    assert_selector('.loginContainer', visible: true)
     take_screenshot
   end
 
   test 'signup' do
     visit '/signup'
-    assert_selector('.signupContainer')
     take_screenshot
   end
 

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -11,14 +11,14 @@ class ScreenshotsTest < ApplicationSystemTestCase
   test 'signup modal' do
     visit '/'
     click_on 'Sign up'
-    assert_selector('.signupContainer', visible: true)
+    assert_selector('#signupContainer', visible: true)
     take_screenshot
   end
 
   test 'login modal' do
     visit '/'
     click_on 'Login'
-    assert_selector('.loginContainer', visible: true)
+    assert_selector('#loginContainer', visible: true)
     take_screenshot
   end
 

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -17,11 +17,13 @@ class ScreenshotsTest < ApplicationSystemTestCase
   test 'login modal' do
     visit '/'
     click_on 'Login'
+    assert_selector('.loginContainer')
     take_screenshot
   end
 
   test 'signup' do
     visit '/signup'
+    assert_selector('.signupContainer')
     take_screenshot
   end
 


### PR DESCRIPTION
Follow-up to #6178, I'm trying to add a little delay to the `test_signup_modal` and `test_login_modal` so that this screenshot is taken just a little bit later, and we get to see the modal finish opening:

![image](https://user-images.githubusercontent.com/24359/63532753-571d5c00-c4d9-11e9-85e5-b237bb3c2729.png)

Any help appreciated! I thought the selector would work. But maybe we need to say `, visible: true` so it waits until it's fully shown...

