### PR TITLE
On Profile pages, have the profile picture and bio info stay on top when screen width decreases

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,5 +1,5 @@
 
-<div class="col-lg-7">
+<div class="col-md-7 order-last order-md-first">
 
   <% if !@map_lat.nil? && !@map_lon.nil? %>
   <%= render :partial => "map/userLeaflet" , locals: { haslocation: true, user: @profile_user } %>
@@ -34,10 +34,7 @@
 
 </div>
 
-<div class="col-lg-1">
-</div>
-
-<div class="col-lg-4 text-center">
+<div class="offset-md-1 order-first order-md-last col-md-4 text-center">
   <div class="text-center">
     <img class="d-none d-lg-inline rounded-circle" id="profile-photo" style="width:50%;margin-bottom:10px;" src="<%= @profile_user.profile_image %>" />
     <h4 class="mt-3"><strong>@<%= @profile_user.name %> <%= @profile_user.new_contributor %></strong></h4>


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/6218

![profile](https://user-images.githubusercontent.com/26685258/64029051-72cfd480-cb61-11e9-987d-dc55144b580b.gif)

