### PR TITLE
Fix change on hover and other bug-fix

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -50,7 +50,7 @@
   <h4>
     <small>
       <% if logged_in_as(['admin']) %><%= @profile_user.email %><% end %>
-      <span style = "font-size:24px;"><small> | <%= raw t('users.profile.joined_time_ago', :time_ago => distance_of_time_in_words(@profile_user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' })) %></small></span>
+      <span style = "font-size:24px;"><small> <%= raw t('users.profile.joined_time_ago', :time_ago => distance_of_time_in_words(@profile_user.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' })) %></small></span>
       <% if @profile_user.role == "moderator" %> | <i class="fa fa-certificate"></i> <%= t('users.profile.moderator') %><% end %>
       <% if @profile_user.role == "admin" %> | <i class="fa fa-certificate"></i> <%= t('users.profile.admin') %><% end %>
       <% if @profile_user.status == 0 %> | <i class="fa fa-ban" style="color:#a00;"></i> <%= t('users.profile.banned') %><% end %>
@@ -351,6 +351,13 @@
   .token{
     font-weight: bold;
   }
+
+  h5 a:hover {
+    color: blue !important;
+    text-decoration: underline;
+    font-weight:bold;
+}
+
 </style>
 
 <%= stylesheet_link_tag "dashboard" %>


### PR DESCRIPTION
Recently, I guess @ebarry mentioned that we don't have links to some pages. At that time, I found that we do have links for most them except few but to follow to new designs, I've changed the underline and other features. 
Thus unless you know before, You'll get never discover that these are the links not just info.
<hr />

![Screenshot from 2019-08-31 22-06-23](https://user-images.githubusercontent.com/26685258/64066958-08d92d00-cc3e-11e9-94c8-dc92898a370a.png)


<hr />

So I added a small css for this. Is hovered, We'll just show blue info and some text-decoration on hover. By this , we'll at least know that these are links. 

<hr />

![Screenshot from 2019-08-31 22-11-01](https://user-images.githubusercontent.com/26685258/64066946-c7488200-cc3d-11e9-9d3b-7e0f9fec7f1a.png)


And there is another small fix added in this PR by removing `|` in 

![Screenshot from 2019-08-31 22-21-10](https://user-images.githubusercontent.com/26685258/64066938-a8e28680-cc3d-11e9-97fa-ebbd6300e288.png)

and getting this -

![Screenshot from 2019-08-31 22-20-53](https://user-images.githubusercontent.com/26685258/64066941-b1d35800-cc3d-11e9-8c64-c97b387c1bea.png)

