### PR TITLE
Make profile user links more prominent

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -9,7 +9,12 @@
 
   <br />
 
-  <p style="width: 100%; text-align: center; border-bottom: 1px solid #ccc; line-height:2px; margin: 10px 0 20px;">
+  <div style="text-align: center;">
+  <h5><a href='/notes/author/<%= @profile_user.name %>'><%= @profile_user.note_count %> research notes</a>
+  <a class="ml-2" href = "/tag/question:*/author/<%= params[:id] %>"><%= Node.questions.where(status: 1, uid: @profile_user.id).length %> questions </a></h5>
+  </div>
+
+  <p style="width: 100%; text-align: center; border-bottom: 1px solid #ccc; line-height:2px; margin: 21px 0 20px;">
     <span style="background-color: #fff; padding: 0 10px; color: #808080;">
       <h7>Most Common Tags</h7>
     </span>
@@ -245,7 +250,7 @@
   <div class="info float:left">
     <ul>
     <li class="mt-3"><h5>@<%= @profile_user.name %> has</h5></li> 
-      <li><h5><%= @profile_user.note_count %><a href='/notes/author/<%= @profile_user.name %>'> research notes</a></h5></li>
+      <li><h5><a href='/notes/author/<%= @profile_user.name %>'><%= @profile_user.note_count %> research notes</a></h5></li>
       <li><h5><%= @profile_user.revisions.count %> wiki edits</h5></li>
       <li><h5><a href = "/tag/question:*/author/<%= params[:id] %>"><%= Node.questions.where(status: 1, uid: @profile_user.id).length %> questions </a></h5></li>
       <li><h5><%= Comment.where(uid: @profile_user.id).count %> comments</h5></li>
@@ -349,11 +354,16 @@
     font-weight: bold;
   }
 
-  h5 a:hover {
+  h5 a{
     color: blue !important;
     text-decoration: underline;
     font-weight:bold;
 }
+
+  .links {
+    font-size: 18px;
+    padding: 8px 5px 8px 4px;
+  }
 
 </style>
 


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/6001
Continuing with https://github.com/publiclab/plots2/issues/6001#issuecomment-528931533.
This PR tried to make links more prominent. And I have added Notes and Questions above the most common cards. As User might not be able to find their notes/questions in recent tags or topic cards. 

![Screenshot from 2019-09-07 12-40-59](https://user-images.githubusercontent.com/26685258/64471252-de6efe80-d16c-11e9-8acb-f02f6b93e2ca.png)

![Screenshot from 2019-09-07 12-33-38](https://user-images.githubusercontent.com/26685258/64471215-4113ca80-d16c-11e9-8786-22515c8bf40b.png)


Thanks!
