### PR TITLE
Newly-created user tag cannot be immediately deleted (#6163)

### DIFF
--- a/app/controllers/user_tags_controller.rb
+++ b/app/controllers/user_tags_controller.rb
@@ -94,11 +94,11 @@ class UserTagsController < ApplicationController
       errors: []
     }
 
-    @user_tag = UserTag.where(uid: params[:id], value: params[:name]).first
+    @user_tag = UserTag.where(id: params[:id], uid: params[:uid]).first
 
     if !@user_tag.nil?
       if logged_in_as(['admin']) || @user_tag.user == current_user
-        UserTag.where(uid: params[:id], value: params[:name]).destroy_all
+        UserTag.where(id: params[:id], uid: params[:uid]).destroy_all
         output[:errors] = I18n.t('user_tags_controller.tag_deleted')
         output[:status] = true
       else

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -52,7 +52,7 @@ $(function () {
   <span style="float:left;color:#666;margin-top:14px;margin-left:5px;">Add tags</a> 
 <% end %>
 
-<%= render partial: 'tag/form', locals: { node: @node ||= nil, user: user ||= nil } %>
+<%= render partial: 'tag/form', locals: { node: @node ||= nil, user: user ||= nil, url: url ||= nil } %>
 
 <% end %>
 

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -45,7 +45,7 @@
         <%= tag.name[0..5] + tag.name.split(':')[1] %>
       <% end %>
       <% if logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid) %>
-        <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete">x</a>
+        <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>/<%= tag.id %>" data-method="delete">x</a>
       <% end %>
     </span></li>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,7 +239,7 @@ Plots2::Application.routes.draw do
 
   post 'profile/tags/create/:id' => 'user_tags#create'
   get 'profile/tags/create/:id' => 'user_tags#create'
-  delete 'profile/tags/delete/:id' => 'user_tags#delete'
+  delete 'profile/tags/delete/:uid/:id' => 'user_tags#delete'
   get 'user_tags' => 'user_tags#index'
   get 'user_tags/:search' => 'user_tags#index'
   get 'groups' => 'user_tags#index'

--- a/test/functional/user_tags_controller_test.rb
+++ b/test/functional/user_tags_controller_test.rb
@@ -33,7 +33,7 @@ class UserTagsControllerTest < ActionController::TestCase
   test 'should delete existing tag' do
     UserSession.create(users(:bob))
     user_tag = user_tags(:one)
-    delete :delete , params: { id: users(:bob).id , name: user_tag.name }
+    delete :delete , params: { uid: users(:bob).id , id: user_tag.id }
     assert_equal 'Tag deleted.', flash[:notice]
     assert_redirected_to info_path
   end
@@ -41,13 +41,13 @@ class UserTagsControllerTest < ActionController::TestCase
   test 'should render a text/plain when a tag is deleted through post request xhr' do
     UserSession.create(users(:bob))
     user_tag = user_tags(:two)
-    delete :delete , params: { id: users(:bob).id , name: user_tag.name }, xhr: true
+    delete :delete , params: { uid: users(:bob).id , id: user_tag.id }, xhr: true
     assert_equal user_tag.id, JSON.parse(@response.body)['tid']
   end
 
   test 'cannot delete non-existent tag' do
     UserSession.create(users(:bob))
-    delete :delete, params: { id: users(:bob).id , name: "temp tag" }
+    delete :delete, params: { uid: users(:bob).id , id: 1000 }
     assert_equal "Tag doesn't exist.", flash[:error]
     assert_redirected_to info_path
   end
@@ -75,7 +75,7 @@ class UserTagsControllerTest < ActionController::TestCase
     user_tags_count = UserTag.where(uid: users(:bob).id).count
     # Delete above tag
     UserSession.create(users(:jeff))
-    delete :delete, params: { id: users(:bob).id , name: user_tag.name }
+    delete :delete, params: { uid: users(:bob).id , id: user_tag.id }
     assert_equal user_tags_count - 1, UserTag.where(uid: users(:bob).id).count
   end
 
@@ -95,7 +95,7 @@ class UserTagsControllerTest < ActionController::TestCase
   test 'Normal user should not delete tag for other user' do
     user_tag = UserTag.where(uid: users(:jeff).id).last
     UserSession.create(users(:bob))
-    delete :delete, params: { id: users(:jeff).id , name: user_tag.name }
+    delete :delete, params: { uid: users(:jeff).id , id: user_tag.id }
     assert_equal 'Only admin (or) target user can manage tags', flash[:error]
   end
 
@@ -109,7 +109,7 @@ class UserTagsControllerTest < ActionController::TestCase
       @controller = old_controller
 
       UserSession.create(users(:bob))
-      delete :delete, params: { id: users(:bob).id , name: "temp tag" }
+      delete :delete, params: { uid: users(:bob).id , id: 1000 }
       assert_equal I18n.t('user_tags_controller.tag_doesnt_exist'), flash[:error]
     end
   end
@@ -138,7 +138,7 @@ class UserTagsControllerTest < ActionController::TestCase
 
   test 'should report error if delete tag non existing (xhr req)' do
     UserSession.create(users(:bob))
-    delete :delete, xhr: true, params: { id: users(:bob).id , name: "N/A" }
+    delete :delete, xhr: true, params: { uid: users(:bob).id , id: 1000 }
     assert response.body.include? "Tag doesn't exist."
     assert_not JSON.parse(response.body)['status']
   end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -1,0 +1,25 @@
+require "application_system_test_case"
+
+class ProfileTest < ApplicationSystemTestCase
+  Capybara.default_max_wait_time = 60
+
+  test 'create and delete user tag using AJAX' do
+    visit '/'
+    click_on 'Login'
+    fill_in("username-login", with: "Bob")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
+
+    visit '/profile/bob'
+
+    find_link('tags-section', href: nil).click
+    find_link('tags-open', href: nil).click
+    find('.tag-input').set("test_user_tag\n")
+    assert_selector('span', text: 'test_user_tag')
+
+    accept_alert('Are you sure you want to delete it?') do
+      find_link('x', href: /name=test_user_tag\z/).click
+    end
+    assert_no_selector('span', text: 'test_user_tag')
+  end
+end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -15,11 +15,11 @@ class ProfileTest < ApplicationSystemTestCase
     find_link('tags-section', href: nil).click
     find_link('tags-open', href: nil).click
     find('.tag-input').set("test_user_tag\n")
-    assert_selector('span', text: 'test_user_tag')
 
-    accept_alert('Are you sure you want to delete it?') do
-      find_link('x', href: /name=test_user_tag\z/).click
+    within('div#tags.profile-tags') do
+      assert_selector('a', text: 'test_user_tag')
+      find('p:last-of-type a', text: 'x').click
+      assert_no_selector('a', text: 'test_user_tag')
     end
-    assert_no_selector('span', text: 'test_user_tag')
   end
 end


### PR DESCRIPTION
Newly-created user tag cannot be immediately deleted

Fixes #6163 
<img src="https://user-images.githubusercontent.com/14910846/64476811-2c4f2b00-d19c-11e9-971c-cd0932a3b53a.gif" width="500" height="300">

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
