### PR TITLE
Weird warnings while testing (#2365)

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -7,16 +7,6 @@ class Tag < ApplicationRecord
   has_many :node_tag, foreign_key: 'tid'
 
   # we're not really using the filter_by_type stuff here:
-  has_many :node, through: :drupal_node_tag do
-    def filter_by_type(type, limit = 10)
-      where(status: 1, type: type)
-        .limit(limit)
-        .order('created DESC')
-    end
-  end
-
-  # the following probably never gets used; tag.node will use the above definition.
-  # also, we're not really using the filter_by_type stuff here:
   has_many :node, through: :node_tag do
     def filter_by_type(type, limit = 10)
       where(status: 1, type: type)


### PR DESCRIPTION
Fixes #2365

Warnings caused by double association declaration: tag has_many node through 2 different tables. Only one is valid and still exists. 

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
