### PR TITLE
Fix missing user profile image when none set on profile page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,9 +230,9 @@ class User < ActiveRecord::Base
     following_users.include?(other_user)
   end
 
-  def profile_image
+  def profile_image(size = :thumb)
     if photo_file_name
-      photo_path(:thumb)
+      photo_path(size)
     else
       "https://www.gravatar.com/avatar/#{OpenSSL::Digest::MD5.hexdigest(email)}"
     end

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -45,7 +45,7 @@
     <h4 class="mt-3"><strong>@<%= @profile_user.name %> <%= @profile_user.new_contributor %></strong></h4>
   </div>
   <div style="text-align:center;" class="d-lg-none">
-    <img class="rounded-circle" id="profile-photo" style="width:50%;margin-bottom:20px;" src="<%= @profile_user.photo_path %>" />
+    <img class="rounded-circle" id="profile-photo" style="width:50%;margin-bottom:20px;" src="<%= @profile_user.profile_image(:medium) %>" />
   <h4 class="mt-3"><strong>@<%= @profile_user.name %> <%= @profile_user.new_contributor %></strong></h4>
   </div>
 


### PR DESCRIPTION
On the profile page there is a 404 error for the large user image that appears when there is no photo set.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁

Thanks!
