### PR TITLE
Add likes count to questions in wiki #6321

### DIFF
--- a/app/views/grids/_notes.html.erb
+++ b/app/views/grids/_notes.html.erb
@@ -7,6 +7,7 @@
       <th><a data-type="author">Author</a></th>
       <th><a data-type="updated">Updated</a></th>
       <th><a data-type="likes">Likes</a></th>
+      <th><a data-type="comments">Comments</a></th>
     <% elsif type == "activity" || type == "upgrades" %>
       <th><a data-type="title">Purpose</a></th>
       <th><a data-type="category">Category</a></th>
@@ -52,6 +53,7 @@
       <td class="author"><a href="/profile/<%= node.author.username %>">@<%= node.author.username %> <%=node.author.new_contributor %></a></td>
       <td class="updated" data-timestamp="<%= node.latest.timestamp.to_s %>"><%= distance_of_time_in_words(Time.at(node.latest.updated_at), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></td>
       <td class="likes"><%= node.cached_likes.to_s %></td>
+      <td><%= node.comments_count.to_s %></td>
     <% else %>
       <td class="title">
         <% if node.has_tag("pin:#{tagname}") %><i rel="tooltip" title="This item was pinned with the tag 'pin:<%= tagname %>'." class="fa fa-thumb-tack"></i> 

--- a/test/unit/node_shared_test.rb
+++ b/test/unit/node_shared_test.rb
@@ -202,7 +202,7 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert_equal 1, html.scan('<table class="table inline-grid notes-grid notes-grid-test notes-grid-test-').length
     assert_equal 1, html.scan('<table').length
     assert_equal 5, html.scan('notes-grid-test').length
-    assert_equal 4, html.scan('<td').length
+    assert_equal 5, html.scan('<td').length
   end
 
   test 'about ability of power tags to exclude tags like [questions:foo!foo1]' do


### PR DESCRIPTION
Previously the questions table rendered likes as a measure of
popularity. Comments would give another useful indicator to how active a
question is and how many answers there are.

![image](https://user-images.githubusercontent.com/12040789/66119136-8d9bda00-e634-11e9-8087-9270ea1001c5.png)

Fixes #6321

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
