### PR TITLE
Fixed "Publically" to "publicly" where found

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -375,7 +375,7 @@ class NotesController < ApplicationController
       @node.slug = @node.slug.split('token').first
       @node.publish
       SubscriptionMailer.notify_node_creation(@node).deliver_now
-      flash[:notice] = "Thanks for your contribution. Research note published! Now, it's visible publically."
+      flash[:notice] = "Thanks for your contribution. Research note published! Now, it's visible publicly."
       redirect_to @node.path
     else
       flash[:warning] = "You are not author or moderator so you can't publish a draft!"

--- a/doc/DATA_MODEL.md
+++ b/doc/DATA_MODEL.md
@@ -37,7 +37,7 @@ Node `status` -- a property of `Node`, can be:
 
 ### Drafts
 
-Drafts are a type of Research notes. They can be used by users to save their research notes without publishing them publically. But, not all users are eligible to create draft.
+Drafts are a type of Research notes. They can be used by users to save their research notes without publishing them publicly. But, not all users are eligible to create draft.
 Only users who have successfully published their first-note would be shown option for creating draft. Draft would be visible to co-author and other users can access it using secret link
 shared by author. Different draft-related privileges are mentioned below in the table:
 

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -786,7 +786,7 @@ class NotesControllerTest < ActionController::TestCase
     get :publish_draft, params: { id: node.id }
 
     assert_response :redirect
-    assert_equal "Thanks for your contribution. Research note published! Now, it's visible publically.", flash[:notice]
+    assert_equal "Thanks for your contribution. Research note published! Now, it's visible publicly.", flash[:notice]
     node = assigns(:node)
     assert_equal 1, node.status
     assert_equal 1, node.author.status
@@ -805,7 +805,7 @@ class NotesControllerTest < ActionController::TestCase
      get :publish_draft, params: { id: node.id }
 
      assert_response :redirect
-     assert_equal "Thanks for your contribution. Research note published! Now, it's visible publically.", flash[:notice]
+     assert_equal "Thanks for your contribution. Research note published! Now, it's visible publicly.", flash[:notice]
      node = assigns(:node)
      assert_equal 1, node.status
      assert_equal 1, node.author.status
@@ -824,7 +824,7 @@ class NotesControllerTest < ActionController::TestCase
      get :publish_draft, params: { id: node.id }
 
      assert_response :redirect
-     assert_equal "Thanks for your contribution. Research note published! Now, it's visible publically.", flash[:notice]
+     assert_equal "Thanks for your contribution. Research note published! Now, it's visible publicly.", flash[:notice]
      node = assigns(:node)
      assert_equal 1, node.status
      assert_equal 1, node.author.status


### PR DESCRIPTION
Fixes #6359 

Corrected the spelling in two locations and updated the tests. 
