### PR TITLE
Add prompt section to notes display

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -59,10 +59,6 @@
       </span>
       </span>
 
-    <p>
-      Read more: <%= request.host %>/n/<%= @node.id %>
-    </p>
-
   </div>
 
   <hr style="margin-top:10px;" />
@@ -96,6 +92,12 @@
   <div class="d-print-none">
     <hr />
 
+    <% if @node.has_power_tag('prompt') && feature("prompt-#{@node.power_tag('prompt')}") != "" %>
+      <% if current_user && (current_user.id == @node.uid || current_user.admin? || current_user.moderator? || current_user.is_coauthor?(@node)) %>
+        <%= feature("prompt-#{@node.power_tag('prompt')}") %>
+      <% end %>
+    <% end %>
+
     <% if @node.has_tag('event:rsvp') %>
       <p><b><% if @node.has_power_tag('date') %>
         <script>
@@ -115,11 +117,10 @@
       <hr />
     <% end %>
 
-    <%= render :partial => "notes/responses" %>
+    <%= render partial: "notes/responses" %>
 
-    <div>
-      <%= render :partial => "notes/comments" %>
-    </div>
+    <div><%= render partial: "notes/comments" %></div>
+
   </div>
 
 </div><!--/span-->


### PR DESCRIPTION
### Prompt powertags

By adding a `prompt:FOO` power tag on a node, for example via a link to post such as `https://publiclab.org/post?tags=prompt:photo`, the post will displays an HTML feature with (in this example) the name `prompt-photo`. 

Using this, admins may create any HTML content to be displayed just under the post - for example, a notice to add a photo to your post, or guidance on further posting. The feature may even include JavaScript functions to add/remove tags (`add_tag('new-tag')`) or comments (`add_comment('This post is ____')`), allowing a sequence of prompts to be generated which guide the user through a more gradual updating or refinement of their post. 