### PR TITLE
Delay moderator notifications 24h, remove all confirmation emails, remove spam from dashboard

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -119,7 +119,8 @@ class AdminController < ApplicationController
       if @node.status == 1 || @node.status == 4
         @node.spam
         @node.author.ban
-        AdminMailer.notify_moderators_of_spam(@node, current_user).deliver_later
+        # No longer notifying other moderators as of https://github.com/publiclab/plots2/issues/6246
+        # AdminMailer.notify_moderators_of_spam(@node, current_user).deliver_later
         flash[:notice] = "Item marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>."
         redirect_to '/dashboard' + '?_=' + Time.now.to_i.to_s
       else
@@ -143,7 +144,8 @@ class AdminController < ApplicationController
         @comment.spam
         user = @comment.author
         user.ban
-        AdminMailer.notify_moderators_of_comment_spam(@comment, current_user).deliver_later
+        # No longer notifying other moderators as of https://github.com/publiclab/plots2/issues/6246
+        # AdminMailer.notify_moderators_of_comment_spam(@comment, current_user).deliver_later
         flash[:notice] = "Comment has been marked as spam and comment author has been banned. You can undo this on the <a href='/spam/comments'>spam moderation page</a>."
       else
         flash[:notice] = "Comment already marked as spam."
@@ -167,7 +169,8 @@ class AdminController < ApplicationController
         end
         if first_timer_comment
           AdminMailer.notify_author_of_comment_approval(@comment, current_user).deliver_later
-          AdminMailer.notify_moderators_of_comment_approval(@comment, current_user).deliver_later
+          # No longer notifying other moderators as of https://github.com/publiclab/plots2/issues/6246
+          # AdminMailer.notify_moderators_of_comment_approval(@comment, current_user).deliver_later
         else
           flash[:notice] = 'Comment published.'
         end
@@ -191,7 +194,8 @@ class AdminController < ApplicationController
         @node.author.unban
         if first_timer_post
           AdminMailer.notify_author_of_approval(@node, current_user).deliver_later
-          AdminMailer.notify_moderators_of_approval(@node, current_user).deliver_later
+          # No longer notifying other moderators as of https://github.com/publiclab/plots2/issues/6246
+          # AdminMailer.notify_moderators_of_approval(@node, current_user).deliver_later
           SubscriptionMailer.notify_node_creation(@node).deliver_now
           flash[:notice] = if @node.has_power_tag('question')
                              "Question approved and published after #{time_ago_in_words(@node.created_at)} in moderation. Now reach out to the new community member; thank them, just say hello, or help them revise/format their post in the comments."

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -81,7 +81,7 @@ class AdminController < ApplicationController
       @nodes = if params[:type] == 'wiki'
                  @nodes.where(type: 'page', status: 1)
                else
-                 @nodes.where(status: 0)
+                 @nodes.where(status: [0, 4]) # spam OR as-yet-unmoderated posts
       end
     else
       flash[:error] = 'Only moderators can moderate posts.'

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -88,8 +88,8 @@ class HomeController < ApplicationController
                    .group(['title', 'comments.cid']) # ONLY_FULL_GROUP_BY, issue #3120
 
     if logged_in_as(['admin', 'moderator'])
-      notes = notes.where('(node.status = 1 OR node.status = 4 OR node.status = 3)')
-      comments = comments.where('comments.status = 1 OR comments.status = 4')
+      notes = notes.where('(node.status = 1 OR node.status = 3)')
+      comments = comments.where('comments.status = 1')
     elsif current_user
       coauthor_nids = Node.joins(:node_tag)
         .joins('LEFT OUTER JOIN term_data ON term_data.tid = community_tags.tid')

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -11,11 +11,13 @@ class AdminMailer < ActionMailer::Base
     @user = node.author
     @footer = feature('email-footer')
     moderators = User.where(role: %w(moderator admin)).collect(&:email)
-    mail(
-      to: "moderators@#{ActionMailer::Base.default_url_options[:host]}",
-      bcc: moderators,
-      subject: subject
-    )
+    if node.status == 4 # only if it remains unmoderated
+      mail(
+        to: "moderators@#{ActionMailer::Base.default_url_options[:host]}",
+        bcc: moderators,
+        subject: subject
+      )
+    end
   end
 
   def notify_comment_moderators(comment)
@@ -24,11 +26,13 @@ class AdminMailer < ActionMailer::Base
     @user = comment.author
     @footer = feature('email-footer')
     moderators = User.where(role: %w(moderator admin)).collect(&:email)
-    mail(
-      to: "comment-moderators@#{ActionMailer::Base.default_url_options[:host]}",
-      bcc: moderators,
-      subject: subject
-    )
+    if node.status == 4 # only if it remains unmoderated
+      mail(
+        to: "comment-moderators@#{ActionMailer::Base.default_url_options[:host]}",
+        bcc: moderators,
+        subject: subject
+      )
+    end
   end
 
   def notify_author_of_approval(node, moderator)

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -26,7 +26,7 @@ class AdminMailer < ActionMailer::Base
     @user = comment.author
     @footer = feature('email-footer')
     moderators = User.where(role: %w(moderator admin)).collect(&:email)
-    if node.status == 4 # only if it remains unmoderated
+    if comment.status == 4 # only if it remains unmoderated
       mail(
         to: "comment-moderators@#{ActionMailer::Base.default_url_options[:host]}",
         bcc: moderators,

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -219,7 +219,7 @@ class Node < ActiveRecord::Base
 
   def notify
     if status == 4
-      AdminMailer.notify_node_moderators(self).deliver_now
+      AdminMailer.notify_node_moderators(self).deliver_later!(wait_until: 24.hours.from_now)
     else
       SubscriptionMailer.notify_node_creation(self).deliver_now
     end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -221,7 +221,7 @@ class Node < ActiveRecord::Base
     if status == 4
       AdminMailer.notify_node_moderators(self).deliver_later!(wait_until: 24.hours.from_now)
     else
-      SubscriptionMailer.notify_node_creation(self).deliver_now
+      SubscriptionMailer.notify_node_creation(self).deliver_later!
     end
   end
 

--- a/app/views/admin/_nodes.html.erb
+++ b/app/views/admin/_nodes.html.erb
@@ -21,15 +21,15 @@
   <td><input class="batch-checkbox" value="<%= node.nid %>" type="checkbox" /></td>
   <td>
     <i class="fa fa-file"></i> <a href="javascript:void(0);" onClick="$('#ninfo<%= node.nid %>').toggle()"><%= node.title.truncate(40) %></a><br />
-    <span style="color:grey;"><%= node.type.capitalize %> | <%= time_ago_in_words(node.updated_at) %> ago</span>
+    <span style="color:grey;"><%= node.type.capitalize %> (<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>) | <%= time_ago_in_words(node.updated_at) %> ago</span>
   </td>
   <td style="width:200px;">
     <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a>  <%= node.author.new_contributor %>
   </td>
   <td><div class="btn-toolbar" style="margin:0;">
     <div class="btn-group">
-      <a class="btn btn-lg <% if node.status == 0 %>btn-success<% else %>disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>"><i class="fa fa-check-circle fa-white"></i> Publish post</a>
-      <a class="btn btn-lg <% if node.status == 0 %>btn-danger<% else %>disabled<% end %> publish" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a>
+      <a class="btn btn-lg <% if node.status == 0 %>btn-success<% else %>btn-outline-secondary disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>"><i class="fa fa-check-circle fa-white"></i> Publish post</a>
+      <a class="btn btn-lg <% if node.status == 0 %>btn-danger<% else %>btn-outline-secondary disabled<% end %> publish" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a>
 
       <a class="btn btn-outline-secondary btn-lg ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
       <a class="btn btn-outline-secondary btn-lg unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>

--- a/app/views/admin/_nodes.html.erb
+++ b/app/views/admin/_nodes.html.erb
@@ -21,15 +21,15 @@
   <td><input class="batch-checkbox" value="<%= node.nid %>" type="checkbox" /></td>
   <td>
     <i class="fa fa-file"></i> <a href="javascript:void(0);" onClick="$('#ninfo<%= node.nid %>').toggle()"><%= node.title.truncate(40) %></a><br />
-    <span style="color:grey;"><%= node.type.capitalize %> (<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>) | <%= time_ago_in_words(node.updated_at) %> ago</span>
+    <span style="color:grey;"><%= node.type.capitalize %> (<span class="status"><% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %></span>) | <%= time_ago_in_words(node.updated_at) %> ago</span>
   </td>
   <td style="width:200px;">
     <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a>  <%= node.author.new_contributor %>
   </td>
   <td><div class="btn-toolbar" style="margin:0;">
     <div class="btn-group">
-      <a class="btn btn-lg <% if node.status == 0 %>btn-success<% else %>btn-outline-secondary disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>"><i class="fa fa-check-circle fa-white"></i> Publish post</a>
-      <a class="btn btn-lg <% if node.status == 0 %>btn-danger<% else %>btn-outline-secondary disabled<% end %> publish" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a>
+      <a class="btn btn-lg <% if node.status != 1 %>btn-success<% else %>btn-outline-secondary disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>"><i class="fa fa-check-circle fa-white"></i> Publish post</a>
+      <a class="btn btn-lg <% if node.status != 0 %>btn-danger<% else %>btn-outline-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a>
 
       <a class="btn btn-outline-secondary btn-lg ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
       <a class="btn btn-outline-secondary btn-lg unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>
@@ -41,9 +41,15 @@
       $('#n<%= node.id %> .delete').bind('ajax:success', function(e){
         $('#n<%= node.id %>').fadeOut()
       });
+
       $('#n<%= node.id %> .publish').bind('ajax:success', function(e){
         $('#n<%= node.id %>').hide()
-        $('#ndel<%= node.id %>').fadeIn()
+        $('#ndel<%= node.id %>').fadeIn(); // published!
+      });
+
+      $('#n<%= node.id %> .spam').bind('ajax:success', function(e){
+        $('#n<%= node.id %>').hide()
+        $('#nspam<%= node.id %>').fadeIn(); // spammed!
       });
 
       // authors:
@@ -60,6 +66,11 @@
 </tr>
 <tr style="display:none;" id="ndel<%= node.id %>">
   <td>Content <a href='<%= node.path %>'>published</a>.</td>
+  <td></td>
+  <td></td>
+</tr>
+<tr style="display:none;" id="nspam<%= node.id %>">
+  <td>Content <a href='<%= node.path %>'>spammed</a>.</td>
   <td></td>
   <td></td>
 </tr>

--- a/app/views/admin/_nodes.html.erb
+++ b/app/views/admin/_nodes.html.erb
@@ -28,10 +28,11 @@
   </td>
   <td><div class="btn-toolbar" style="margin:0;">
     <div class="btn-group">
-      <a class="btn btn-outline-secondary btn-lg <% if node.status == 0 %>btn-success<% else %>disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>"><i class="fa fa-ok-circle fa fa-white"></i> Publish</a>
+      <a class="btn btn-lg <% if node.status == 0 %>btn-success<% else %>disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>"><i class="fa fa-check-circle fa-white"></i> Publish post</a>
+      <a class="btn btn-lg <% if node.status == 0 %>btn-danger<% else %>disabled<% end %> publish" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a>
 
-      <a class="btn btn-outline-secondary btn-lg ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban</a>
-      <a class="btn btn-outline-secondary btn-lg unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban</a>
+      <a class="btn btn-outline-secondary btn-lg ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
+      <a class="btn btn-outline-secondary btn-lg unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>
       <%= link_to "/notes/delete/"+node.id.to_s, data: { confirm: 'Are you sure you want to delete "'+node.path+'"?' }, :remote => true, :class => "btn btn-outline-secondary btn-lg delete" do %>
         <i class="fa fa-trash"></i>
       <% end %>

--- a/app/views/admin/spam.html.erb
+++ b/app/views/admin/spam.html.erb
@@ -1,16 +1,8 @@
-<div class="col-lg-3">
-
-  <h3>Spam moderation:</h3>
-
-  <p>Moderators and admins have the ability to "spam" posts if they include inappropriate content, blatant advertising, or are otherwise problematic. If you're not sure, email <a href="mailto:organizers@<%= request.host %>">organizers@<%= request.host %></a>. If we all work together, we can keep spam to a minimum. Thanks for helping out!</p>
-
-  <hr />
-
-</div>
-
-<div class="col-lg-9">
+<div class="col-lg-12">
 
   <h3>Moderate potential spam</h3>
+
+  <p>Moderators and admins have the ability to "spam" posts if they include inappropriate content, blatant advertising, or are otherwise problematic. If you're not sure, email <a href="mailto:organizers@<%= request.host %>">moderators@<%= request.host %></a>. If we all work together, we can keep spam to a minimum. Thanks for helping out!</p>
 
   <ul class="nav nav-tabs">
     <li class="nav-item"><a class="nav-link <% unless params[:type] && params[:action] == "spam_revisions" %> active <% end %>" href="/spam">Filtered</a></li>

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -1,9 +1,11 @@
 <h3 id="activity-header"><i><%= t('dashboard._activity.activity') %></i></h3>
 
 <div class="activity-menu">
-  <a id="refreshA" href="/dashboard" class="btn btn-sm btn-outline-secondary float-right" data-toggle="tooltip" data-placement="bottom" title="Refresh" type="button">
-    <i class="fa fa-refresh"></i>
-  </a>
+  <% if current_user && (current_user.moderator? || current_user.admin?) %>
+    <a href="/spam" class="btn btn-sm btn-outline-secondary float-right" type="button">
+      <i class="fa fa-flag"></i>
+    </a>
+  <% end %>
 </div>
 
 <div class="meta activity-dropdown">

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -3,7 +3,8 @@
 <div class="activity-menu">
   <% if current_user && (current_user.moderator? || current_user.admin?) %>
     <a href="/spam" class="btn btn-sm btn-outline-secondary float-right" type="button">
-      <i class="fa fa-flag"></i>
+      <i class="fa fa-flag"></i> 
+      <%= Node.where(status: 4).count %>
     </a>
   <% end %>
 </div>

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -201,17 +201,6 @@ class AdminControllerTest < ActionController::TestCase
         assert_not_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
       end
     end
-
-    # shouldn't have sent notification yet per policy, but 
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
-      email = ActionMailer::Base.deliveries.last
-      assert_not_nil email.to
-      assert_not_nil email.bcc
-      assert_equal ["moderators@#{request_host}"], ActionMailer::Base.deliveries.last.to
-      # title same as initial for email client threading
-      assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
-    end
   end
 
   test 'admin user should be able to mark a node as spam' do
@@ -412,7 +401,7 @@ class AdminControllerTest < ActionController::TestCase
       node = nodes(:first_timer_note)
       ActionMailer::Base.deliveries.clear
 
-      assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      assert_difference 'ActionMailer::Base.deliveries.size', 0 do
         perform_enqueued_jobs do
           get :mark_spam, params: { id: node.id }
  
@@ -422,11 +411,6 @@ class AdminControllerTest < ActionController::TestCase
           assert_equal 0, node.status
           assert_equal 0, node.author.status
           assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
-  
-          email = ActionMailer::Base.deliveries.last
-          assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
-          assert_equal ["moderators@#{request_host}"], email.to
-          assert_not_nil email.bcc
         end
       end
     end

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -415,19 +415,19 @@ class AdminControllerTest < ActionController::TestCase
       assert_difference 'ActionMailer::Base.deliveries.size', 1 do
         perform_enqueued_jobs do
           get :mark_spam, params: { id: node.id }
+ 
+          assert_equal "Item marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>.", flash[:notice]
+   
+          node = assigns(:node)
+          assert_equal 0, node.status
+          assert_equal 0, node.author.status
+          assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
+  
+          email = ActionMailer::Base.deliveries.last
+          assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
+          assert_equal ["moderators@#{request_host}"], email.to
+          assert_not_nil email.bcc
         end
- 
-        assert_equal "Item marked as spam and author banned. You can undo this on the <a href='/spam'>spam moderation page</a>.", flash[:notice]
- 
-        node = assigns(:node)
-        assert_equal 0, node.status
-        assert_equal 0, node.author.status
-        assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
-
-        email = ActionMailer::Base.deliveries.last
-        assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
-        assert_equal ["moderators@#{request_host}"], email.to
-        assert_not_nil email.bcc
       end
     end
   end

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -204,14 +204,13 @@ class AdminControllerTest < ActionController::TestCase
       # shouldn't have sent notification yet per policy, but 
       assert_difference 'ActionMailer::Base.deliveries.size', 1 do
         Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
-        perform_enqueued_jobs do
-          email = ActionMailer::Base.deliveries.last
-          assert_not_nil email.to
-          assert_not_nil email.bcc
-          assert_equal ["moderators@#{request_host}"], ActionMailer::Base.deliveries.last.to
-          # title same as initial for email client threading
-          assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
-        end
+        perform_enqueued_jobs
+        email = ActionMailer::Base.deliveries.last
+        assert_not_nil email.to
+        assert_not_nil email.bcc
+        assert_equal ["moderators@#{request_host}"], ActionMailer::Base.deliveries.last.to
+        # title same as initial for email client threading
+        assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
       end
     end
   end
@@ -427,12 +426,11 @@ class AdminControllerTest < ActionController::TestCase
 
       assert_difference 'ActionMailer::Base.deliveries.size', 1 do
         Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
-        perform_enqueued_jobs do
-          email = ActionMailer::Base.deliveries.last
-          assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
-          assert_equal ["moderators@#{request_host}"], email.to
-          assert_not_nil email.bcc
-        end
+        perform_enqueued_jobs
+        email = ActionMailer::Base.deliveries.last
+        assert_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
+        assert_equal ["moderators@#{request_host}"], email.to
+        assert_not_nil email.bcc
       end
     end
   end

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -196,9 +196,6 @@ class AdminControllerTest < ActionController::TestCase
         assert_equal 0, node.status
         assert_equal 0, node.author.status
         assert_redirected_to '/dashboard' + '?_=' + Time.now.to_i.to_s
-       
-        email = ActionMailer::Base.deliveries.last
-        assert_not_equal '[New Public Lab poster needs moderation] ' + node.title, email.subject
       end
     end
   end

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -506,13 +506,14 @@ class NotesControllerTest < ActionController::TestCase
          redirect: 'question'
          }
     node = nodes(:blog)
-    email = AdminMailer.notify_node_moderators(node)
-    assert_emails 0 do
-      email.deliver_now # shouldn't deliver immediately
-    end
-    perform_enqueued_jobs
-    assert_emails 1 do
-      Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
+    perform_enqueued_jobs do
+      email = AdminMailer.notify_node_moderators(node)
+      assert_emails 0 do
+        email.deliver_now # shouldn't deliver immediately
+      end
+      assert_emails 1 do
+        Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
+      end
     end
     Timecop.return
 

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -496,10 +496,10 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to questions show page after creating a new question' do
+    title = 'How to use Spectrometer'
     perform_enqueued_jobs do
       assert_emails 1 do
         user = UserSession.create(users(:bob))
-        title = 'How to use Spectrometer'
         post :create,
              params: {
              title: title,

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -510,6 +510,7 @@ class NotesControllerTest < ActionController::TestCase
     assert_emails 0 do
       email.deliver_now # shouldn't deliver immediately
     end
+    perform_enqueued_jobs
     assert_emails 1 do
       Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
     end

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -496,26 +496,20 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to questions show page after creating a new question' do
-    user = UserSession.create(users(:bob))
-    title = 'How to use Spectrometer'
-    post :create,
-         params: {
-         title: title,
-         body: 'Spectrometer question',
-         tags: 'question:spectrometer',
-         redirect: 'question'
-         }
-    node = nodes(:blog)
     perform_enqueued_jobs do
-      email = AdminMailer.notify_node_moderators(node)
-      assert_emails 0 do
-        email.deliver_now # shouldn't deliver immediately
-      end
       assert_emails 1 do
-        Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
+        user = UserSession.create(users(:bob))
+        title = 'How to use Spectrometer'
+        post :create,
+             params: {
+             title: title,
+             body: 'Spectrometer question',
+             tags: 'question:spectrometer',
+             redirect: 'question'
+             }
+        node = nodes(:blog)
       end
     end
-    Timecop.return
 
     assert_redirected_to '/questions/' + users(:bob).username + '/' + Time.now.strftime('%m-%d-%Y') + '/' + title.parameterize
     assert_equal "Success! Thank you for contributing with a question, and thanks for your patience while your question is approved by <a href='/wiki/moderation'>community moderators</a> and we'll email you when it is published.", flash[:notice]

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -513,6 +513,7 @@ class NotesControllerTest < ActionController::TestCase
     assert_emails 1 do
       Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
     end
+    Timecop.return
 
     assert_redirected_to '/questions/' + users(:bob).username + '/' + Time.now.strftime('%m-%d-%Y') + '/' + title.parameterize
     assert_equal "Success! Thank you for contributing with a question, and thanks for your patience while your question is approved by <a href='/wiki/moderation'>community moderators</a> and we'll email you when it is published.", flash[:notice]

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -233,7 +233,7 @@ class WikiControllerTest < ActionController::TestCase
     node.reload
     assert_redirected_to node.path
     assert_equal flash[:notice], 'Edits saved.'
-    assert_equal nil, node.main_image_id
+    assert_nil node.main_image_id
   end
 
   test 'normal user should not delete wiki page' do

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -102,29 +102,30 @@ class I18nTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'should choose i18n for dashboard/_node_moderate' do
-    available_testing_locales.each do |lang|
-      get '/change_locale/' + lang.to_s
-      follow_redirect!
-      post '/user_sessions',
-        params: {
-          user_session: {
-            username: users(:jeff).username,
-            password: 'secretive'
-          }
-        }
-      follow_redirect!
-      post '/notes/create',
-          params: {
-           title: 'Some post',
-           body: 'Some post body',
-           tags: 'Some-tag',
-           status: 4
-          }
-      get '/dashboard'
-      assert_select 'a[class=?]', 'btn btn-outline-secondary btn-sm float-right', I18n.t('dashboard.moderate.approve')
-    end
-  end
+  # turning this off due to policy change in https://github.com/publiclab/plots2/issues/6246
+  #test 'should choose i18n for dashboard/_node_moderate' do
+  #  available_testing_locales.each do |lang|
+  #    get '/change_locale/' + lang.to_s
+  #    follow_redirect!
+  #    post '/user_sessions',
+  #      params: {
+  #        user_session: {
+  #          username: users(:jeff).username,
+  #          password: 'secretive'
+  #        }
+  #      }
+  #    follow_redirect!
+  #    post '/notes/create',
+  #        params: {
+  #         title: 'Some post',
+  #         body: 'Some post body',
+  #         tags: 'Some-tag',
+  #         status: 4
+  #        }
+  #    get '/dashboard'
+  #    assert_select 'a[class=?]', 'btn btn-outline-secondary btn-sm float-right', I18n.t('dashboard.moderate.approve')
+  #  end
+  #end
 
   test 'should choose i18n for dashboard/_node_question' do
     available_testing_locales.each do |lang|

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -122,7 +122,7 @@ class I18nTest < ActionDispatch::IntegrationTest
            status: 4
           }
       get '/dashboard'
-      assert_select 'a[class=?]', 'btn btn-outline-secondary btn-sm', I18n.t('dashboard.moderate.approve')
+      assert_select 'a[class=?]', 'btn btn-outline-secondary btn-sm float-right', I18n.t('dashboard.moderate.approve')
     end
   end
 

--- a/test/integration/node_series_tag_test.rb
+++ b/test/integration/node_series_tag_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class NodeSeriesTagTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   test 'add series tag' do
     post '/user_sessions', params: { user_session: { username: users(:bob).username, password: 'secretive'} }
 

--- a/test/integration/node_update_test.rb
+++ b/test/integration/node_update_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class NodeUpdateTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
   test 'edit note after creating a new note' do
     post '/user_sessions', params: { user_session: { username: users(:bob).username, password: 'secretive' } }
 

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -2,6 +2,7 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class PostTest < ApplicationSystemTestCase
+  include ActiveJob::TestHelper
   Capybara.default_max_wait_time = 60
 
   test 'posting from the editor' do

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -179,7 +179,7 @@ class ScreenshotsTest < ApplicationSystemTestCase
   test 'spam moderation page' do
     visit '/'
     click_on 'Login'
-    fill_in("username-login", with: "moderator")
+    fill_in("username-login", with: "obiwan") # moderator
     fill_in("password-signup", with: "secretive")
     click_on "Log in"
     visit '/spam'

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -176,6 +176,17 @@ class ScreenshotsTest < ApplicationSystemTestCase
     take_screenshot
   end
 
+  test 'spam moderation page' do
+    visit '/'
+    click_on 'Login'
+    fill_in("username-login", with: "moderator")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
+    visit '/spam'
+    assert_selector('#batch-delete', visible: true)
+    take_screenshot
+  end
+
   test 'blog page with location modal' do
     visit '/'
     click_on 'Login'

--- a/test/unit/admin_mailer_test.rb
+++ b/test/unit/admin_mailer_test.rb
@@ -10,14 +10,16 @@ class AdminMailerTest < ActionMailer::TestCase
     moderators = User.where(role: %w[moderator admin])
     assert !moderators.empty?
 
+    # policy at  https://github.com/publiclab/plots2/issues/6246
     assert_difference 'ActionMailer::Base.deliveries.size', 0 do
-      # send the email
+      assert_not_equal 4, node.status
       AdminMailer.notify_node_moderators(node).deliver_now
     end
+
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
+      node.status = 4 # notify if status == 4
+      AdminMailer.notify_comment_moderators(node).deliver_now
     end
-    Timecop.return
 
     # test that it got queued
     assert !ActionMailer::Base.deliveries.empty?
@@ -37,8 +39,14 @@ class AdminMailerTest < ActionMailer::TestCase
     moderators = User.where(role: %w[moderator admin])
     assert !moderators.empty?
 
+    # policy at  https://github.com/publiclab/plots2/issues/6246
+    assert_difference 'ActionMailer::Base.deliveries.size', 0 do
+      assert_not_equal 4, comment.status
+      AdminMailer.notify_comment_moderators(comment).deliver_now
+    end
+
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      # this is no longer used as of https://github.com/publiclab/plots2/issues/6246
+      comment.status = 4 # notify if status == 4
       AdminMailer.notify_comment_moderators(comment).deliver_now
     end
 

--- a/test/unit/admin_mailer_test.rb
+++ b/test/unit/admin_mailer_test.rb
@@ -18,7 +18,7 @@ class AdminMailerTest < ActionMailer::TestCase
 
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
       node.status = 4 # notify if status == 4
-      AdminMailer.notify_comment_moderators(node).deliver_now
+      AdminMailer.notify_node_moderators(node).deliver_now
     end
 
     # test that it got queued

--- a/test/unit/admin_mailer_test.rb
+++ b/test/unit/admin_mailer_test.rb
@@ -10,9 +10,12 @@ class AdminMailerTest < ActionMailer::TestCase
     moderators = User.where(role: %w[moderator admin])
     assert !moderators.empty?
 
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+    assert_difference 'ActionMailer::Base.deliveries.size', 0 do
       # send the email
       AdminMailer.notify_node_moderators(node).deliver_now
+    end
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
     end
 
     # test that it got queued
@@ -33,8 +36,11 @@ class AdminMailerTest < ActionMailer::TestCase
     moderators = User.where(role: %w[moderator admin])
     assert !moderators.empty?
 
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+    assert_difference 'ActionMailer::Base.deliveries.size', 0 do
       AdminMailer.notify_comment_moderators(comment).deliver_now
+    end
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
     end
 
     # # test that it got queued

--- a/test/unit/admin_mailer_test.rb
+++ b/test/unit/admin_mailer_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 include ActionView::Helpers::DateHelper # required for time_ago_in_words()
 
 class AdminMailerTest < ActionMailer::TestCase
+  include ActiveJob::TestHelper
+
   test 'notify_node_moderators' do
     node = nodes(:one)
     moderators = User.where(role: %w[moderator admin])

--- a/test/unit/admin_mailer_test.rb
+++ b/test/unit/admin_mailer_test.rb
@@ -17,6 +17,7 @@ class AdminMailerTest < ActionMailer::TestCase
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
       Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
     end
+    Timecop.return
 
     # test that it got queued
     assert !ActionMailer::Base.deliveries.empty?
@@ -36,11 +37,9 @@ class AdminMailerTest < ActionMailer::TestCase
     moderators = User.where(role: %w[moderator admin])
     assert !moderators.empty?
 
-    assert_difference 'ActionMailer::Base.deliveries.size', 0 do
-      AdminMailer.notify_comment_moderators(comment).deliver_now
-    end
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      Timecop.travel(Time.now + 2.days) # should be delivered after 24 hours
+      # this is no longer used as of https://github.com/publiclab/plots2/issues/6246
+      AdminMailer.notify_comment_moderators(comment).deliver_now
     end
 
     # # test that it got queued

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 class NodeTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
 
   def setup
     @start = (Date.today - 1.year).to_time


### PR DESCRIPTION
Fixes #6246 fixes #7142

Plus: removing post-moderation confirmations to moderators: "another moderator has approved/spammed this post"

repeating both above for comments!

Turning off confirmations will likely trip the tests, which will also have to be turned off. 