### PR TITLE
Add '# posts by # contributors | # followers' to tag pages

### DIFF
--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -54,7 +54,9 @@
 
             <%= render partial: 'tag/show/nav_tabs' %>
 
-            
+            <p><%= Tag.find_nodes_by_type(tag.name, 'note', false).count %> posts by <%= Tag.contributors(tag.name) %> contributors | <%= Tag.follower_count(tag.name) %> followers
+              <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
+            </p>
 
             <%= render partial: 'tag/show/tab_content' %>
             <div>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -54,7 +54,7 @@
 
             <%= render partial: 'tag/show/nav_tabs' %>
 
-            <p><%= Tag.find_nodes_by_type(tag.name, 'note', false).count %> posts by <%= Tag.contributor_count(tag.name) %> contributors | <%= Tag.follower_count(tag.name) %> followers
+            <p style="color: #aaa"><%= Tag.find_nodes_by_type(tag.name, 'note', false).count %> posts by <%= Tag.contributor_count(tag.name) %> contributors | <%= Tag.follower_count(tag.name) %> followers
               <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
             </p>
 

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -7,7 +7,7 @@
       <div class="pull-right"><%= render :partial => "tag/show/user_controls" %></div>
       <h1 style="margin-top:6px;"><%= @title %></h1>
       <% if @wildcard %>
-      
+
         <% if @node_type == "questions"%>
           <p><i>Showing <b>questions</b></i></p>
         <% elsif @node_type == "note" && params[:id].match("activity:") %>
@@ -54,10 +54,7 @@
 
             <%= render partial: 'tag/show/nav_tabs' %>
 
-            <p style="padding-top:8px;margin-bottom:0;">
-            <a class="btn btn-sm btn-outline-secondary" href="?order=views"><i class="fa fa-eye"></i> by views</a>
-            <a class="btn btn-sm btn-outline-secondary" href="?order=likes"><i class="fa fa-star"></i> by likes</a>
-            </p><br />
+            
 
             <%= render partial: 'tag/show/tab_content' %>
             <div>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -54,7 +54,7 @@
 
             <%= render partial: 'tag/show/nav_tabs' %>
 
-            <p><%= Tag.find_nodes_by_type(tag.name, 'note', false).count %> posts by <%= Tag.contributors(tag.name) %> contributors | <%= Tag.follower_count(tag.name) %> followers
+            <p><%= Tag.find_nodes_by_type(tag.name, 'note', false).count %> posts by <%= Tag.contributor_count(tag.name) %> contributors | <%= Tag.follower_count(tag.name) %> followers
               <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
             </p>
 

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -1,11 +1,6 @@
 <div class="dropdown" style="margin-top:10px; float:right;">
 
-  <p style="padding-top:8px;margin-bottom:0;">
-  <a class="btn btn-sm btn-outline-secondary" href="?order=views"><i class="fa fa-eye"></i> by views</a>
-  <a class="btn btn-sm btn-outline-secondary" href="?order=likes"><i class="fa fa-star"></i> by likes</a>
-  </p><br />
-
-  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">By Type</button>
+  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">by type</button>
 
   <!-- when will it not be show...? -->
   <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
@@ -48,4 +43,8 @@
       </a>
     <% end %>
   </div>
+</div>
+<div style="margin-top: 10px; float: right">
+  <a class="btn btn-outline-secondary" href="?order=views"><i class="fa fa-eye"></i> by views</a>
+  <a class="btn btn-outline-secondary" style="margin-right: 5px" href="?order=likes"><i class="fa fa-star"></i> by likes</a>
 </div>

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -1,6 +1,12 @@
 <div class="dropdown" style="margin-top:10px; float:right;">
+
+  <p style="padding-top:8px;margin-bottom:0;">
+  <a class="btn btn-sm btn-outline-secondary" href="?order=views"><i class="fa fa-eye"></i> by views</a>
+  <a class="btn btn-sm btn-outline-secondary" href="?order=likes"><i class="fa fa-star"></i> by likes</a>
+  </p><br />
+
   <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">By Type</button>
-  
+
   <!-- when will it not be show...? -->
   <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
     <% if params[:action] == "show" %>
@@ -10,24 +16,24 @@
       <a class="dropdown-item <% if @node_type == "questions" %> active<% end %>" href="/questions/tag/<%= params[:id] %>"><i class="fa fa-question-circle"></i> <span class="d-none d-lg-inline"><%= t('tag.show.questions') %></span></a>
       <a class="dropdown-item <% if @node_type=="wiki" %> active <% end %>" href="/wiki/tag/<%= params[:id] %>"><i class="fa fa-book"></i> <span class="d-none d-lg-inline"><%= raw t('tag.show.wiki_pages') %></span></a>
       <a class="dropdown-item <% if @node_type == "maps" %> active <% end %>" href="/maps/tag/<%= params[:id] %>"><i class="fa fa-map-marker"></i> <span class="d-none d-lg-inline"><%= t('tag.show.maps') %></span></a>
-  
+
       <!-- show if we can see the list of contributors
       again, can we have a generic list of contributors that is
-      
+
       calculated in the controller? -->
       <% if !@wildcard %>
       <a class="dropdown-item <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>"><i class="fa fa-user"></i> <span class="d-none d-lg-inline"><%= raw t('tag.show.people') %></span><span class="badge"><%=@length %></span></a>
       <% else %>
     <a class="disabled" class="dropdown-item<% if @node_type == "contributors" %> active <% end %>" href="#" rel="tooltip" title="Contributors cannot be listed for wildcard tag searches" ><i class="fa fa-user"></i> <span class="d-none d-lg-inline"><%= raw t('tag.show.contributors') %></span></a>
       <% end %>
-  
+
     <% else %>
       <!-- calculate whatever this should be in the controller -->
       <% unless params[:id].match("question:") %>
         <a class="dropdown-item" <% if @node_type == "note" %> class="active"<% end %> href="/tag/<%= params[:id] %>/author/<%= params[:author] %>"><i class="fa fa-file"></i> <span class="d-none d-lg-inline"><%= raw t('tag.show.research_notes') %></span>
         </a>
       <% end %>
-  
+
       <a class="dropdown-item" <% if @node_type == "questions" %> class="active"<% end %> href="/questions/tag/<%= params[:id] %>/author/<%= params[:author] %>" >
         <i class="fa fa-question-circle"></i> <span class="d-none d-lg-inline"><%= t('tag.show.questions') %></span>
       </a>

--- a/test/system/tags_controller_test.rb
+++ b/test/system/tags_controller_test.rb
@@ -8,7 +8,7 @@ class TagTest < ApplicationSystemTestCase
 
     take_screenshot
 
-    click_on "By Type"
+    click_on "by type"
 
     take_screenshot
 


### PR DESCRIPTION
Fixes #6305 (<=== Add issue number here)


Here is a screenshot of the page with the changes I made:
![image](https://user-images.githubusercontent.com/37421108/66523036-8cdfc980-eab4-11e9-9aa6-ebb48632543c.png)
The 'by likes' and 'by views' buttons are on the right, and the number of contributors, posts, and followers are listed on the left.
I was unable to add tags on my local installation of the project; that's why number of posts and contributors is 0 in this screenshot. 
Also, I changed the capitalization and height of the buttons on the right side so that they match.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
