### PR TITLE
Show 'x' to unfollow vs. 'unfollow' button depending on page

### DIFF
--- a/app/views/tag/_topicCard.html.erb
+++ b/app/views/tag/_topicCard.html.erb
@@ -4,7 +4,7 @@
   <% tags.each do |tag| %>
     <div class="card shadow-sm p-2 mb-3 bg-white rounded" >
       <div class="card-header mt-2" style=" padding:0.8em; background-color: inherit; border:none;">
-        <% if current_user && current_user.following(tag.name) %>
+        <% if current_user && current_user.following(tag.name) && controller.controller_name != 'tag' %>
           <a style="margin-top:-8px;" data-method="delete" data-confirm="Are you sure you'd like to unfollow this topic?" rel="tooltip" title="<%= t('tag.show.unfollow') %>" class="pull-right" href="/unsubscribe/tag/<%= tag.name %>"><i style="color:#ccc;" class="fa fa-times"></i></a>
         <% end %>
         <h4 style="display: inline-block;"><%= tag.name %></h4>
@@ -38,6 +38,16 @@
             <% if !current_user.following(tag.name) %>
               <a style="width: 100px;" class="btn btn-outline-secondary btn-sm index-follow-buttons follow-btn-remote" href="/subscribe/tag/<%= tag.name %>" data-remote="true"><%= t('tag.index.follow') %></a>
             <% end %>
+
+            <% if current_user.following(tag.name) && controller.controller_name == 'tag' %>
+              <a style="width: 100px;"
+                 data-method="delete"
+                 data-confirm="Are you sure you'd like to unfollow this topic?"
+                 rel="tooltip" title="<%= t('tag.show.unfollow') %>"
+                 class="btn btn-outline-secondary btn-sm index-follow-buttons follow-btn-remote"
+                 href="/unsubscribe/tag/<%= tag.name %>">Unfollow</a>
+            <% end %>
+
             <a rel="tooltip" title="<%= t('sidebar._post_button.share_your_work') %>" data-placement="bottom" href="/post?tags=<%= tag.name %>" class="btn btn-primary btn-sm requireLogin">New post <i class="fa fa-plus fa-white"></i></a>
           <% else %>
             <a class="btn btn-primary btn-sm index-follow-buttons follow-btn-remote requireLogin" href="/subscribe/tag/<%= tag.name %>" data-remote="true"><%= t('tag.index.follow') %></a>


### PR DESCRIPTION
Show "x" to unfollow vs. "unfollow" button depending on page #6424 

Note: We should have it offer an unfollow button on the https://publiclab.org/tags page, but an x on the dashboard. @publiclab/reviewers can you please review.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
