### PR TITLE
Change 'Read More' blog link to button

### DIFF
--- a/app/views/tag/blog.html.erb
+++ b/app/views/tag/blog.html.erb
@@ -60,7 +60,7 @@
             <% end %>
           </small></p>
           <p><%= raw auto_link(insert_extras(node.latest.render_body), :sanitize => false) %></p>
-          <p><a href="<%= node.path %>"><%=raw translation('tag.blog.read_more') %> &raquo;</a><%= render partial: 'tag/subscribe_button', locals:{tags: node.tags} %></p>
+          <p><a class="btn btn-outline-secondary btn-md" href="<%= node.path %>" style="color: black"><%=raw translation('tag.blog.read_more')%> <i class="fa fa-angle-double-right"></i></a><%= render partial: 'tag/subscribe_button', locals:{tags: node.tags} %></p>
           <p>
             <%= render :partial => "like/like", :locals => {:node => node, :tagnames => node.tags.collect(&:name) } %>
             <% node.tags[0..3].each do |tag| %>


### PR DESCRIPTION
Fixes #4940

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ X ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ X ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ X ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ X ] screenshots/GIFs are attached 📎 in case of UI updation
* [ X ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!

Hi @publiclab/reviewers! First time contribution, screen shot posted below. I thought about setting this button up in a separate file similar to `_subscribe_button.html.erb` to keep the blog file cleaner, but decided to make the changes inline as this requires much less code than the other button. Let me know if any edits can be made!

<img width="523" alt="Screen Shot 2019-10-25 at 9 40 41 AM" src="https://user-images.githubusercontent.com/25539203/67580243-a23b3180-f70b-11e9-8f46-7865226f5cbf.png">
