### PR TITLE
Change_function t to translation in comments/_form

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -40,12 +40,12 @@
 
           <p>
             <span id="create_uploading" class="uploading" style="display:none;">
-              <%= t('comments._form.uploading') %>
+              <%= translation('comments._form.uploading') %>
             </span>
             <span id="create_prompt" class="prompt">
 
               <span style="padding-right:4px;float:left;" class="d-none d-md-inline">
-                <%= raw t('comments._form.drag_and_drop') %>
+                <%= raw translation('comments._form.drag_and_drop') %>
               </span>
 
               <!-- http://stackoverflow.com/questions/11235206/twitter-bootstrap-form-file-element-upload-button -->
@@ -54,7 +54,7 @@
                 <a onClick="handleClick()" class="d-none d-md-inline">choose one</a>
                 <span class="d-md-none">
                   <i class="fa fa-upload"></i>
-                  <a><%= t('comments._form.upload_image') %></a>
+                  <a><%= translation('comments._form.upload_image') %></a>
                 </span>
               </label>
             </span>
@@ -91,28 +91,28 @@
           <%= javascript_include_tag "comment.js" %>
 
           <div class="control-group">
-            <button type="submit" class="btn btn-primary"><%= t('comments._form.publish') %></button>
+            <button type="submit" class="btn btn-primary"><%= translation('comments._form.publish') %></button>
             <% if local_assigns[:comment] %>
               <a class="btn btn-outline-secondary preview-btn" onClick="$('#c<%= comment.cid %>preview').toggle();
                   $('#c<%= comment.cid %>text-input').toggle();
                   $('#c<%= comment.cid %>edit .preview-btn').button('toggle');
                   $E.generate_preview('c<%= comment.cid %>preview',$('#c<%= comment.cid %>text-input').val())">
-                <%= t('comments._form.preview') %>
+                <%= translation('comments._form.preview') %>
               </a>
-              <a class="btn btn-outline-secondary" onClick="$('#c<%= comment.cid %>show').toggle();$('#c<%= comment.cid %>edit').toggle()"><%= t('comments._form.cancel') %></a>
+              <a class="btn btn-outline-secondary" onClick="$('#c<%= comment.cid %>show').toggle();$('#c<%= comment.cid %>edit').toggle()"><%= translation('comments._form.cancel') %></a>
             <% else %>
-              <a class="btn btn-outline-secondary preview-btn>" id="post_comment" data-previewing-text="Hide Preview" onClick="handleClick();$E.toggle_preview()"><%= t('comments._form.preview') %></a>
+              <a class="btn btn-outline-secondary preview-btn>" id="post_comment" data-previewing-text="Hide Preview" onClick="handleClick();$E.toggle_preview()"><%= translation('comments._form.preview') %></a>
             <% end %>
 
             <span style="color:#888;"> &nbsp;
-              <br class="d-md-none" /><%= raw t('comments._form.logged_in', :username => current_user.username) %> &nbsp;
+              <br class="d-md-none" /><%= raw translation('comments._form.logged_in', :username => current_user.username) %> &nbsp;
               <a target="_blank" href="/wiki/authoring-help#Formatting"><i class="fa fa-question-circle"></i></a> &nbsp;
               <a onClick="$('#who-is-notified-form').toggle()"><i class="fa fa-bell-o"></i></a> 
             </span>
           </div>
 
           <p id="who-is-notified-form" style="display:none;color:#888;">
-            <%= t('comments._form.email_notifications') %>
+            <%= translation('comments._form.email_notifications') %>
           </p>
 
     </form>


### PR DESCRIPTION
Fixes #6596  (<=== Add issue number here)
Change_function t to translation in comments/_form
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [N/A ] screenshots/GIFs are attached 📎 in case of UI updation
* [N/A] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
