### PR TITLE
Changed to fetch_comments function to fix comment count on blog posts

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -42,7 +42,7 @@
         | <%= number_with_delimiter(@node.views) %> <%= t('notes.show.views') %>
         <% if @node.comments %>
           | <i class="fa fa-comment"></i>
-          <a href="#comments"> <%= @node.comments.length %> <%= t('notes.show.comments') %> </a>
+          <a href="#comments"> <%= @node.fetch_comments(current_user).length %> <%= t('notes.show.comments') %> </a>
         <% end %>
           | <a href="/n/<%= @node.id %>"><i class="fa fa-link"></i></a> <span class="d-none d-xl-inline"><a href="/n/<%= @node.id %>">#<%= @node.id %></a></span>
       </span>
@@ -50,7 +50,7 @@
         | <%= number_with_delimiter(@node.views) %> <%= t('notes.show.views') %>
         <% if @node.comments %>
           | <i class="fa fa-comment"></i>
-          <a href="#comments"> <%= @node.comments.length %> <%= t('notes.show.comments') %> </a>
+          <a href="#comments"> <%= @node.fetch_comments(current_user).length %> <%= t('notes.show.comments') %> </a>
         <% end %>
           | <a href="/n/<%= @node.id %>"><i class="fa fa-link"></i></a> <span class="d-none d-xl-inline"><a href="/n/<%= @node.id %>">#<%= @node.id %></a></span>
       </span>

--- a/app/views/tag/blog.html.erb
+++ b/app/views/tag/blog.html.erb
@@ -52,7 +52,7 @@
           <p class="meta" style="color:#888;"><small>
             <%=raw translation('tag.blog.by') %> <a href="/profile/<%= node.author.name %>"><%= node.author.name %></a>  <%= node.author.new_contributor %>
 	    | <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %>
-            | <a href="<%= node.path %>#comments"><i style="color:#888;" class="fa fa-comment-o"></i> <%= node.comments.size %></a>
+            | <a href="<%= node.path %>#comments"><i style="color:#888;" class="fa fa-comment-o"></i> <%= node.fetch_comments(current_user).length %></a>
             <% if params[:controller] == "notes" && params[:action] == "popular" %>
             | <%= number_with_delimiter(node.views) %> <%=raw translation('tag.blog.views') %>
             <% else %>


### PR DESCRIPTION
Fixes #6702  (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!



This is what it looked like before where there was a comment in moderation, notice the comment count at the top of the page and the count in the comment header don't match.

![FireShot Capture 056 - 🎈 Public Lab_ Blog Post - localhost](https://user-images.githubusercontent.com/49460529/68413092-826c2a80-015b-11ea-80a2-fe236dd8ba5b.png)

This is what it looks like after, both match. But why is the comment posted by "spammer", which needs moderation, showing up when I am logged in as "user"? Shouldn't that be hidden?

![FireShot Capture 058 - 🎈 Public Lab_ Blog - localhost](https://user-images.githubusercontent.com/49460529/68413178-b6dfe680-015b-11ea-8b9a-796ef5fb0dd5.png)

![FireShot Capture 057 - 🎈 Public Lab_ Blog Post - localhost](https://user-images.githubusercontent.com/49460529/68413171-afb8d880-015b-11ea-96c3-d62f40e86893.png)