### PR TITLE
Fix tagging user profiles and add JS ajax function

### DIFF
--- a/app/assets/javascripts/tagging.js
+++ b/app/assets/javascripts/tagging.js
@@ -47,7 +47,7 @@ function initTagForm(deletion_path, selector) {
       var tag_id = tag[1];
       $('.tags-list:first').append("<p id='tag_"+tag_id+"' class='badge badge-primary'> \
         <a class='tag-name' style='color:white;' href='/tag/"+tag_name+"'>"+tag_name+"</a> <a class='tag-delete' \
-        data-remote='true' href='"+deletion_path+"/"+tag_id+"' style='color:white' data-tag-id='"+tag_id+"' \
+        data-remote='true' href='"+deletion_path+"/"+tag_id+"' data-tag-id='"+tag_id+"' \
         data-method='delete'><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a></p> ")
       el.find('.tag-input').val("")
       el.find('.control-group').removeClass('has-error')

--- a/app/assets/stylesheets/tags.css
+++ b/app/assets/stylesheets/tags.css
@@ -7,3 +7,16 @@
 .popover-content {
   padding: 9px 14px;
 }
+
+.tags-list .badge a {
+  color: white;
+}
+
+.tags-list .badge i {
+  margin-left: 0;
+}
+
+.tags-list i:hover{
+  transition-duration: .2s;
+  transform: scale(1.2);
+}

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -52,7 +52,7 @@ $(function () {
   <span style="float:left;color:#666;margin-top:14px;margin-left:5px;">Add tags</a> 
 <% end %>
 
-<%= render partial: 'tag/form', locals: { node: @node ||= nil, user: user ||= nil } %>
+<%= render partial: 'tag/form', locals: { node: @node ||= nil, user: user ||= nil, url: url ||= nil } %>
 
 <% end %>
 

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -14,13 +14,13 @@
         <a class="show-more-tags" href="javascript:void(0);"><p style="float:left; color:#666; margin-top:14px; margin-left:5px;"><u><%= tags.length - 2 %> more</u> &nbsp </p></a>
       <% end %>
 
-      <p class="badge <%= badge_name %> pop more-tags" style="display:none;cursor:pointer;margin-bottom:3px;" id="tag_<%= tag.tid %>" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p><div style='text-align:center;' class='text-center'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
-       <%= tag.name %>
+      <p class="badge <%= badge_name %> pop more-tags" style="display:none;cursor:pointer;margin-bottom:3px;" id="tag_<%= tag.tid %>" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p><div class='text-center'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
+        <a class='tag-name' href='/tag/<%= tag.name %>'><%= tag.name %></a>
         <% if logged_in_as(['admin', 'moderator']) || (current_user && ( current_user.uid ==  @node.uid || current_user.uid == tag.uid)) %>
           <% if tag.name.include? ':' %>
-            <a data-confirm="This is a power tag (see https://publiclab.org/wiki/power-tags) -- and may drive a specific function on this page. Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete" style="color:white;">x</a>
+            <a data-confirm="This is a power tag (see https://publiclab.org/wiki/power-tags) -- and may drive a specific function on this page. Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
           <% else %>
-            <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete" style="color:white">x</a>
+            <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
           <% end %>
         <% end %>
       </p>
@@ -38,16 +38,20 @@
 
   <% elsif tag.class == UserTag && (tag.name[0..4] != "oauth" || (logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid))) %>
 
-    <li style="width: 100%;"><span id="tag_<%= tag.id %>" class="badge <%= badge_name %> pop" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
-      <% if tag.name[0..4] != "oauth" %>
-        <%= tag.name %>
-      <% else %>
-        <%= tag.name[0..5] + tag.name.split(':')[1] %>
-      <% end %>
+    <li style="width: 100%;">
+    <span id="tag_<%= tag.id %>" class="badge <%= badge_name %> pop" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
+      <a class='tag-name' href='/tag/<%= tag.name %>'>
+        <% if tag.name[0..4] != "oauth" %>
+          <%= tag.name %>
+        <% else %>
+          <%= tag.name[0..5] + tag.name.split(':')[1] %>
+        <% end %>
+      </a>
       <% if logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid) %>
-        <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete">x</a>
+        <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
       <% end %>
-    </span></li>
+    </span>
+    </li>
 
   <% end %>
 <% end %>

--- a/test/system/tag_test.rb
+++ b/test/system/tag_test.rb
@@ -45,4 +45,29 @@ class TagTest < ApplicationSystemTestCase
 
   end
 
+  test 'adding a tag to a user profile' do
+    visit '/'
+
+    click_on 'Login'
+
+    fill_in("username-login", with: "jeff")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
+
+    visit "/profile/jeff"
+
+    # run the javascript function
+    page.evaluate_script("addTag('specialgroup', '/profile/tags/create/2')")
+
+    visit "/profile/jeff" # refresh page
+
+    find('#tags-section').click
+
+    # check that the tag showed up on the page - check last tag in list
+    within('.tags-list') do
+      assert_equal('specialgroup', all('span').last.text.chomp(' x'))
+    end
+
+  end
+
 end

--- a/test/system/tag_test.rb
+++ b/test/system/tag_test.rb
@@ -5,45 +5,45 @@ require "application_system_test_case"
 class TagTest < ApplicationSystemTestCase
   Capybara.default_max_wait_time = 60
 
-  # test 'adding a tag via javascript' do
-  #   visit '/'
+  test 'adding a tag via javascript' do
+    visit '/'
 
-  #   click_on 'Login'
+    click_on 'Login'
 
-  #   fill_in("username-login", with: "jeff")
-  #   fill_in("password-signup", with: "secretive")
-  #   click_on "Log in"
+    fill_in("username-login", with: "jeff")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
 
-  #   visit "/wiki/wiki-page-path"
+    visit "/wiki/wiki-page-path"
 
-  #   # run the javascript function
-  #   page.evaluate_script("addTag('bluebell')")
+    # run the javascript function
+    page.evaluate_script("addTag('bluebell')")
 
-  #   # check that the tag showed up on the page
-  #   assert_selector('.tags-list .tag-name', text: 'bluebell')
+    # check that the tag showed up on the page
+    assert_selector('.tags-list .tag-name', text: 'bluebell')
 
-  # end
+  end
 
-  # test 'adding a tag via javascript with url only' do
-  #   visit '/'
+  test 'adding a tag via javascript with url only' do
+    visit '/'
 
-  #   click_on 'Login'
+    click_on 'Login'
 
-  #   fill_in("username-login", with: "jeff")
-  #   fill_in("password-signup", with: "secretive")
-  #   click_on "Log in"
+    fill_in("username-login", with: "jeff")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
 
-  #   visit "/wiki/wiki-page-path"
+    visit "/wiki/wiki-page-path"
 
-  #   # run the javascript function
-  #   page.evaluate_script("addTag('roses', '/tag/create/11')")
+    # run the javascript function
+    page.evaluate_script("addTag('roses', '/tag/create/11')")
 
-  #   visit "/wiki/wiki-page-path" # refresh page
+    visit "/wiki/wiki-page-path" # refresh page
 
-  #   # check that the tag showed up on the page
-  #   assert_selector('.tags-list .card-body h5', text: 'roses')
+    # check that the tag showed up on the page
+    assert_selector('.tags-list .card-body h5', text: 'roses')
 
-  # end
+  end
 
   test 'adding a tag to a user profile' do
     visit '/'

--- a/test/system/tag_test.rb
+++ b/test/system/tag_test.rb
@@ -5,45 +5,45 @@ require "application_system_test_case"
 class TagTest < ApplicationSystemTestCase
   Capybara.default_max_wait_time = 60
 
-  test 'adding a tag via javascript' do
-    visit '/'
+  # test 'adding a tag via javascript' do
+  #   visit '/'
 
-    click_on 'Login'
+  #   click_on 'Login'
 
-    fill_in("username-login", with: "jeff")
-    fill_in("password-signup", with: "secretive")
-    click_on "Log in"
+  #   fill_in("username-login", with: "jeff")
+  #   fill_in("password-signup", with: "secretive")
+  #   click_on "Log in"
 
-    visit "/wiki/wiki-page-path"
+  #   visit "/wiki/wiki-page-path"
 
-    # run the javascript function
-    page.evaluate_script("addTag('bluebell')")
+  #   # run the javascript function
+  #   page.evaluate_script("addTag('bluebell')")
 
-    # check that the tag showed up on the page
-    assert_selector('.tags-list .tag-name', text: 'bluebell')
+  #   # check that the tag showed up on the page
+  #   assert_selector('.tags-list .tag-name', text: 'bluebell')
 
-  end
+  # end
 
-  test 'adding a tag via javascript with url only' do
-    visit '/'
+  # test 'adding a tag via javascript with url only' do
+  #   visit '/'
 
-    click_on 'Login'
+  #   click_on 'Login'
 
-    fill_in("username-login", with: "jeff")
-    fill_in("password-signup", with: "secretive")
-    click_on "Log in"
+  #   fill_in("username-login", with: "jeff")
+  #   fill_in("password-signup", with: "secretive")
+  #   click_on "Log in"
 
-    visit "/wiki/wiki-page-path"
+  #   visit "/wiki/wiki-page-path"
 
-    # run the javascript function
-    page.evaluate_script("addTag('roses', '/tag/create/11')")
+  #   # run the javascript function
+  #   page.evaluate_script("addTag('roses', '/tag/create/11')")
 
-    visit "/wiki/wiki-page-path" # refresh page
+  #   visit "/wiki/wiki-page-path" # refresh page
 
-    # check that the tag showed up on the page
-    assert_selector('.tags-list .card-body h5', text: 'roses')
+  #   # check that the tag showed up on the page
+  #   assert_selector('.tags-list .card-body h5', text: 'roses')
 
-  end
+  # end
 
   test 'adding a tag to a user profile' do
     visit '/'
@@ -65,7 +65,7 @@ class TagTest < ApplicationSystemTestCase
 
     # check that the tag showed up on the page - check last tag in list
     within('.tags-list') do
-      assert_equal('specialgroup', all('span').last.text.chomp(' x'))
+      assert_equal('specialgroup', all('.tag-name').last.text.rstrip.lstrip)
     end
 
   end


### PR DESCRIPTION
Fixes #6724  (<=== Add issue number here)
@jywarren This references what we talked about in #6422 - do I need to create an issue for this?

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

+++

In this PR:
- fixed the form to add tags to a user profile, which wasn't working
- added a test to ensure that adding tags via the existing javascript methods work
- added styling to all badge tags based on what was already done for some node tags - added a FA icon instead of an x
- also added a link to the tag badge so when it is clicked on it will go to the tag page

The badges for the node tags:
![FireShot Capture 081 - 🎈 Public Lab_ Where can I find information on caves_ - localhost](https://user-images.githubusercontent.com/49460529/69977385-b20f1800-14f8-11ea-9e06-a241396c4f71.png)


Badges for the user profile tags:
![FireShot Capture 082 - 🎈 Public Lab_ admin - localhost](https://user-images.githubusercontent.com/49460529/69977395-b6d3cc00-14f8-11ea-86a9-097d62e619a5.png)
