### PR TITLE
Custom error page when tagname has no posts

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -534,13 +534,18 @@ class TagController < ApplicationController
     @start = params[:start] ? Time.parse(params[:start].to_s) : Time.now - 1.year
     @end = params[:end] ? Time.parse(params[:end].to_s) : Time.now
     tagname = params[:id]
-
+    
+    @tag_name = params[:id]
     @tags = Tag.where(name: params[:id])
-    @tag_notes = @tags.first.contribution_graph_making('note', @start, @end)
-    @tag_wikis = @tags.first.contribution_graph_making('page', @start, @end)
-    @tag_questions = @tags.first.quiz_graph(@start, @end)
-    @tag_comments = @tags.first.comment_graph(@start, @end)
-    @subscriptions = @tags.first.subscription_graph(@start, @end)
+
+    if @tags.size != 0 
+      @tag_notes = @tags.first.contribution_graph_making('note', @start, @end)
+      @tag_wikis = @tags.first.contribution_graph_making('page', @start, @end)
+      @tag_questions = @tags.first.quiz_graph(@start, @end)
+      @tag_comments = @tags.first.comment_graph(@start, @end)
+      @subscriptions = @tags.first.subscription_graph(@start, @end)
+    end
+
     @all_subscriptions = TagSelection.graph(@start, @end)
 
     total_questions = Node.published.questions

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -538,7 +538,7 @@ class TagController < ApplicationController
     @tag_name = params[:id]
     @tags = Tag.where(name: params[:id])
 
-    if @tags.size != 0 
+    if !@tags.empty? 
       @tag_notes = @tags.first.contribution_graph_making('note', @start, @end)
       @tag_wikis = @tags.first.contribution_graph_making('page', @start, @end)
       @tag_questions = @tags.first.quiz_graph(@start, @end)

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -538,13 +538,13 @@ class TagController < ApplicationController
     @tag_name = params[:id]
     @tags = Tag.where(name: params[:id])
 
-    unless @tags.empty? 
-      @tag_notes = @tags.first.contribution_graph_making('note', @start, @end)
-      @tag_wikis = @tags.first.contribution_graph_making('page', @start, @end)
-      @tag_questions = @tags.first.quiz_graph(@start, @end)
-      @tag_comments = @tags.first.comment_graph(@start, @end)
-      @subscriptions = @tags.first.subscription_graph(@start, @end)
-    end
+    return if @tags.empty?
+
+    @tag_notes = @tags.first.contribution_graph_making('note', @start, @end)
+    @tag_wikis = @tags.first.contribution_graph_making('page', @start, @end)
+    @tag_questions = @tags.first.quiz_graph(@start, @end)
+    @tag_comments = @tags.first.comment_graph(@start, @end)
+    @subscriptions = @tags.first.subscription_graph(@start, @end)
 
     @all_subscriptions = TagSelection.graph(@start, @end)
 

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -538,7 +538,7 @@ class TagController < ApplicationController
     @tag_name = params[:id]
     @tags = Tag.where(name: params[:id])
 
-    if !@tags.empty? 
+    unless @tags.empty? 
       @tag_notes = @tags.first.contribution_graph_making('note', @start, @end)
       @tag_wikis = @tags.first.contribution_graph_making('page', @start, @end)
       @tag_questions = @tags.first.quiz_graph(@start, @end)

--- a/app/views/tag/stats.html.erb
+++ b/app/views/tag/stats.html.erb
@@ -43,6 +43,6 @@
     <%= render partial: "tag/graph", locals: { wikis: @tag_wikis, notes: @tag_notes, questions: @tag_questions, comments: @tag_comments  } %>
     <br>
     <p><i>This graph shows the number of followers who began subscribing within a given time period; this is not a cumulative graph of subscriptions. Note also: if someone 'unfollows,' the record is deleted, and we can't see it anymore, so we cannot currently measure a decline in followers over time.</i></p>
+<% end %>
 </div>
 
-<% end %>

--- a/app/views/tag/stats.html.erb
+++ b/app/views/tag/stats.html.erb
@@ -1,7 +1,8 @@
 <br>
 <div class="col-lg-8">
     <% if @tags.size == 0 %>
-      <h4><%= @tag_name %> not found</h4>
+      <h4>Uh oh, your search for <%= @tag_name %> returned no results</h4>
+      <h6> <%= link_to "See statistics for all contents", stats_path %> </h6>
     <% else %>
     <h4>Tag statistics for <%= @tag_name %> </h4>
     <hr>

--- a/app/views/tag/stats.html.erb
+++ b/app/views/tag/stats.html.erb
@@ -1,6 +1,9 @@
 <br>
 <div class="col-lg-8">
-    <h4>Tag statistics for <%= @tags.first.name %> </h4>
+    <% if @tags.size == 0 %>
+      <h4><%= @tag_name %> not found</h4>
+    <% else %>
+    <h4>Tag statistics for <%= @tag_name %> </h4>
     <hr>
     <h6> <%= link_to "See statistics for all contents", stats_path %> </h6>
     <%= form_tag request.url, method: :get do %>
@@ -32,7 +35,6 @@
 
 <%= render 'stats/barchart' %>
 
-
 <br><br><br>
 <div class="graph">
     <p> <b><%= params[:id].capitalize%></b> graph from <b><%= (@start).to_formatted_s(:long)%></b> to <b><%= @end.to_formatted_s(:long)%></b> </p>
@@ -41,3 +43,5 @@
     <br>
     <p><i>This graph shows the number of followers who began subscribing within a given time period; this is not a cumulative graph of subscriptions. Note also: if someone 'unfollows,' the record is deleted, and we can't see it anymore, so we cannot currently measure a decline in followers over time.</i></p>
 </div>
+
+<% end %>

--- a/app/views/tag/stats.html.erb
+++ b/app/views/tag/stats.html.erb
@@ -1,6 +1,6 @@
 <br>
 <div class="col-lg-8">
-    <% if @tags.size == 0 %>
+    <% if @tags.empty? %>
       <h4>Uh oh, your search for <%= @tag_name %> returned no results</h4>
       <h6> <%= link_to "See statistics for all contents", stats_path %> </h6>
     <% else %>


### PR DESCRIPTION
Resolves https://github.com/publiclab/plots2/issues/6854

I've added a custom error page when the tag cannot be found. 
![image](https://user-images.githubusercontent.com/20526314/70027335-c3870d00-1556-11ea-9111-fa3ce1c302c8.png)

The error was caused by `@tags` being empty, resulting in `@tags.first` being nil. I added an additional if statement for `@tags.size.empty?` in both the ruby code and html, skipping the corresponding calculations and rendering if `@tags` was empty. 

I also refactored `@tags.first.name` into `@tag_name`. 

@nstjean if you could take a look, that'd be great!
