### PR TITLE
Fix add your location on /people/ page

### DIFF
--- a/app/assets/javascripts/tagging.js
+++ b/app/assets/javascripts/tagging.js
@@ -2,7 +2,6 @@
 // Taking the prompt+value retrieved in promptTag() or the links in the drop-down menu and populating the form field before submitting it
 // Instead we want to take the tag value and directly submit it with AJAX
 function addTag(tagname, submitTo) {
-  alert(tagname + ' ' + submitTo);
   submitTo = submitTo || '#tagform';
   if (tagname.slice(0,5).toLowerCase() === "place") {
     place = tagname.split(":")[1];

--- a/app/assets/javascripts/tagging.js
+++ b/app/assets/javascripts/tagging.js
@@ -2,6 +2,7 @@
 // Taking the prompt+value retrieved in promptTag() or the links in the drop-down menu and populating the form field before submitting it
 // Instead we want to take the tag value and directly submit it with AJAX
 function addTag(tagname, submitTo) {
+  alert(tagname + ' ' + submitTo);
   submitTo = submitTo || '#tagform';
   if (tagname.slice(0,5).toLowerCase() === "place") {
     place = tagname.split(":")[1];

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -118,7 +118,12 @@
     var tags = 'lat:' + blurredLocation.getLat() + ',lon:' + blurredLocation.getLon();
     if (blurredLocation.isBlurred()) tags = tags + ',' + 'location:blurred'
     if ($('#placenameDisplay').val() != 'Location unavailable') tags = tags + ',' + 'place:' + parameterize($('#placenameDisplay').val());
-    addTag(tags);
+    <% if params[:url] %>
+      addTag(tags, '<%= params[:url] %>');
+    <% else %>
+      alert('no url');
+      addTag(tags);
+    <% end %>
     
     <% if params[:reload] %>setTimeout(function() { location.reload(); }, 3000);<% end %>
   }

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -121,7 +121,6 @@
     <% if params[:url] %>
       addTag(tags, '<%= params[:url] %>');
     <% else %>
-      alert('no url');
       addTag(tags);
     <% end %>
     

--- a/app/views/tag/_location.html.erb
+++ b/app/views/tag/_location.html.erb
@@ -5,11 +5,19 @@
   jQuery(document).ready(function() {
     $('.blurred-location-input').click(function createBlurredLocationInput() {
       $(this).attr("disabled", "disabled");
-      <% if params[:action] == "profile" %>
-        $.ajax('/locations/modal?reload=true')
-      <% else %>
-        $.ajax('/locations/modal')
-      <% end %>
+      let modalUrl = '/locations/modal';
+      let firstVar = true;
+      // <% if (params[:action] == "list") || (params[:action] == "profile") %>
+      //   modalUrl += firstVar ? '?' : '&';
+      //   modalUrl += 'reload=true';
+      //   firstVar = false;
+      // <% end %>
+      if( $(this).attr("submit_to") ) {
+        modalUrl += firstVar ? '?' : '&';
+        modalUrl += 'url=' + encodeURIComponent($(this).attr("submit_to"));
+        firstVar = false;
+      }
+      $.ajax(modalUrl)
        .done(function(response) {
          $('.blurred-location-container').html(response);
          $('#blurred-location-modal').on('shown.bs.modal', function () { blurredLocation.map.invalidateSize(); });

--- a/app/views/tag/_location.html.erb
+++ b/app/views/tag/_location.html.erb
@@ -7,11 +7,11 @@
       $(this).attr("disabled", "disabled");
       let modalUrl = '/locations/modal';
       let firstVar = true;
-      // <% if (params[:action] == "list") || (params[:action] == "profile") %>
-      //   modalUrl += firstVar ? '?' : '&';
-      //   modalUrl += 'reload=true';
-      //   firstVar = false;
-      // <% end %>
+      <% if (params[:action] == "list") || (params[:action] == "profile") %>
+        modalUrl += firstVar ? '?' : '&';
+        modalUrl += 'reload=true';
+        firstVar = false;
+      <% end %>
       if( $(this).attr("submit_to") ) {
         modalUrl += firstVar ? '?' : '&';
         modalUrl += 'url=' + encodeURIComponent($(this).attr("submit_to"));

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -8,7 +8,7 @@
       <h2><%= raw t('People') %></h2>
       <h5><%= t('Recently active on Publiclab') =%></h5>
     </div>
-    <% if @map_lat.blank? || @map_lon.blank? %>
+    <% if current_user && (@map_lat.blank? || @map_lon.blank?) %>
       <div class="col-md-4">
         <a class="btn btn-outline-secondary blurred-location-input" style="color:#666;" onmouseover="this.style.background='white';" submit_to="/profile/tags/create/<%= current_user.uid %>"><i class="fa fa-map-marker"></i> Add your location</a>
       </div>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -8,9 +8,11 @@
       <h2><%= raw t('People') %></h2>
       <h5><%= t('Recently active on Publiclab') =%></h5>
     </div>
-    <div class ="col-md-4">
-      <a class="btn btn-outline-secondary blurred-location-input" style="color:#666;" onmouseover="this.style.background='white';"><i class="fa fa-map-marker"></i> Add your location</a>
-    </div>
+    <% if @map_lat.blank? || @map_lon.blank? %>
+      <div class="col-md-4">
+        <a class="btn btn-outline-secondary blurred-location-input" style="color:#666;" onmouseover="this.style.background='white';" submit_to="/profile/tags/create/<%= current_user.uid %>"><i class="fa fa-map-marker"></i> Add your location</a>
+      </div>
+    <% end %>
   </div>
     <div>
     <br>


### PR DESCRIPTION
Fixes #5882  (<=== Add issue number here)

This button wasn't working because there was no form and no URL to submit to.

This PR adds a URL as an attribute to the `Add your location` link, and checks for that attribute in the javascript code.

It also doesn't show the button link if the user already has a location entered.


* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below
