### PR TITLE
Fixed /stats page margin

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,4 +1,4 @@
-<div class="col-lg-10" style="margin-bottom:20px; margin-left:100px;">
+<div class="col-lg-10" style="margin: 20px auto; ">
 
     <h2><%= raw t('notes.stats.contributors_statistics') %></h2>
     <hr>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,4 +1,4 @@
-<div class="col-lg-12 offset-lg-1" style="margin-bottom:20px; margin-left:100px;">
+<div class="col-lg-10" style="margin-bottom:20px; margin-left:100px;">
 
     <h2><%= raw t('notes.stats.contributors_statistics') %></h2>
     <hr>


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/6853

By decreasing the column width to `col-lg-10`, the stats panel now fits entirely on the screen. 

![image](https://user-images.githubusercontent.com/20526314/70113965-90ed1b00-160f-11ea-8f78-bba36a551803.png)

In addition, I removed the redundant `offset-lg-1` class, because the `margin-left` property was already being set with the inline style. 

Could you please take a look @gauravano @SidharthBansal @IshaGupta18 @cesswairimu @jywarren @ananyaarun @pydevsg @sashadev-sky? Thanks!