### PR TITLE
Fixed notes_controller so that notes are sorted by likes

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -298,6 +298,7 @@ class NotesController < ApplicationController
       .where(type: 'page', status: 1)
       .order('nid DESC')
     @notes = Node.where(type: 'note', status: 1, created: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
+                 .order('created DESC')
     @unpaginated = true
     render template: 'notes/index'
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -287,7 +287,7 @@ class NotesController < ApplicationController
     @notes = Node.research_notes
       .where(status: 1)
       .limit(20)
-      .order('nid DESC')
+      .order('cached_likes DESC')
     @unpaginated = true
     render template: 'notes/index'
   end


### PR DESCRIPTION
The notes were being ordered through their 'nid' which I assume means node id instead of their 'cached_likes' count. I think this is the solution to problem and it worked on my local machine.

I looked at schema for the nodes and believe this is what they need to be ordered by.

Fixes #6850
@ananya and @divyabaid16 do you think this is it?
Thanks! 👍 

Update: I also just added sorting to the /notes/recent endpoint so instead of getting all notes in the last week in random order the notes from last week will be sorted from most recent to least recent.