### PR TITLE
Fix form validation message

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
       @action = "create"
       email_errs = @user.errors.messages[:email]
       username_errs = @user.errors.messages[:username]
-      
+
       if email_errs.size > 1
         email_errs.delete("is invalid")
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,15 +49,15 @@ class UsersController < ApplicationController
       end
       # send all errors to the page so the user can try again
       @action = "create"
-      email_errs = @user.errors.messages[:email]
-      username_errs = @user.errors.messages[:username]
+      email_errors = @user.errors.messages[:email]
+      username_errors = @user.errors.messages[:username]
 
-      if email_errs.size > 1
-        email_errs.delete("is invalid")
+      if email_errors.size > 1
+        email_errors.delete("is invalid")
       end
 
-      if username_errs.size > 1
-        username_errs.delete("is invalid")
+      if username_errors.size > 1
+        username_errors.delete("is invalid")
       end
 
       render action: 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,7 +49,6 @@ class UsersController < ApplicationController
       end
       # send all errors to the page so the user can try again
       @action = "create"
-puts "LSL"
       email_errs = @user.errors.messages[:email]
       username_errs = @user.errors.messages[:username]
       

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,16 +49,6 @@ class UsersController < ApplicationController
       end
       # send all errors to the page so the user can try again
       @action = "create"
-      email_errors = @user.errors.messages[:email]
-      username_errors = @user.errors.messages[:username]
-
-      if email_errors.size > 1
-        email_errors.delete("is invalid")
-      end
-
-      if username_errors.size > 1
-        username_errors.delete("is invalid")
-      end
 
       render action: 'new'
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,9 @@ class UsersController < ApplicationController
     using_recaptcha = !params[:spamaway] && Rails.env == "production"
     recaptcha = verify_recaptcha(model: @user) if using_recaptcha
     @spamaway = Spamaway.new(spamaway_params) unless using_recaptcha
-    if ((@spamaway&.valid?) || recaptcha) && @user.save
+
+    saved = @user.save
+    if ((@spamaway&.valid?) || recaptcha) && saved
       if current_user.crypted_password.nil? # the user has not created a pwd in the new site
         flash[:warning] = I18n.t('users_controller.account_migrated_create_new_password')
         redirect_to "/profile/edit"
@@ -47,6 +49,19 @@ class UsersController < ApplicationController
       end
       # send all errors to the page so the user can try again
       @action = "create"
+puts "LSL"
+      email_errs = @user.errors.messages[:email]
+      username_errs = @user.errors.messages[:username]
+      
+      if email_errs.size > 1
+        email_errs.clear
+        email_errs.push("is invalid")
+      end
+
+      if username_errs.size > 1
+        username_errs.delete("is invalid")
+      end
+
       render action: 'new'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
     @spamaway = Spamaway.new(spamaway_params) unless using_recaptcha
 
     saved = @user.save
-    if ((@spamaway&.valid?) || recaptcha) && saved
+    if saved && ((@spamaway&.valid?) || recaptcha)
       if current_user.crypted_password.nil? # the user has not created a pwd in the new site
         flash[:warning] = I18n.t('users_controller.account_migrated_create_new_password')
         redirect_to "/profile/edit"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,8 +53,7 @@ class UsersController < ApplicationController
       username_errs = @user.errors.messages[:username]
       
       if email_errs.size > 1
-        email_errs.clear
-        email_errs.push("is invalid")
+        email_errs.delete("is invalid")
       end
 
       if username_errs.size > 1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
     @spamaway = Spamaway.new(spamaway_params) unless using_recaptcha
 
     saved = @user.save
-    if saved && ((@spamaway&.valid?) || recaptcha)
+    if ((@spamaway&.valid?) || recaptcha) && saved
       if current_user.crypted_password.nil? # the user has not created a pwd in the new site
         flash[:warning] = I18n.t('users_controller.account_migrated_create_new_password')
         redirect_to "/profile/edit"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class UniqueUsernameValidator < ActiveModel::Validator
       record.errors[:username].clear
       record.errors[:username] << 'cannot be blank'
     end
-    
+
     if record.email.blank?
       record.errors[:email].clear
       record.errors[:email] << 'cannot be blank'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,10 @@ class UniqueUsernameValidator < ActiveModel::Validator
   end
 end
 
+# Fixes authlogic's broken regex. 
+# See https://github.com/publiclab/plots2/pull/6932#issuecomment-563878155
+Authlogic::Regex::LOGIN = /\A[A-Za-z\d_\-]*\z/
+
 class User < ActiveRecord::Base
   extend Utils
   include Statistics

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,11 @@ class UniqueUsernameValidator < ActiveModel::Validator
       record.errors[:username].clear
       record.errors[:username] << 'cannot be blank'
     end
+    
+    if record.email.blank?
+      record.errors[:email].clear
+      record.errors[:email] << 'cannot be blank'
+    end
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,11 @@ class UniqueUsernameValidator < ActiveModel::Validator
     if User.find_by(username: record.username) && record.openid_identifier.nil?
       record.errors[:base] << 'That username is already taken. If this is your username, you can simply log in to this site.'
     end
+
+    if record.username.blank?
+      record.errors[:username].clear
+      record.errors[:username] << 'cannot be blank'
+    end
   end
 end
 
@@ -59,7 +64,7 @@ class User < ActiveRecord::Base
   has_many :comments, foreign_key: :uid
 
   validates_with UniqueUsernameValidator, on: :create
-  validates_format_of :username, with: /\A[A-Za-z\d_\-]+\z/
+  validates_format_of :username, with: /\A[A-Za-z\d_\-]*\z/
 
   before_save :set_token
 

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -1,13 +1,93 @@
 require 'test_helper'
 
 class SignUpTest < ActionDispatch::IntegrationTest
-  test 'all error messages display on signup' do
+  test 'username length error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'a', 
+        email: 'validemail@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Username is too short (minimum is 3 characters)'
+  end
+  
+  test 'username character error messages' do
     post '/register', params: { 
       user: {
         username: '', 
-        email: '',
-        password: '',
-        password_confirmation: '',
+        email: 'validemail@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Username should use only letters, numbers, spaces, and .-_@+ please.'
+  end
+
+  test 'password length error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'validemail@gmail.com',
+        password: 'a',
+        password_confirmation: 'a',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Password is too short (minimum is 8 characters)'
+  end
+
+  test 'password confirmation error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'validemail@gmail.com',
+        password: 'a',
+        password_confirmation: 'b',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Password confirmation doesn&#39;t match Password'
+  end
+
+  test 'email error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'notanemail',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
       },
       spamaway: {
         follow_instructions: '',
@@ -19,8 +99,6 @@ class SignUpTest < ActionDispatch::IntegrationTest
     }
     
     assert response.body.include? 'Email should look like an email address.'
-    assert response.body.include? 'Username is too short'
-    assert response.body.include? 'Password is too short'
   end
 
   test 'no redundant email error messages' do

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -87,6 +87,26 @@ class SignUpTest < ActionDispatch::IntegrationTest
       user: {
         username: 'validusername', 
         email: 'validemail@gmail.com',
+        password: 'aaaaaaaa',
+        password_confirmation: 'bbbbbbbb',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Password confirmation doesn&#39;t match Password'
+  end
+
+  test 'password confirmation and length error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'validemail@gmail.com',
         password: 'a',
         password_confirmation: 'b',
       },
@@ -100,6 +120,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
     }
     
     assert response.body.include? 'Password confirmation doesn&#39;t match Password'
+    assert response.body.include? 'Password confirmation is too short (minimum is 8 characters)'
   end
 
   test 'email error messages' do
@@ -120,6 +141,26 @@ class SignUpTest < ActionDispatch::IntegrationTest
     }
     
     assert response.body.include? 'Email should look like an email address.'
+  end
+  
+  test 'recaptcha error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'validemail@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Spam detection -- It doesn&#39;t seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test.'
   end
 
   test 'custom blank email error messages' do

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -19,6 +19,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
     }
     
     assert response.body.include? 'Username is too short (minimum is 3 characters)'
+    assert !(response.body.include? 'Username should use only letters, numbers, spaces, and .-_@+ please.')
   end
 
   test 'username max length error messages' do
@@ -242,45 +243,4 @@ class SignUpTest < ActionDispatch::IntegrationTest
 
     assert response.body.include? 'Username cannot be blank'
   end
-
-  test 'no redundant username error messages' do
-    post '/register', params: { 
-      user: {
-        username: '^', 
-        email: '',
-        password: '',
-        password_confirmation: '',
-      },
-      spamaway: {
-        follow_instructions: '',
-        statement1: '',
-        statement2: '',
-        statement3: '',
-        statement4: ''
-      }
-    }
-
-    assert !(response.body.include? 'Username is invalid')
-  end
-
-  test 'no redundant email error messages' do
-    post '/register', params: { 
-      user: {
-        username: 'validusername', 
-        email: 'notanemail',
-        password: '',
-        password_confirmation: '',
-      },
-      spamaway: {
-        follow_instructions: '',
-        statement1: '',
-        statement2: '',
-        statement3: '',
-        statement4: ''
-      }
-    }
-
-    assert !(response.body.include? 'Email is invalid')
-  end
-
 end

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class SignUpTest < ActionDispatch::IntegrationTest
-  test 'username length error messages' do
+  test 'username min length error messages' do
     post '/register', params: { 
       user: {
         username: 'a', 
@@ -20,7 +20,27 @@ class SignUpTest < ActionDispatch::IntegrationTest
     
     assert response.body.include? 'Username is too short (minimum is 3 characters)'
   end
-  
+
+  test 'username max length error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'a' * 101, 
+        email: 'validemail@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Username is too long (maximum is 100 characters)'
+  end
+
   test 'username character error messages' do
     post '/register', params: { 
       user: {
@@ -143,6 +163,26 @@ class SignUpTest < ActionDispatch::IntegrationTest
     assert response.body.include? 'Email should look like an email address.'
   end
   
+  test 'email max length error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'a' * 100 + '@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Email is too long (maximum is 100 characters)'
+  end
+
   test 'recaptcha error messages' do
     post '/register', params: { 
       user: {

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -40,8 +40,8 @@ class SignUpTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert response.body.include? 'Email is invalid'
-    assert !(response.body.include? 'Email should look like an email address.')
+    assert !(response.body.include? 'Email is invalid')
+    assert response.body.include? 'Email should look like an email address.'
   end
 
 end

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class SignUpTest < ActionDispatch::IntegrationTest
+  test 'all error messages display on signup' do
+    post '/register', params: { 
+      user: {
+        username: '', 
+        email: '',
+        password: '',
+        password_confirmation: '',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Email is invalid'
+    assert response.body.include? 'Username is too short'
+    assert response.body.include? 'Password is too short'
+  end
+
+  test 'no redundant email error messages' do
+    post '/register', params: { 
+      user: {
+        username: '', 
+        email: '',
+        password: '',
+        password_confirmation: '',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+
+    assert response.body.include? 'Email is invalid'
+    assert !(response.body.include? 'Email should look like an email address.')
+  end
+
+end

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -24,7 +24,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
   test 'username character error messages' do
     post '/register', params: { 
       user: {
-        username: '', 
+        username: '^', 
         email: 'validemail@gmail.com',
         password: 'validpassword',
         password_confirmation: 'validpassword',
@@ -119,6 +119,26 @@ class SignUpTest < ActionDispatch::IntegrationTest
     }
 
     assert response.body.include? 'Email cannot be blank'
+  end
+
+  test 'custom blank username error messages' do
+    post '/register', params: { 
+      user: {
+        username: '', 
+        email: 'validemail@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+
+    assert response.body.include? 'Username cannot be blank'
   end
 
   test 'no redundant username error messages' do

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -18,7 +18,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
       }
     }
     
-    assert response.body.include? 'Email is invalid'
+    assert response.body.include? 'Email should look like an email address.'
     assert response.body.include? 'Username is too short'
     assert response.body.include? 'Password is too short'
   end

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -101,10 +101,30 @@ class SignUpTest < ActionDispatch::IntegrationTest
     assert response.body.include? 'Email should look like an email address.'
   end
 
-  test 'no redundant email error messages' do
+  test 'custom blank email error messages' do
     post '/register', params: { 
       user: {
-        username: '', 
+        username: 'validusername', 
+        email: '',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+
+    assert response.body.include? 'Email cannot be blank'
+  end
+
+  test 'no redundant username error messages' do
+    post '/register', params: { 
+      user: {
+        username: '^', 
         email: '',
         password: '',
         password_confirmation: '',
@@ -118,8 +138,27 @@ class SignUpTest < ActionDispatch::IntegrationTest
       }
     }
 
+    assert !(response.body.include? 'Username is invalid')
+  end
+
+  test 'no redundant email error messages' do
+    post '/register', params: { 
+      user: {
+        username: 'validusername', 
+        email: 'notanemail',
+        password: '',
+        password_confirmation: '',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+
     assert !(response.body.include? 'Email is invalid')
-    assert response.body.include? 'Email should look like an email address.'
   end
 
 end

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -24,6 +24,26 @@ class SignUpTest < ActionDispatch::IntegrationTest
   test 'username character error messages' do
     post '/register', params: { 
       user: {
+        username: 'xzd^', 
+        email: 'validemail@gmail.com',
+        password: 'validpassword',
+        password_confirmation: 'validpassword',
+      },
+      spamaway: {
+        follow_instructions: '',
+        statement1: '',
+        statement2: '',
+        statement3: '',
+        statement4: ''
+      }
+    }
+    
+    assert response.body.include? 'Username should use only letters, numbers, spaces, and .-_@+ please.'
+  end
+
+  test 'username character and length error messages' do
+    post '/register', params: { 
+      user: {
         username: '^', 
         email: 'validemail@gmail.com',
         password: 'validpassword',
@@ -39,6 +59,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
     }
     
     assert response.body.include? 'Username should use only letters, numbers, spaces, and .-_@+ please.'
+    assert response.body.include? 'Username is too short (minimum is 3 characters)'
   end
 
   test 'password length error messages' do


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/6303

I noticed that `user.save` populated many of the relevant errors. This was not being called when the recaptcha failed because the if statement short circuited the method call. 

```ruby
if ((@spamaway&.valid?) || recaptcha) && @user.save
```

To make this code more declarative, I refactored the result of `@user.save` into a new variable `saved`. This way, the errors would be populated every time. 

In addition, I added code to manually clean up the errors returned from the `@user.save`. In particular, the `is invalid` errors aren't very informative. I added a check to remove these errors if there was already an error associated with that field. 

Finally, I added an integration test for the errors returned from the `/register` endpoint. 

@gauravano @SidharthBansal @IshaGupta18 @ananyaarun @pydevsg @sashadev-sky @cesswairimu Could you take a look please? Thanks!