### PR TITLE
Add bootstrap popover to authors shown in header

### DIFF
--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -31,7 +31,7 @@
 
     <div style="padding-top:8px;text-align:center">
       <span class="d-none d-lg-inline">
-        <span rel="tooltip" data-placement="top" data-html="true" data-title="
+        <span rel="tooltip" tabindex="0" data-placement="top" data-toggle="popover" data-trigger="focus" data-html="true" data-content="
           <ul>
             <% @node.authors.each do |author| %>
               <li><a href='/profile/<%= author.username %>'>@<%= author.username %></a></li>

--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -31,7 +31,15 @@
 
     <div style="padding-top:8px;text-align:center">
       <span class="d-none d-lg-inline">
-        <%= number_with_delimiter(@node.authors.length)  %> Authors |
+        <span rel="tooltip" data-placement="top" data-html="true" data-title="
+          <ul>
+            <% @node.authors.each do |author| %>
+              <li><a href='/profile/<%= author.username %>'>@<%= author.username %></a></li>
+            <% end %>
+          </ul>
+        ">
+          <%= number_with_delimiter(@node.authors.length) %> Authors
+        </span> |
         <a rel="tooltip" title="View all revisions for this page." data-placement="top" href="/wiki/revisions/<%= @node.slug_from_path %>"><%= @node.revisions.length %> <%= t('wiki.revisions.revisions') %></a> |
         <a href="/talk/<%= @node.slug_from_path %>" rel="tooltip" title="Practice in a realtime doc." data-placement="top"><%= t('wiki.show.talk') %></a>
       </span>


### PR DESCRIPTION
Trying to fix #6923

Here are the current screencasts showing the behavior of author popover.
[popover when with 1 author](https://imgur.com/a/jtcJito)
[popover when with 3 authors](https://imgur.com/a/V97cKoP)

As you see in these screencasts, the popover vanishes when we move the cursor to the authors' links. This is not what we intended but I have no idea how to fix this behavior.

@jywarren @gauravano @SidharthBansal @IshaGupta18 @ananyaarun @pydevsg @sashadev-sky @cesswairimu 
Could you help me out?
Thanks!
