### PR TITLE
Test for changes to /notes/liked and /recent endpoints

### DIFF
--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -673,7 +673,25 @@ class NotesControllerTest < ActionController::TestCase
     assert (notes & expected).present?
     assert !(notes & questions).present?
   end
-
+  
+    test 'first note in /liked endpoint should be highest liked' do
+    get :liked
+    notes = assigns(:notes)
+    # gets highest liked note's number of likes
+    expected = Node.research_notes.where(status: 1).maximum("cached_likes")
+    # gets first note of /notes/liked endpoint
+    actual = notes.first
+    # both should be equal
+    assert expected == actual.cached_likes
+  end
+  test 'first note in /recent endpoint should be most recent' do
+    get :recent
+    notes = assigns(:notes)
+    expected = Node.where(type: 'note', status: 1, created: Time.now.to_i - 1.weeks.to_i..Time.now.to_i)
+                   .maximum("created")
+    actual = notes.first
+    assert expected == actual.created
+  end
   test 'should choose I18n for notes controller' do
     available_testing_locales.each do |lang|
       old_controller = @controller

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -692,6 +692,15 @@ class NotesControllerTest < ActionController::TestCase
     actual = notes.first
     assert expected == actual.created
   end
+     
+  test 'first three posts in /liked should be sorted by likes' do
+    get :liked
+    # gets first notes
+    notes = assigns(:notes)[0...3]
+     # sort_by is from lowest to highest so it needs to be reversed
+    assert notes.sort_by { |note| note.cached_likes }.reverse ==  notes
+  end
+   
   test 'should choose I18n for notes controller' do
     available_testing_locales.each do |lang|
       old_controller = @controller


### PR DESCRIPTION
@jywarren @ananyaarun @SidharthBansal @keshav234156 
This adds testing for the features of this [pull request](https://github.com/publiclab/plots2/pull/6919). 
It checks if the first notes in the liked and recent endpoints have the most likes or are the most recent respectively. I am not sure if this is what you were looking for but I think it works well.
Thanks! :smile:
