### PR TITLE
solve pluralization for user notes page

### DIFF
--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -11,7 +11,7 @@
   <% elsif params[:action] == "author_topic" %>
     <h3><%= raw t('notes.index.research_on', :tags => @tagnames.join(', '), :url1 => "/people/"+@user.name, :user_name => @user.name) %> <br /><small><%= raw t('notes.index.research_notes_and_wiki_edits_with_time', :count => @user.nodes.count, :time => time_ago_in_words(@user.created_at)) %></small></h3>
   <% elsif params[:action] == "author" %>
-    <h3><%= raw t('notes.index.research_by', :url1 => "/people/"+@user.name, :user_name => @user.name) %> <small><%= raw t('notes.index.research_notes_and_wiki_edits', :count1 => @user.note_count, :count2 => @user.revisions.count) %> <% if @user.notes.length > 0 %><%= raw t('notes.index.starting_time', :time => time_ago_in_words(@user.created_at)) %><% end %></small></h3>
+    <h3><%= raw t('notes.index.research_by', :url1 => "/people/"+@user.name, :user_name => @user.name) %> <small><%= pluralize(@user.note_count, "note") %> and <%= pluralize(@user.revisions.count, "edit") %><% if @user.notes.length > 0 %> <%= raw t('notes.index.starting_time', :time => time_ago_in_words(@user.created_at)) %><% end %></small></h3>
   <% else %>
     <h2><%= raw t('notes.index.research_notes_ideas_and_documentation') %></h2>
   <% end %>


### PR DESCRIPTION
Fixes #6827
@sashadev-sky 
I think using the rails ```pluralize``` method is the most efficient way to solve this issue. This pull request solves the pluralization on the ```/notes/author/user``` page. 

I searched in the code base to see if the following line that used to be used to show this information was used elsewhere but it was not. So I removed it since it is not needed in this different solution
https://github.com/publiclab/plots2/blob/b3dc71222e3a1ce9e5417bc01c8b1e3c0d92f21f/config/locales/en.yml#L158-L159
Thanks!
