### PR TITLE
Fix new system tests for adding tags to node and user

### DIFF
--- a/app/assets/javascripts/submit_form_ajax.js
+++ b/app/assets/javascripts/submit_form_ajax.js
@@ -1,7 +1,7 @@
 // Takes in a data object that contains the info to be submitted in the form property: dataString
 //   and the url to submit to the controller
 // Allows data to be submitted from anywhere on the page using Javascript without using the form itself
-function sendFormSubmissionAjax(dataObj, submitTo) {
+function sendFormSubmissionAjax(dataObj, submitTo, responseEl = "") {
   let url = '';
   if(submitTo.slice(0,1) === "/") {
     url = submitTo;
@@ -12,8 +12,8 @@ function sendFormSubmissionAjax(dataObj, submitTo) {
     url: url,
     data: dataObj,
     success: (event, success) => {
-      if (url !== submitTo) {
-        $(submitTo).trigger('ajax:success', event);
+      if (responseEl !== "") {
+        $(responseEl).trigger('ajax:success', event);
       }
     }
   });

--- a/app/assets/javascripts/tagging.js
+++ b/app/assets/javascripts/tagging.js
@@ -42,17 +42,11 @@ function initTagForm(deletion_path, selector) {
 
   el.bind('ajax:success', function(e, response){
     if (typeof response == "string") response = JSON.parse(response)
-    $.each(response['saved'], function(i,tag) {
-      var tag_name = tag[0];
-      var tag_id = tag[1];
-      $('.tags-list:first').append("<p id='tag_"+tag_id+"' class='badge badge-primary'> \
-        <a class='tag-name' style='color:white;' href='/tag/"+tag_name+"'>"+tag_name+"</a> <a class='tag-delete' \
-        data-remote='true' href='"+deletion_path+"/"+tag_id+"' data-tag-id='"+tag_id+"' \
-        data-method='delete'><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a></p> ")
+    $.each(response['saved'], function(i, tag) {
+      displayNewTag(deletion_path, tag[0], tag[1]);
       el.find('.tag-input').val("")
       el.find('.control-group').removeClass('has-error')
       el.find('.control-group .help-block').remove()
-      setupTagDelete($('#tag_' + tag_id + ' .tag-delete'));
     })
     if (response['errors'].length > 0) {
       el.find('.control-group').addClass('has-error')
@@ -90,6 +84,17 @@ function initTagForm(deletion_path, selector) {
   return el;
 
 }
+
+
+
+function displayNewTag(deletion_path, tag_name, tag_id) {
+  $('.tags-list:first').append("<p id='tag_"+tag_id+"' class='badge badge-primary'> \
+    <a class='tag-name' style='color:white;' href='/tag/"+tag_name+"'>"+tag_name+"</a> <a class='tag-delete' \
+    data-remote='true' href='"+deletion_path+"/"+tag_id+"' data-tag-id='"+tag_id+"' \
+    data-method='delete'><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a></p> ")
+  setupTagDelete($('#tag_' + tag_id + ' .tag-delete'));
+}
+
 
 function geocodeStringAndPan(string, onComplete) {
   var url = "https://maps.googleapis.com/maps/api/geocode/json?address=" + string.split(" ").join("+");

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -352,7 +352,7 @@ class TagController < ApplicationController
 
         if saved
           @tags << tag
-          @output[:saved] << [tag.name, tag.id]
+          @output[:saved] << [tag.name, tag.id, nid]
         else
           @output[:errors] << I18n.t('tag_controller.error_tags') + tag.errors[:name].first
         end

--- a/app/controllers/user_tags_controller.rb
+++ b/app/controllers/user_tags_controller.rb
@@ -63,7 +63,7 @@ class UserTagsController < ApplicationController
           elsif  tagname.split(':')[1] == "twitter"
             @output[:errors] << "This tag is used for associating a Twitter account. <a href='https://publiclab.org/wiki/oauth'>Click here to read more </a>"
           elsif user_tag.save
-            @output[:saved] << [name, user_tag.id]
+            @output[:saved] << [name, user_tag.id, params[:id]]
           else
             @output[:errors] << I18n.t('user_tags_controller.cannot_save_value')
           end

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -28,7 +28,7 @@ class TagControllerTest < ActionController::TestCase
     post :create, params: { name: 'myfourthtag,myfifthtag', nid: nodes(:one).nid, uid: users(:bob).id }, xhr: true
 
     assert_response :success
-    assert_equal [['myfourthtag', Tag.find_by_name('myfourthtag').tid], ['myfifthtag', Tag.find_by_name('myfifthtag').tid]], JSON.parse(response.body)['saved']
+    assert_equal [['myfourthtag', Tag.find_by_name('myfourthtag').tid, nodes(:one).nid.to_s], ['myfifthtag', Tag.find_by_name('myfifthtag').tid, nodes(:one).nid.to_s]], JSON.parse(response.body)['saved']
   end
 
   test 'check tag show page and confirm pinned post' do

--- a/test/functional/user_tags_controller_test.rb
+++ b/test/functional/user_tags_controller_test.rb
@@ -18,7 +18,7 @@ class UserTagsControllerTest < ActionController::TestCase
     UserSession.create(users(:bob))
     post :create, params: { id: users(:bob).id, name: 'environment' }, xhr: true
     assert_response :success
-    assert_equal [['environment', UserTag.where(value:'environment').first.id]], JSON.parse(response.body)['saved']
+    assert_equal [['environment', UserTag.where(value:'environment').first.id, users(:bob).id.to_s]], JSON.parse(response.body)['saved']
   end
 
   test 'should create two new tags from "one,two"' do
@@ -27,7 +27,7 @@ class UserTagsControllerTest < ActionController::TestCase
       post :create, params: { name: 'one,two', nid: nodes(:one).nid, id: users(:bob).id }, xhr: true
     end
     assert_response :success
-    assert_equal [['one', UserTag.where(value: 'one').first.id], ['two', UserTag.where(value: 'two').first.id]], JSON.parse(response.body)['saved']
+    assert_equal [['one', UserTag.where(value: 'one').first.id, users(:bob).id.to_s], ['two', UserTag.where(value: 'two').first.id, users(:bob).id.to_s]], JSON.parse(response.body)['saved']
   end
 
   test 'should delete existing tag' do

--- a/test/system/tag_test.rb
+++ b/test/system/tag_test.rb
@@ -38,10 +38,8 @@ class TagTest < ApplicationSystemTestCase
     # run the javascript function
     page.evaluate_script("addTag('roses', '/tag/create/11')")
 
-    visit "/wiki/wiki-page-path" # refresh page
-
     # check that the tag showed up on the page
-    assert_selector('.tags-list .card-body h5', text: 'roses')
+    assert_selector('.tags-list .tag-name', text: 'roses')
 
   end
 
@@ -58,8 +56,6 @@ class TagTest < ApplicationSystemTestCase
 
     # run the javascript function
     page.evaluate_script("addTag('specialgroup', '/profile/tags/create/2')")
-
-    visit "/profile/jeff" # refresh page
 
     find('#tags-section').click
 


### PR DESCRIPTION
Fixes #6904  (<=== Add issue number here)

I have added some logic to the updating of the page after adding tags so now tags added via URL (instead of the form) will also be updated immediately on the page, just like it did when tags were added by the form. I also added a check so that it would only show on the page if you were adding a tag to the same node/user as the one that's being displayed.

I have updated the system tests to check for this instead of refreshing the page. Hopefully this will stop the timing issue we were seeing!

@jywarren 