### PR TITLE
Removed duplicate "email is invalid" error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,6 @@ class User < ActiveRecord::Base
   acts_as_authentic do |c|
     c.crypto_provider = Authlogic::CryptoProviders::Sha512
   end
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   has_attached_file :photo, styles: { thumb: '200x200#', medium: '500x500#', large: '800x800#' },
                                     url: '/system/profile/photos/:id/:style/:basename.:extension'


### PR DESCRIPTION
Fixes part of https://github.com/publiclab/plots2/issues/6303

The regex check is a duplicate of the one performed in authlogic, resulting in an extra "email is invalid" error. 