### PR TITLE
FIX: "Post note" form overflow

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -27,6 +27,14 @@
   body {
     background-color: white;
   }
+
+  .pl-editor {
+    max-width: 100%;
+  }
+
+  .ple-module-main_image .col-lg-9 {
+    margin: 0 auto;
+  }
 </style>
 
 <div class="pl-editor">


### PR DESCRIPTION
In the old UI, the map and drop-image elements were cut off the screen.
This change makes them responsive.

Resolves #6970 

![Screenshot_20191215_191929](https://user-images.githubusercontent.com/35997844/70867030-fb3b7f00-1f70-11ea-8f34-e2beeb37d6dc.png)

![Screenshot_20191215_192045](https://user-images.githubusercontent.com/35997844/70867040-1b6b3e00-1f71-11ea-8a3a-155ac944bec6.png)

@keshav234156 @SidharthBansal could you review this, please?