### PR TITLE
Remove deprecated Answers table from QuestionsController#unanswered

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -111,7 +111,7 @@ class QuestionsController < ApplicationController
     @questions = Node.questions
       .where(status: 1)
       .left_outer_joins(:comments)
-      .where(comments: {cid: nil})
+      .where(comments: { cid: nil })
       .order('node.nid DESC')
       .group('node.nid')
       .paginate(page: params[:page], per_page: 24)

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -33,7 +33,7 @@ class QuestionsController < ApplicationController
       .where(status: 1)
       .order('node.nid DESC')
       .paginate(page: params[:page], per_page: 24)
-    
+
     @populartitle = 'Popular Questions'
     @popularquestions = Node.questions
       .where(status: 1)
@@ -110,9 +110,8 @@ class QuestionsController < ApplicationController
     @title = 'Unanswered questions'
     @questions = Node.questions
       .where(status: 1)
-      .includes(:answers)
-      .references(:answers)
-      .where(answers: { id: nil })
+      .left_outer_joins(:comments)
+      .where(comments: {cid: nil})
       .order('node.nid DESC')
       .group('node.nid')
       .paginate(page: params[:page], per_page: 24)


### PR DESCRIPTION
Fixes #6878 

I modified the SQL query in questions_controller.rb to check if there are any comments on a question, rather than relying on the deprecated Answers table. Here is a screenshot of the two questions I made for testing, one of which has a comment:
![Recently Asked Questions Screenshot](https://user-images.githubusercontent.com/37421108/70951782-fab2ef00-2029-11ea-8230-e1746a3d57a5.png)

Here is a screenshot of the new unanswered questions page, which contains only the question with no comment:
![Unanswered Questions Screenshot](https://user-images.githubusercontent.com/37421108/70951776-f8509500-2029-11ea-8376-a273ba676ec7.png)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

