### PR TITLE
Save zoom in location modal

### DIFF
--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -112,7 +112,7 @@
   })();
     
   function saveLocation() {
-    var tags = 'lat:' + blurredLocation.getLat() + ',lon:' + blurredLocation.getLon();
+    var tags = 'lat:' + blurredLocation.getLat() + ',lon:' + blurredLocation.getLon() + ',zoom:' + blurredLocation.getZoom();
     if (blurredLocation.isBlurred()) tags = tags + ',' + 'location:blurred'
     if ($('#placenameDisplay').val() != 'Location unavailable') tags = tags + ',' + 'place:' + parameterize($('#placenameDisplay').val());
     <% if params[:url] %>


### PR DESCRIPTION
Fixes #7019  (<=== Add issue number here)

This PR adds `zoom:xx` to the tags list when saving a location in the popup modal.

I wasn't sure if yarn.lock should be added to the list of files in the commit? Google tells me it should be, but if I shouldn't then let me know and I'll remove it.