### PR TITLE
typo replace omment with comment

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
-omment:
+comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ branches:
   only:
     - master
     - unstable
+    - codecov
 
 install:
   - rm -rf test/reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ env:
     - TASK="rails test test/integration"
     - TASK="rails test:system"
 
+branches:
+  only:
+    - master
+    - unstable
+
 install:
   - rm -rf test/reports
   - cp config/database.yml.example config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ env:
     - TASK="rails test test/integration"
     - TASK="rails test:system"
 
-branches:
-  only:
-    - master
-    - unstable
-
 install:
   - rm -rf test/reports
   - cp config/database.yml.example config/database.yml

--- a/app/assets/stylesheets/blog.css
+++ b/app/assets/stylesheets/blog.css
@@ -2,7 +2,7 @@
   font-size:4em;
   margin-top:100px;
   color:#326;
-  line-height:1.3em;
+  line-height:1.3em
 }
 
 .blog h1 {


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/6290


I think there is an error here and the `omment` should be replaced with `comment` instead for the codecov configuration. 
I might be wrong but I think it might be something worth trying out to solve the codecov coverage issues.

Thanks!
