### PR TITLE
Use default location lat lon for /map/

### DIFF
--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -23,10 +23,10 @@ class MapController < ApplicationController
   def map
     @layersname = params[:layersname]
 
-    if current_user&.has_power_tag("lat") && current_user&.has_power_tag("lon")
-      @map_lat = current_user.get_value_of_power_tag("lat").to_f
-      @map_lon = current_user.get_value_of_power_tag("lon").to_f
-    end
+    return if current_user&.has_power_tag("lat").blank? || current_user&.has_power_tag("lon").blank?
+    
+    @user_lat = current_user.get_value_of_power_tag("lat").to_f
+    @user_lon = current_user.get_value_of_power_tag("lon").to_f
   end
 
   def show

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -22,6 +22,11 @@ class MapController < ApplicationController
 
   def map
     @layersname = params[:layersname]
+
+    if current_user&.has_power_tag("lat") && current_user&.has_power_tag("lon")
+      @map_lat = current_user.get_value_of_power_tag("lat").to_f
+      @map_lon = current_user.get_value_of_power_tag("lon").to_f
+    end
   end
 
   def show

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -24,7 +24,7 @@ class MapController < ApplicationController
     @layersname = params[:layersname]
 
     return if current_user&.has_power_tag("lat").blank? || current_user&.has_power_tag("lon").blank?
-    
+
     @user_lat = current_user.get_value_of_power_tag("lat").to_f
     @user_lon = current_user.get_value_of_power_tag("lon").to_f
   end

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -32,14 +32,17 @@
       var user_lon = null;
       var profile_zoom = null;
       <% if @user_lat && @user_lon %>
-        user_lat = <%= @user_lat %>;
-        user_lon = <%= @user_lon %>;
+        user_lat = "<%= @user_lat %>";
+        user_lon = "<%= @user_lon %>";
         profile_zoom = 7;
       <% end %>
 
-      var lat = parseFloat(params.lat) || user_lat || 23;
-      var lon = parseFloat(params.lon) || user_lon || 77;
+      var lat = params.lat || user_lat || 23;
+      var lon = params.lon || user_lon || 77;
       var zoom = parseFloat(params.zoom) || profile_zoom || 3;
+      // These must be parsed after evaluating above or else 0 will not be displayed
+      lat = parseFloat(lat);
+      lon = parseFloat(lon);
 
       var map = L.map("map", {
         maxBounds: bounds,

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -28,20 +28,18 @@
         new L.LatLng(-54.36775852, 178.59375)
       );
 
+      var user_lat = null;
+      var user_lon = null;
+      var profile_zoom = null;
       <% if @map_lat && @map_lon %>
-        var user_lat = <%= @map_lat %>;
-        var user_lon = <%= @map_lon %>;
-        var default_profile_zoom = 4;
+        user_lat = <%= @map_lat %>;
+        user_lon = <%= @map_lon %>;
+        profile_zoom = 7;
       <% end %>
 
-      // check if lat and lon exist. If not, then check user lat and lon. Then assign default.
       var lat = parseFloat(params.lat) || user_lat || 23;
       var lon = parseFloat(params.lon) || user_lon || 77;
-      var zoom = parseFloat(params.zoom) || default_profile_zoom || 3;
-        console.log("Params: " + lat + "  " + lon);
-      if(user_lat) {
-        console.log("User: " + user_lat + "  " + user_lon);
-      }
+      var zoom = parseFloat(params.zoom) || profile_zoom || 3;
 
       var map = L.map("map", {
         maxBounds: bounds,

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -31,9 +31,9 @@
       var user_lat = null;
       var user_lon = null;
       var profile_zoom = null;
-      <% if @map_lat && @map_lon %>
-        user_lat = <%= @map_lat %>;
-        user_lon = <%= @map_lon %>;
+      <% if @user_lat && @user_lon %>
+        user_lat = <%= @user_lat %>;
+        user_lon = <%= @user_lon %>;
         profile_zoom = 7;
       <% end %>
 

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -28,9 +28,20 @@
         new L.LatLng(-54.36775852, 178.59375)
       );
 
-      var lat = parseFloat(params.lat)|| 23;
-      var lon = parseFloat(params.lon) || 77;
-      var zoom = parseFloat(params.zoom) || 4;
+      <% if @map_lat && @map_lon %>
+        var user_lat = <%= @map_lat %>;
+        var user_lon = <%= @map_lon %>;
+        var default_profile_zoom = 4;
+      <% end %>
+
+      // check if lat and lon exist. If not, then check user lat and lon. Then assign default.
+      var lat = parseFloat(params.lat) || user_lat || 23;
+      var lon = parseFloat(params.lon) || user_lon || 77;
+      var zoom = parseFloat(params.zoom) || default_profile_zoom || 3;
+        console.log("Params: " + lat + "  " + lon);
+      if(user_lat) {
+        console.log("User: " + user_lat + "  " + user_lon);
+      }
 
       var map = L.map("map", {
         maxBounds: bounds,
@@ -50,8 +61,12 @@
         urlHash.setUrlHashParameter('zoom', zoom + "");
       })
 
-      var layersname = "<%= @layersname %>";
-      layersname = layersname.split(',');
+      <% if @layersname.nil? %>
+        var layersname = ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'];
+      <% else %>
+        var layersname = "<%= @layersname %>";
+        layersname = layersname.split(',')
+      <% end %>
 
       L.tileLayer(
         "https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png",
@@ -62,7 +77,7 @@
 
 
       L.LayerGroup.EnvironmentalLayers({
-        include: layersname  || ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'],
+        include: layersname,
         hash: false,
         embed: true,
       }).addTo(map);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,10 +247,10 @@ Plots2::Application.routes.draw do
   get 'groups/:search' => 'user_tags#index'
 
 
+  get 'map' => 'map#map'
   get 'map/:layersname' => 'map#map'
   get 'maps' => 'map#index'
   get 'users/map' => 'users#map'
-  get 'map' => 'search#map'
   get 'maps/:id' => 'map#tag'
   get 'map/edit/:id' => 'map#edit'
   put 'map/update/:id' => 'map#update'


### PR DESCRIPTION
Fixes #7045  (<=== Add issue number here)

- [x] Fix route error so /map/ displays the same as /map/:layernames
- [x] If lat and lon isn't specified in the params, display the user's profile location. If the user has no profile location, show a default lat and lon.