### PR TITLE
Change Color and Whitespace of Ellipses Button in Profile

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -73,7 +73,7 @@
       <a href="/profile/<%= @profile_user.name %>/edit" class="btn btn-outline-secondary"><%= t('users.profile.edit_profile') %></a>
     <% end %>
 
-    <a class="btn btn-outline-secondary" id="info-ellipsis"><i class="fa fa-ellipsis-h" style="color : #666;"></i></a>
+    <a class="btn btn-outline-secondary" id="info-ellipsis"><i class="fa fa-ellipsis-h" style="margin:0"></i></a>
 
   </div>
 


### PR DESCRIPTION
Original Issue: https://github.com/publiclab/plots2/issues/7050
Changes incorrect color and removes extra whitespace from ellipses button on the Profile page.
The following is a screenshot with the fixed button:
![Screen Shot 2019-12-27 at 3 12 26 PM](https://user-images.githubusercontent.com/59002451/71531777-3d908480-28be-11ea-9f66-277b7f9e71af.png)


Fixes #7050  (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
