### PR TITLE
Set map bounds in /post/ and location modal

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -314,6 +314,7 @@
 
 </div>
 <script>
+
   var editor;
 
   (function() {
@@ -414,6 +415,12 @@
       }
     });
 
+    var bounds = new L.LatLngBounds(
+      new L.LatLng(90, -180),
+      new L.LatLng(-90, 180)
+    );
+    editor.mapModule.blurredLocation.map.setMaxBounds(bounds);
+
     $('#coord_button').click((event) => {
       event.preventDefault();
       $('#coord_input').toggle();
@@ -438,11 +445,10 @@
       // write the ArrayBuffer to a blob, and you're done
       var blob = new Blob([ab], {type: mimeString});
       return blob;
-  }
-  <% if true || params[:datauri_main_image] %>
-    $('.ple-module-main_image input').fileupload('add', {'files': [ dataURItoBlob('<%= params[:datauri_main_image] %>') ]});
-  <% end %>
-
+    }
+    <% if true || params[:datauri_main_image] %>
+      $('.ple-module-main_image input').fileupload('add', {'files': [ dataURItoBlob('<%= params[:datauri_main_image] %>') ]});
+    <% end %>
 
   })();
   $('.legacy-button').click(function onLegacyClick(event) {

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -70,7 +70,12 @@
 </div>
 
 <script>
-  
+
+  var bounds = new L.LatLngBounds(
+    new L.LatLng(90, -180),
+    new L.LatLng(-90, 180)
+  );
+
   var options = {
     InterfaceOptions: {
       latId: 'lat',
@@ -99,6 +104,8 @@
     blurredLocation = new BlurredLocation(options);
 
     blurredLocation.panMapToGeocodedLocation("placenameInput");
+
+    blurredLocation.map.setMaxBounds(bounds);
 
      var changeZoom = function() {
         var zoom = slider.getValue();


### PR DESCRIPTION
Fixes #7052 (<=== Add issue number here)

So right now this is the "quick fix" version by setting the map bounds after the map is created. If we want to allow it being set on initialization then we'll have to change add options to both LBL and PL.Editor.

I am a little concerned with how this looks when you get to the edge of the map. There is no visual boundary, so I'm worried that people trying to select Hawaii will have problems doing so and not understand why it's bouncing away from Hawaii when zoomed out. I know this is just how Leaflet works, but it doesn't seem intuitive to a user.

![Peek 2019-12-30 10-44](https://user-images.githubusercontent.com/49460529/71589025-782e3300-2af1-11ea-9861-13e0dcdeb024.gif)

Zoomed in you can select Hawaii.

![Peek 2019-12-30 10-45](https://user-images.githubusercontent.com/49460529/71589065-92681100-2af1-11ea-8db2-e135ffbc8f90.gif)

The same happens when trying to select Fiji, Tonga.