### PR TITLE
Create /map/ route for wiki pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,3 +58,4 @@
 //= require jquery-validation/dist/jquery.validate.js
 //= require validation.js
 //= require submit_form_ajax.js
+//= require urlMapHash.js

--- a/app/assets/javascripts/urlMapHash.js
+++ b/app/assets/javascripts/urlMapHash.js
@@ -1,0 +1,53 @@
+function urlMapHash() {
+  // This is based off of jywarren's urlhash, made specific to our map hash needs
+
+  const paramArray = ["zoom", "lat", "lon"];
+  
+  function getUrlHashParameter(param) {
+  
+    var params = getUrlHashParameters();
+    return params[param];
+  
+  }
+  
+  function getUrlHashParameters() {
+  
+    var sPageURL = window.location.hash;
+    if (sPageURL) sPageURL = sPageURL.split('#')[1];
+    var items = sPageURL.split('/');
+    var object = {};
+    items.forEach(function(item, i) {
+      if ((item != '') && (paramArray[i])) object[paramArray[i]] = item;
+    });
+    return object;
+  }
+  
+  // accepts an object like { paramName: value, paramName1: value }
+  // and transforms to: url.com#zoom/lat/lon
+  function setUrlHashParameters(params) {
+  
+    var values = [];
+    paramArray.forEach(function(key, i) {
+      values.push(params[key]);
+    });
+    var hash = values.join('/');
+    window.location.hash = hash;
+  
+  }
+  
+  function setUrlHashParameter(param, value) {
+  
+    var params = getUrlHashParameters();
+    params[param] = value;
+    setUrlHashParameters(params);
+  
+  }
+  
+  return {
+    getUrlHashParameter:   getUrlHashParameter,
+    getUrlHashParameters:  getUrlHashParameters,
+    setUrlHashParameter:   setUrlHashParameter,
+    setUrlHashParameters:  setUrlHashParameters
+  }
+    
+}

--- a/app/assets/javascripts/urlMapHash.js
+++ b/app/assets/javascripts/urlMapHash.js
@@ -17,7 +17,7 @@ function urlMapHash() {
     var items = sPageURL.split('/');
     var object = {};
     items.forEach(function(item, i) {
-      if ((item != '') && (paramArray[i])) object[paramArray[i]] = item;
+      if ((item !== '') && (paramArray[i])) object[paramArray[i]] = item;
     });
     return object;
   }

--- a/app/assets/stylesheets/location.css
+++ b/app/assets/stylesheets/location.css
@@ -14,3 +14,19 @@
 #map_content .form-group .btn {
   margin-top: .4rem;
 }
+
+a:not([href]):not([tabindex]).btn-location,
+.btn-location {
+  position: inline;
+  color:#666;
+}
+a:not([href]):not([tabindex]).btn-outline-secondary.btn-location .fa,
+a.btn-outline-secondary.btn-location .fa {
+  color: #c40;
+}
+a:not([href]):not([tabindex]).btn-outline-secondary.btn-location:hover,
+a:not([href]):not([tabindex]).btn-outline-secondary.btn-location:hover i,
+.btn-outline-secondary.btn-location:hover,
+.btn-outline-secondary.btn-location:hover i {
+  color: white;
+}

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -34,7 +34,7 @@ class MapController < ApplicationController
 
     if @node.blank?
       flash[:warning] = "Wiki page not found."
-      redirect_to :controller=>'map', :action=>'map'
+      redirect_to controller: 'map', action: 'map'
       return
     end
 
@@ -45,7 +45,7 @@ class MapController < ApplicationController
       @lon = @node.power_tag("lon").to_f
       @zoom = @node.power_tag("zoom").to_f if @node.has_power_tag("zoom")
     end
-  
+
     render :map
   end
 

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -21,28 +21,29 @@ class MapController < ApplicationController
   end
 
   def map
-    return if current_user&.has_power_tag("lat").blank? || current_user&.has_power_tag("lon").blank?
+    @lat = 0
+    @lon = 0
+    @zoom = 3
 
-    @user_lat = current_user.get_value_of_power_tag("lat").to_f
-    @user_lon = current_user.get_value_of_power_tag("lon").to_f
+    if current_user&.has_power_tag("lat") && current_user&.has_power_tag("lon")
+      @lat = current_user.get_value_of_power_tag("lat").to_f
+      @lon = current_user.get_value_of_power_tag("lon").to_f
+    end
+    @zoom = current_user.get_value_of_power_tag("zoom").to_f if current_user&.has_power_tag("zoom")
   end
 
   def wiki
     @node = Node.find_wiki(params[:id])
 
-    if @node.blank?
-      flash[:warning] = "Wiki page not found."
+    if @node.blank? || @node.has_power_tag("lat").blank? || @node.has_power_tag("lon").blank?
+      flash[:warning] = @node.blank? ? "Wiki page not found." : "No location found for wiki page."
       redirect_to controller: 'map', action: 'map'
       return
     end
 
-    if @node.has_power_tag("lat").blank? && @node.has_power_tag("lon").blank?
-      flash[:warning] = "No location found for this wiki page."
-    else
-      @lat = @node.power_tag("lat").to_f
-      @lon = @node.power_tag("lon").to_f
-      @zoom = @node.power_tag("zoom").to_f if @node.has_power_tag("zoom")
-    end
+    @lat = @node.power_tag("lat").to_f
+    @lon = @node.power_tag("lon").to_f
+    @zoom = @node.has_power_tag("zoom") ? @node.power_tag("zoom").to_f : 6
 
     render :map
   end

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -33,13 +33,19 @@ class MapController < ApplicationController
     @node = Node.find_wiki(params[:id])
 
     if @node.blank?
-      redirect_to :controller=>'map', :action=>'map' and return
+      flash[:warning] = "Wiki page not found."
+      redirect_to :controller=>'map', :action=>'map'
+      return
     end
 
-      @lat = @node.power_tag("lat").to_f if @node.has_power_tag("lat")
-      @lon = @node.power_tag("lon").to_f if @node.has_power_tag("lon")
+    if @node.has_power_tag("lat").blank? && @node.has_power_tag("lon").blank?
+      flash[:warning] = "No location found for this wiki page."
+    else
+      @lat = @node.power_tag("lat").to_f
+      @lon = @node.power_tag("lon").to_f
       @zoom = @node.power_tag("zoom").to_f if @node.has_power_tag("zoom")
-    
+    end
+  
     render :map
   end
 

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -29,6 +29,20 @@ class MapController < ApplicationController
     @user_lon = current_user.get_value_of_power_tag("lon").to_f
   end
 
+  def wiki
+    @node = Node.find_wiki(params[:id])
+
+    if @node.blank?
+      redirect_to :controller=>'map', :action=>'map' and return
+    end
+
+      @lat = @node.power_tag("lat").to_f if @node.has_power_tag("lat")
+      @lon = @node.power_tag("lon").to_f if @node.has_power_tag("lon")
+      @zoom = @node.power_tag("zoom").to_f if @node.has_power_tag("zoom")
+    
+    render :map
+  end
+
   def show
     @node = Node.find_map(params[:name], params[:date])
 

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -21,8 +21,6 @@ class MapController < ApplicationController
   end
 
   def map
-    @layersname = params[:layersname]
-
     return if current_user&.has_power_tag("lat").blank? || current_user&.has_power_tag("lon").blank?
 
     @user_lat = current_user.get_value_of_power_tag("lat").to_f

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -31,8 +31,7 @@
 
       var urlHash = urlMapHash();
 
-      <% if @node %>
-        // if there are location params in URL let them override
+        // if there are location params in URL let them override, otherwise save lat/lon/zoom from controller
         if (!urlHash.getUrlHashParameter('lat') || !urlHash.getUrlHashParameter('lon')) {
           <% if @lat && @lon %>
             urlHash.setUrlHashParameter('lat', <%= @lat %> + "");
@@ -42,30 +41,17 @@
             <% end %>
           <% end %>
         }
-      <% end %>
 
       const params = urlHash.getUrlHashParameters();
      
+      var lat = parseFloat(params.lat);
+      var lon = parseFloat(params.lon);
+      var zoom = parseFloat(params.zoom);
+
       const bounds = new L.LatLngBounds(
         new L.LatLng(84.67351257, -172.96875),
         new L.LatLng(-54.36775852, 178.59375)
       );
-
-      var user_lat = null;
-      var user_lon = null;
-      var profile_zoom = null;
-      <% if @user_lat && @user_lon %>
-        user_lat = "<%= @user_lat %>";
-        user_lon = "<%= @user_lon %>";
-        profile_zoom = 7;
-      <% end %>
-
-      var lat = params.lat || user_lat || 23;
-      var lon = params.lon || user_lon || 77;
-      var zoom = parseFloat(params.zoom) || profile_zoom || 3;
-      // These must be parsed after evaluating above or else 0 will not be displayed
-      lat = parseFloat(lat);
-      lon = parseFloat(lon);
 
       var map = L.map("map", {
         maxBounds: bounds,

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -73,18 +73,25 @@
         maxBoundsViscosity: 0.75
       }).setView([lat, lon], zoom);
 
+      updateLocationHash();
+      updateZoomHash();
+
       map.options.minZoom = 3;
 
-      map.on('moveend', function() {
+      map.on('moveend', updateLocationHash);
+
+      map.on('zoomend', updateZoomHash);
+
+      function updateLocationHash() {
         const center = map.getCenter();
         urlHash.setUrlHashParameter('lat', center.lat + "");
         urlHash.setUrlHashParameter('lon', center.lng + "");
-      })
+      }
 
-      map.on('zoomend', function() {
+      function updateZoomHash() {
         const zoom = map.getZoom();
         urlHash.setUrlHashParameter('zoom', zoom + "");
-      })
+      }
 
       <% if @layersname.nil? %>
         var layersname = ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'];
@@ -106,6 +113,5 @@
         hash: false,
         embed: true,
       }).addTo(map);
-
 
     </script>

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -21,13 +21,35 @@
     height: 80vh;
     background:rgba(255,255,255,0.5);
   }
+  .alert {
+    z-index: 600;
+  }
   </style>
 
-  <div id="map"></div>
+<% if flash[:alert] %><div class="alert alert-warning"><button type="button" class="close" data-dismiss="alert">×</button><%= raw flash[:alert] %></div><% end %>
+
+<div id="map"></div>
 
    <script>
 
       var urlHash = urlHash();
+
+      <% if @node %>
+        // if there are location params in URL let them override
+        if (!urlHash.getUrlHashParameter('lat') || !urlHash.getUrlHashParameter('lon')) {
+          <% if @lat && @lon %>
+            urlHash.setUrlHashParameter('lat', <%= @lat %> + "");
+            urlHash.setUrlHashParameter('lon', <%= @lon %> + "");
+            <% if @zoom %>
+              urlHash.setUrlHashParameter('zoom', <%= @zoom %> + "");
+            <% end %>
+          <% else %>
+            // Display error message, this page has no location
+            console.log("This wiki has no location.");
+          <% end %>
+        }
+      <% end %>
+
       const params = urlHash.getUrlHashParameters();
      
       const bounds = new L.LatLngBounds(

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -26,8 +26,6 @@
   }
   </style>
 
-<% if flash[:alert] %><div class="alert alert-warning"><button type="button" class="close" data-dismiss="alert">×</button><%= raw flash[:alert] %></div><% end %>
-
 <div id="map"></div>
 
    <script>
@@ -43,9 +41,6 @@
             <% if @zoom %>
               urlHash.setUrlHashParameter('zoom', <%= @zoom %> + "");
             <% end %>
-          <% else %>
-            // Display error message, this page has no location
-            console.log("This wiki has no location.");
           <% end %>
         }
       <% end %>

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_include_tag('/lib/urlhash/urlHash.js') %>
 <%= render :partial => "map/mapDependencies" %>
   
   <style>
@@ -30,7 +29,7 @@
 
    <script>
 
-      var urlHash = urlHash();
+      var urlHash = urlMapHash();
 
       <% if @node %>
         // if there are location params in URL let them override

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -41,14 +41,19 @@
   <% if @node && @node.has_power_tag('response') %>
     <%= render partial: 'sidebar/notes', locals: { notes: @node.responses, title: I18n.t('sidebar._related.responses_to_note'), node: @node } %>
   <% end %>
-    <% if @node  && @node.has_tag("place") && @node.lat && @node.lon %>
-      <%= render_top_map(@node.lat, @node.lon, @node.zoom) %>
+    <% if @node && @node.lat && @node.lon %>
+      <% if @node.has_tag("place") %>
+        <%= render_top_map(@node.lat, @node.lon, @node.zoom) %>
+      <% else %>
+        <%= render_map(@node.lat, @node.lon, @node.zoom) %>
+      <% end %>
       <%# Link to map %>
-      <center><a href="/map/wiki/<%= @node.slug_from_path %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a></center>
-    <% elsif @node && @node.lat && @node.lon %>
-      <%= render_map(@node.lat, @node.lon, @node.zoom) %>
-      <%# Link to map %>
-      <center><a href="/map/wiki/<%= @node.slug_from_path %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a></center>
+      <% zoom = @node.zoom ? @node.zoom : "" %>
+      <% url = "/map#" + zoom.to_s + "/" + @node.lat.to_s + "/" + @node.lon.to_s %>
+      <% if @node.type == "page" %>
+        <% url = "/map/" + @node.slug_from_path %>
+      <% end %>
+      <center><a href="<%= url %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a></center>
     <% elsif !@node.lat && !@node.lon %>
       <a class="btn btn-outline-secondary btn-location my-2"><i class="fa fa-map-marker" aria-hidden="true"></i> Add a location</a> 
     <% end %>

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -1,6 +1,6 @@
 <div class="col-lg-3 d-print-none">
   <div class="sidebar-panel">
-  <div id="sidebar">
+  <div id="sidebar" class="mb-3">
 
   <% cache('related_sidebar-feature', skip_digest: true) do %>
     <%= feature('sidebar') %>
@@ -41,17 +41,17 @@
   <% if @node && @node.has_power_tag('response') %>
     <%= render partial: 'sidebar/notes', locals: { notes: @node.responses, title: I18n.t('sidebar._related.responses_to_note'), node: @node } %>
   <% end %>
-  <% if @node && (@node.has_tag("place") || @node.has_power_tag("place")) && @node.lat && @node.lon %>
-    <%= render_top_map(@node.lat, @node.lon, @node.zoom) %>
-  <% elsif @node && @node.lat && @node.lon %>
-    <%= render_map(@node.lat, @node.lon, @node.zoom) %>
-  <% elsif !@node.lat && !@node.lon %>
-    <div id="map_template" style="position: relative; display: inline-block;">
-      <img src="https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/0/0/0.png" style="height:69px; width: 263px; position: relative; margin-right: -10px;">
-      <button class="btn btn-outline-secondary btn-lg" id="add_location" style="position: absolute; position: absolute;top: 19% ; left: 24% ;" type="button" name="button"><strong>Add location</strong></button>
-    </div>
-    <center><span>Learn about location <a href="https://publiclab.org/location-privacy">privacy</a></span></center>
-  <% end %>
+    <% if @node  && @node.has_tag("place") && @node.lat && @node.lon %>
+      <%= render_top_map(@node.lat, @node.lon, @node.zoom) %>
+      <%# Link to map %>
+      <center><a href="/map/wiki/<%= @node.slug_from_path %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a></center>
+    <% elsif @node && @node.lat && @node.lon %>
+      <%= render_map(@node.lat, @node.lon, @node.zoom) %>
+      <%# Link to map %>
+      <center><a href="/map/wiki/<%= @node.slug_from_path %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a></center>
+    <% elsif !@node.lat && !@node.lon %>
+      <a class="btn btn-outline-secondary btn-location my-2"><i class="fa fa-map-marker" aria-hidden="true"></i> Add a location</a> 
+    <% end %>
 
   <br style="clear:both;" />
 

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -53,9 +53,9 @@
       <% if @node.type == "page" %>
         <% url = "/map/" + @node.slug_from_path %>
       <% end %>
-      <center><a href="<%= url %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a></center>
+      <a href="<%= url %>" class="btn btn-outline-secondary btn-location mt-2"><i class="fa fa-map" aria-hidden="true"></i> View on a map</a>
     <% elsif !@node.lat && !@node.lon %>
-      <a class="btn btn-outline-secondary btn-location my-2"><i class="fa fa-map-marker" aria-hidden="true"></i> Add a location</a> 
+      <a class="blurred-location-input btn btn-outline-secondary btn-location my-2"><i class="fa fa-map-marker" aria-hidden="true"></i> Add a location</a> 
     <% end %>
 
   <br style="clear:both;" />
@@ -78,9 +78,3 @@
   </div>
 </div>
 <%= javascript_include_tag 'sidebar' %>
-
-<script type="text/javascript">
-  $('#add_location').on('click', function() {
-    $('.blurred-location-input').click();
-  })
-</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,6 +248,7 @@ Plots2::Application.routes.draw do
 
 
   get 'map' => 'map#map'
+  get 'map/wiki/:id' => 'map#wiki'
   get 'map/:layersname' => 'map#map'
   get 'maps' => 'map#index'
   get 'users/map' => 'users#map'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,8 +248,7 @@ Plots2::Application.routes.draw do
 
 
   get 'map' => 'map#map'
-  get 'map/wiki/:id' => 'map#wiki'
-  get 'map/:layersname' => 'map#map'
+  get 'map/:id' => 'map#wiki'
   get 'maps' => redirect('/map/')
   get 'users/map' => 'users#map'
   get 'maps/:id' => 'map#tag'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,7 @@ Plots2::Application.routes.draw do
   get 'map' => 'map#map'
   get 'map/wiki/:id' => 'map#wiki'
   get 'map/:layersname' => 'map#map'
-  get 'maps' => 'map#index'
+  get 'maps' => redirect('/map/')
   get 'users/map' => 'users#map'
   get 'maps/:id' => 'map#tag'
   get 'map/edit/:id' => 'map#edit'

--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -199,3 +199,21 @@ project2:
   tid: 28
   uid: 1
   nid: 7
+
+test4_lat:
+  tid: 29
+  uid: 1
+  nid: 7
+  date: <%= DateTime.now.to_i %>
+
+test4_lon:
+  tid: 30
+  uid: 1
+  nid: 7
+  date: <%= DateTime.now.to_i %>
+
+test4_zoom:
+  tid: 31
+  uid: 1
+  nid: 7
+  date: <%= DateTime.now.to_i %>

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -111,3 +111,15 @@ place:
 project:
   tid: 28
   name: project
+
+test4_lat:
+  tid: 29
+  name: lat:41.87
+
+test4_lon:
+  tid: 30
+  name: lon:-87.64
+
+test4_zoom:
+  tid: 31
+  name: zoom:13

--- a/test/fixtures/user_tags.yml
+++ b/test/fixtures/user_tags.yml
@@ -386,7 +386,7 @@ lat2:
 lon2:
   id: 28
   uid: 2
-  value: lon:18
+  value: lon:0
 
 zoom2:
   id: 29

--- a/test/fixtures/user_tags.yml
+++ b/test/fixtures/user_tags.yml
@@ -386,7 +386,7 @@ lat2:
 lon2:
   id: 28
   uid: 2
-  value: lon:0
+  value: lon:15
 
 zoom2:
   id: 29

--- a/test/fixtures/user_tags.yml
+++ b/test/fixtures/user_tags.yml
@@ -367,3 +367,28 @@ notification_tag2:
   id: 24
   uid: 14
   value: notifications:all
+
+zoom:
+  id: 25
+  uid: 1
+  value: zoom:10
+
+blurred:
+  id: 26
+  uid: 1
+  value: blurred:true
+
+lat2:
+  id: 27
+  uid: 2
+  value: lat:59
+
+lon2:
+  id: 28
+  uid: 2
+  value: lon:18
+
+zoom2:
+  id: 29
+  uid: 2
+  value: zoom:10

--- a/test/functional/map_controller_test.rb
+++ b/test/functional/map_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class MapControllerTest < ActionController::TestCase
+  def setup
+    activate_authlogic
+  end
+
   test 'should get index' do
     get :index
     assert_response :success
@@ -13,8 +17,46 @@ class MapControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'renders map for user who has a location' do
+    UserSession.create(users(:jeff))
+
+    get :map
+
+    assert_response :success
+    assert_equal [59, 15, 10], [assigns(:lat), assigns(:lon), assigns(:zoom)]
+  end
+
+  test 'renders map for user who does not have a location' do
+    UserSession.create(users(:moderator))
+    
+    get :map
+
+    assert_response :success
+    assert_equal [0, 0, 3], [assigns(:lat), assigns(:lon), assigns(:zoom)]
+  end
+
+  test 'renders wiki map that has location' do
+    node = nodes(:place)
+    get :wiki, params: { id: node.slug }
+
+    assert_response :success
+    assert_equal [41.87, -87.64, 13], [assigns(:lat), assigns(:lon), assigns(:zoom)]
+  end
+
+  test 'redirects wiki map that does not have location' do
+    node = nodes(:organizers)
+    get :wiki, params: { id: node.slug }
+
+    assert_redirected_to(controller: "map", action: "map")
+  end
+
+  test 'redirects wiki map when wiki does not exist' do
+    get :wiki, params: { id: "nil" }
+
+    assert_redirected_to(controller: "map", action: "map")
+  end
+
   test 'should update without duplicating lat/lon tags' do
-    activate_authlogic
     UserSession.create(users(:admin))
     map = nodes(:map)
     map.add_tag('lat:1', users(:admin))

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -373,7 +373,7 @@ class TagControllerTest < ActionController::TestCase
     get :show,
         params: {
           node_type: 'contributors',
-          id: Tag.last.name
+          id: 'blog'
         }
 
     assert :success

--- a/test/integration/public_pages_test.rb
+++ b/test/integration/public_pages_test.rb
@@ -17,8 +17,8 @@ class PublicPagesTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'browse /maps' do
-    get '/maps'
+  test 'browse /map' do
+    get '/map'
     assert_response :success
   end
 

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class MapTest < ApplicationSystemTestCase
-  Capybara.default_max_wait_time = 10
+  Capybara.default_max_wait_time = 60
 
   test 'show map for wiki with location' do
 

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class MapTest < ApplicationSystemTestCase
-  Capybara.default_max_wait_time = 120
+  Capybara.default_max_wait_time = 90
 
   test 'correct url hash for wiki map' do
     visit '/map/chicago'

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -3,35 +3,33 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class MapTest < ApplicationSystemTestCase
-  def setup
-    Capybara.default_max_wait_time = 60
-  end
+  Capybara.default_max_wait_time = 60
 
-  test 'correct url hash for wiki map' do
-    visit '/map/chicago'
+  # test 'correct url hash for wiki map' do
+  #   visit '/map/chicago'
 
-    # check that the url hash is correct
-    assert_equal("#13/41.87/-87.64", page.evaluate_script("window.location.hash"))
+  #   # check that the url hash is correct
+  #   assert_equal("#13/41.87/-87.64", page.evaluate_script("window.location.hash"))
     
-  end
+  # end
 
-  test 'show map by hash location' do
-    visit '/map#9/-25/-13'
+  # test 'show map by hash location' do
+  #   visit '/map#9/-25/-13'
 
-    assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
-    assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
-    assert_equal(9, page.evaluate_script("map.getZoom()"))
+  #   assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
+  #   assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
+  #   assert_equal(9, page.evaluate_script("map.getZoom()"))
 
-  end
+  # end
 
-  test 'url hash updates when map panned' do
-    visit '/map'
+  # test 'url hash updates when map panned' do
+  #   visit '/map'
 
-    page.execute_script("map.setView([13, 60], 15)")
+  #   page.execute_script("map.setView([13, 60], 15)")
 
-    # check that the url hash is correct
-    assert_equal("#15/13/60", page.evaluate_script("window.location.hash"))
+  #   # check that the url hash is correct
+  #   assert_equal("#15/13/60", page.evaluate_script("window.location.hash"))
     
-  end
+  # end
 
 end

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -5,34 +5,6 @@ require "application_system_test_case"
 class MapTest < ApplicationSystemTestCase
   Capybara.default_max_wait_time = 60
 
-  # test 'show map for wiki with location' do
-
-  #   visit "/map/chicago"
-
-  #   assert_equal("41.87", page.evaluate_script("map.getCenter().lat.toFixed(2)"))
-  #   assert_equal("-87.64", page.evaluate_script("map.getCenter().lng.toFixed(2)"))
-  #   assert_equal(13, page.evaluate_script("map.getZoom()"))
-
-  # end
-
-  # test 'show map for wiki without location' do
-  #   visit '/'
-
-  #   click_on 'Login'
-
-  #   fill_in("username-login", with: "jeff")
-  #   fill_in("password-signup", with: "secretive")
-  #   click_on "Log in"
-
-  #   visit "/map/organizers"
-
-  #   # check that the map is correctly centered - should show user's location
-  #   assert_equal(59, page.evaluate_script("Math.round(map.getCenter().lat)"))
-  #   assert_equal(0, page.evaluate_script("Math.round(map.getCenter().lng)"))
-  #   assert_equal(10, page.evaluate_script("map.getZoom()"))
-
-  # end
-
   test 'correct url hash for wiki map' do
     visit '/map/chicago'
 

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -13,14 +13,16 @@ class MapTest < ApplicationSystemTestCase
     
   # end
 
-  # test 'show map by hash location' do
-  #   visit '/map#9/-25/-13'
+  test 'show map by hash location' do
+    visit '/map#9/-25/-13'
 
-  #   assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
-  #   assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
-  #   assert_equal(9, page.evaluate_script("map.getZoom()"))
+    lat = page.evaluate_script("Math.round(map.getCenter().lat)")
+    assert_equal(-25, lat)
+    # assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
+    # assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
+    # assert_equal(9, page.evaluate_script("map.getZoom()"))
 
-  # end
+  end
 
   # test 'url hash updates when map panned' do
   #   visit '/map'

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class MapTest < ApplicationSystemTestCase
-  Capybara.default_max_wait_time = 60
+  Capybara.default_max_wait_time = 120
 
   test 'correct url hash for wiki map' do
     visit '/map/chicago'
@@ -13,25 +13,25 @@ class MapTest < ApplicationSystemTestCase
     
   end
 
-  # test 'show map by hash location' do
-  #   visit '/map#9/-25/-13'
+  test 'show map by hash location' do
+    visit '/map#9/-25/-13'
 
-  #   lat = page.evaluate_script("Math.round(map.getCenter().lat)")
-  #   assert_equal(-25, lat)
-  #   assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
-  #   assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
-  #   assert_equal(9, page.evaluate_script("map.getZoom()"))
+    lat = page.evaluate_script("Math.round(map.getCenter().lat)")
+    assert_equal(-25, lat)
+    assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
+    assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
+    assert_equal(9, page.evaluate_script("map.getZoom()"))
 
-  # end
+  end
 
-  # test 'url hash updates when map panned' do
-  #   visit '/map'
+  test 'url hash updates when map panned' do
+    visit '/map'
 
-  #   page.execute_script("map.setView([13, 60], 15)")
+    page.execute_script("map.setView([13, 60], 15)")
 
-  #   # check that the url hash is correct
-  #   assert_equal("#15/13/60", page.evaluate_script("window.location.hash"))
+    # check that the url hash is correct
+    assert_equal("#15/13/60", page.evaluate_script("window.location.hash"))
     
-  # end
+  end
 
 end

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+require "application_system_test_case"
+# https://guides.rubyonrails.org/testing.html#implementing-a-system-test
+
+class MapTest < ApplicationSystemTestCase
+  Capybara.default_max_wait_time = 10
+
+  test 'show map for wiki with location' do
+
+    visit "/map/chicago"
+
+    # check that the map is correctly centered
+    assert_equal("41.87", page.evaluate_script("map.getCenter().lat.toFixed(2)"))
+    assert_equal("-87.64", page.evaluate_script("map.getCenter().lng.toFixed(2)"))
+    assert_equal(13, page.evaluate_script("map.getZoom()"))
+
+  end
+
+  test 'show map for wiki without location' do
+    visit '/'
+
+    click_on 'Login'
+
+    fill_in("username-login", with: "jeff")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
+
+    visit "/map/organizers"
+
+    # check that the map is correctly centered - should show user's location
+    assert_equal(59, page.evaluate_script("Math.round(map.getCenter().lat)"))
+    assert_equal(18, page.evaluate_script("Math.round(map.getCenter().lng)"))
+    assert_equal(10, page.evaluate_script("map.getZoom()"))
+
+  end
+
+  test 'correct url hash for wiki map' do
+    visit '/map/chicago'
+
+    # check that the url hash is correct
+    assert_equal("#13/41.87/-87.64", page.evaluate_script("window.location.hash"))
+    
+  end
+
+  test 'show map by hash location' do
+    visit '/map#9/-25/-13'
+
+    assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
+    assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
+    assert_equal(9, page.evaluate_script("map.getZoom()"))
+
+    take_screenshot
+
+  end
+
+  test 'url hash updates when map panned' do
+    visit '/map'
+
+    page.execute_script("map.setView([13, 60], 15)")
+
+    # check that the url hash is correct
+    assert_equal("#15/13/60", page.evaluate_script("window.location.hash"))
+    
+  end
+
+
+end

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -3,7 +3,9 @@ require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
 class MapTest < ApplicationSystemTestCase
-  Capybara.default_max_wait_time = 60
+  def setup
+    Capybara.default_max_wait_time = 60
+  end
 
   test 'correct url hash for wiki map' do
     visit '/map/chicago'

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -5,24 +5,24 @@ require "application_system_test_case"
 class MapTest < ApplicationSystemTestCase
   Capybara.default_max_wait_time = 60
 
-  # test 'correct url hash for wiki map' do
-  #   visit '/map/chicago'
+  test 'correct url hash for wiki map' do
+    visit '/map/chicago'
 
-  #   # check that the url hash is correct
-  #   assert_equal("#13/41.87/-87.64", page.evaluate_script("window.location.hash"))
+    # check that the url hash is correct
+    assert_equal("#13/41.87/-87.64", page.evaluate_script("window.location.hash"))
     
-  # end
-
-  test 'show map by hash location' do
-    visit '/map#9/-25/-13'
-
-    lat = page.evaluate_script("Math.round(map.getCenter().lat)")
-    assert_equal(-25, lat)
-    # assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
-    # assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
-    # assert_equal(9, page.evaluate_script("map.getZoom()"))
-
   end
+
+  # test 'show map by hash location' do
+  #   visit '/map#9/-25/-13'
+
+  #   lat = page.evaluate_script("Math.round(map.getCenter().lat)")
+  #   assert_equal(-25, lat)
+  #   assert_equal(-25, page.evaluate_script("Math.round(map.getCenter().lat)"))
+  #   assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
+  #   assert_equal(9, page.evaluate_script("map.getZoom()"))
+
+  # end
 
   # test 'url hash updates when map panned' do
   #   visit '/map'

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -5,34 +5,33 @@ require "application_system_test_case"
 class MapTest < ApplicationSystemTestCase
   Capybara.default_max_wait_time = 60
 
-  test 'show map for wiki with location' do
+  # test 'show map for wiki with location' do
 
-    visit "/map/chicago"
+  #   visit "/map/chicago"
 
-    # check that the map is correctly centered
-    assert_equal("41.87", page.evaluate_script("map.getCenter().lat.toFixed(2)"))
-    assert_equal("-87.64", page.evaluate_script("map.getCenter().lng.toFixed(2)"))
-    assert_equal(13, page.evaluate_script("map.getZoom()"))
+  #   assert_equal("41.87", page.evaluate_script("map.getCenter().lat.toFixed(2)"))
+  #   assert_equal("-87.64", page.evaluate_script("map.getCenter().lng.toFixed(2)"))
+  #   assert_equal(13, page.evaluate_script("map.getZoom()"))
 
-  end
+  # end
 
-  test 'show map for wiki without location' do
-    visit '/'
+  # test 'show map for wiki without location' do
+  #   visit '/'
 
-    click_on 'Login'
+  #   click_on 'Login'
 
-    fill_in("username-login", with: "jeff")
-    fill_in("password-signup", with: "secretive")
-    click_on "Log in"
+  #   fill_in("username-login", with: "jeff")
+  #   fill_in("password-signup", with: "secretive")
+  #   click_on "Log in"
 
-    visit "/map/organizers"
+  #   visit "/map/organizers"
 
-    # check that the map is correctly centered - should show user's location
-    assert_equal(59, page.evaluate_script("Math.round(map.getCenter().lat)"))
-    assert_equal(0, page.evaluate_script("Math.round(map.getCenter().lng)"))
-    assert_equal(10, page.evaluate_script("map.getZoom()"))
+  #   # check that the map is correctly centered - should show user's location
+  #   assert_equal(59, page.evaluate_script("Math.round(map.getCenter().lat)"))
+  #   assert_equal(0, page.evaluate_script("Math.round(map.getCenter().lng)"))
+  #   assert_equal(10, page.evaluate_script("map.getZoom()"))
 
-  end
+  # end
 
   test 'correct url hash for wiki map' do
     visit '/map/chicago'
@@ -49,8 +48,6 @@ class MapTest < ApplicationSystemTestCase
     assert_equal(-13, page.evaluate_script("Math.round(map.getCenter().lng)"))
     assert_equal(9, page.evaluate_script("map.getZoom()"))
 
-    take_screenshot
-
   end
 
   test 'url hash updates when map panned' do
@@ -62,6 +59,5 @@ class MapTest < ApplicationSystemTestCase
     assert_equal("#15/13/60", page.evaluate_script("window.location.hash"))
     
   end
-
 
 end

--- a/test/system/map_test.rb
+++ b/test/system/map_test.rb
@@ -29,7 +29,7 @@ class MapTest < ApplicationSystemTestCase
 
     # check that the map is correctly centered - should show user's location
     assert_equal(59, page.evaluate_script("Math.round(map.getCenter().lat)"))
-    assert_equal(18, page.evaluate_script("Math.round(map.getCenter().lng)"))
+    assert_equal(0, page.evaluate_script("Math.round(map.getCenter().lng)"))
     assert_equal(10, page.evaluate_script("map.getZoom()"))
 
   end

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -219,9 +219,9 @@ class ScreenshotsTest < ApplicationSystemTestCase
     take_screenshot
   end
   
-  test 'maps' do
-    visit '/map/chicago'
-    take_screenshot
-  end
+  # test 'maps' do
+  #   visit '/map/chicago'
+  #   take_screenshot
+  # end
 
 end

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -218,5 +218,10 @@ class ScreenshotsTest < ApplicationSystemTestCase
     visit node.path
     take_screenshot
   end
+  
+  test 'maps' do
+    visit '/map/chicago'
+    take_screenshot
+  end
 
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@ cssstyle@^2.0.0:
   dependencies:
     cssom "~0.3.6"
 
-csv-parse@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-2.5.0.tgz#65748997ecc3719c594622db1b9ea0e2eb7d56bb"
-  integrity sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA==
+csv-parse@^4.6.5:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.8.3.tgz#9f9b66c3e7e30409dba3d08ecd89eaa04b320659"
+  integrity sha512-0GPxubzYzSn08lhNTWDCkcDKn8krmw0WuscqB2RrW6sugGGskbwaaEz7PCFFwbQ0phNGTTieiyfzzu3S/jZZ7Q==
 
 ctype@0.5.3:
   version "0.5.3"
@@ -1234,9 +1234,9 @@ cwise-compiler@^1.0.0, cwise-compiler@^1.1.2:
     uniq "^1.0.0"
 
 cytoscape@^3.12.1:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.12.1.tgz#48fe85481ba7ba4c3b77396426b6b9cc27fe2bb4"
-  integrity sha512-/TIrNXcWZdjTgB2BK2oJfroO8IAM6XSu9lCGEe3boJ68KHqH0fbSrc0tIOfibkzkMfUhFLNed9tcaoYdjxOnTQ==
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.13.0.tgz#490d06c237cf4ecefb7f86acb6d9a489a23156c4"
+  integrity sha512-1pKd6DUyprUmz/ADPI3aKFbZceqeKoVwYBr3zBplzHOaffF311z6Zo5qWqXK12t4JRdTOvFA4kwt8T/QVIrU1Q==
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"
@@ -2464,9 +2464,9 @@ gpu-mock.js@^1.1.1:
   integrity sha512-BmoRk9nbMaxkrwzTJp4M0iuwIbzNEXt6tlBZ5+ZYzaGH9VWu5Nhn1Q1CBusCam3d8u3FfVEFf3Ueo8DocUCbUw==
 
 gpu.js@^2.0.0-rc.12:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/gpu.js/-/gpu.js-2.4.6.tgz#a625d2d24e79ad5be81dd99dff28880edad65882"
-  integrity sha512-nX2buxg6WTZPBeme6nzeWNq/wK4j3YtmkKkMcD2CmiBnRc9yWQunHk177HKSi3e7mLhJHMGjZIYprsn3xS3u4Q==
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/gpu.js/-/gpu.js-2.4.8.tgz#59e980edfdb622b8e5f85ace012214b7d0525911"
+  integrity sha512-V4CAZIR+kV6enLVPGoeZdb4lK4FGGuolDDYNBMAlNzrfDN7OJjl2V9we6bKDTKhV/gwsYmivs0x22qo/Q0zHzA==
   dependencies:
     acorn "^7.1.0"
     gl "^4.4.0"
@@ -2629,9 +2629,9 @@ gtoken@^2.3.2:
     pify "^4.0.0"
 
 handlebars@^4.0.1:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
-  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.6.0.tgz#33af6c3eda930d7a924f5d8f1c6d8edc3180512e"
+  integrity sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -3524,16 +3524,7 @@ leaflet-blurred-location@^1.2.5, leaflet-blurred-location@^1.5.1:
 
 "leaflet-blurred-location@git://github.com/publiclab/leaflet-blurred-location#main":
   version "1.5.1"
-  uid "550b8ac78144b32e0e01a0dba242a09009f155c8"
   resolved "git://github.com/publiclab/leaflet-blurred-location#550b8ac78144b32e0e01a0dba242a09009f155c8"
-  dependencies:
-    haversine-distance "^1.1.4"
-    jquery "^3.2.1"
-    leaflet "^1.3.3"
-
-"leaflet-blurred-location@git://github.com/publiclab/leaflet-blurred-location.git#main":
-  version "1.5.1"
-  resolved "git://github.com/publiclab/leaflet-blurred-location.git#550b8ac78144b32e0e01a0dba242a09009f155c8"
   dependencies:
     haversine-distance "^1.1.4"
     jquery "^3.2.1"
@@ -3546,7 +3537,7 @@ leaflet-environmental-layers@^2.1.7:
   dependencies:
     jquery "^3.3.1"
     leaflet "^1.3.1"
-    leaflet-blurred-location "git://github.com/publiclab/leaflet-blurred-location.git#main"
+    leaflet-blurred-location "git://github.com/publiclab/leaflet-blurred-location#main"
     leaflet-fullhash "github:sagarpreet-chadha/leaflet-fullHash"
     leaflet-google-places-autocomplete "0.0.8"
     leaflet-heatmap "1.0.0"
@@ -5041,9 +5032,9 @@ resolve@1.1.x:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@^1.1.7:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.1.tgz#9e018c540fcf0c427d678b9931cbf45e984bcaff"
-  integrity sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
+  integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
   dependencies:
     path-parse "^1.0.6"
 
@@ -5259,13 +5250,13 @@ short-code-forms@jywarren/short-code-forms#~0.0.1:
   resolved "https://codeload.github.com/jywarren/short-code-forms/tar.gz/cb7a07452fce13b0ff780c1991bfe8e1eddf39e3"
 
 sifter@^0.5.1:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/sifter/-/sifter-0.5.3.tgz#5e6507fe8c114b2b28d90b6bf4e5b636e611e48b"
-  integrity sha1-XmUH/owRSyso2Qtr9OW2NuYR5Is=
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/sifter/-/sifter-0.5.4.tgz#3cb9e514889edfc887d8d87a355841b01ebdd1ab"
+  integrity sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==
   dependencies:
     async "^2.6.0"
     cardinal "^1.0.0"
-    csv-parse "^2.0.0"
+    csv-parse "^4.6.5"
     humanize "^0.0.9"
     optimist "^0.6.1"
 
@@ -5856,9 +5847,9 @@ uc.micro@~0.1.0:
   integrity sha1-7aESHR/blhVO1v3oJHu724MzCMo=
 
 uglify-js@^3.1.4:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.3.tgz#f918fce9182f466d5140f24bb0ff35c2d32dcc6a"
-  integrity sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.4.tgz#e6d83a1aa32ff448bd1679359ab13d8db0fe0743"
+  integrity sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"
@@ -5908,9 +5899,9 @@ underscore@1.4.4, underscore@1.4.x:
   integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
 underscore@>=1.8.3:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.2.tgz#0c8d6f536d6f378a5af264a72f7bec50feb7cf2f"
+  integrity sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==
 
 underscore@~1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Fixes #7060  (<=== Add issue number here)

- Created a route /map/wiki/:wikislug - I couldn't use /map/:wikislug because we already had a route with that pattern.

- If Wiki exists then it is checking for location info to display:

![🎈 Public Lab: Wiki - Google Chrome_007](https://user-images.githubusercontent.com/49460529/71598498-0962d100-2b15-11ea-92c0-f7feaec7f5ac.png)


- If the map is panned while looking at a wiki page map then it displays the current location in the hash so it can be copied and pasted. If there is location info in the URL hash it will override the display of the wiki's saved location.

![🎈 Public Lab: Wiki - Google Chrome_010](https://user-images.githubusercontent.com/49460529/71598596-75453980-2b15-11ea-9aa0-8e2f02315fec.png)


- If Wiki exists but does not have location information this is displayed:

![🎈 Public Lab: Wiki - Google Chrome_008](https://user-images.githubusercontent.com/49460529/71598504-1253a280-2b15-11ea-82d8-ccc3b71e346e.png)


- If wiki does not exist user is redirected to the standard /map/ and a "not found" message is shown:

![🎈 Public Lab: Map - Google Chrome_009](https://user-images.githubusercontent.com/49460529/71598509-17b0ed00-2b15-11ea-80a6-f2f32eab45df.png)

