### PR TITLE
Fix alerts for login flow

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -286,7 +286,6 @@ class AdminController < ApplicationController
     user = User.find params[:id]
     if logged_in_as(['admin', 'moderator'])
       user.ban
-      flash[:notice] = 'The user has been banned.'
     else
       flash[:error] = 'Only moderators can ban other users.'
     end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -57,6 +57,9 @@ class UserSessionsController < ApplicationController
         if @user.status == 0
           flash[:error] = "You have been banned!"
           redirect_to root_url
+        elsif @user.status == 5
+          flash[:error] = I18n.t('user_sessions_controller.user_has_been_moderated', username: @user.username).html_safe
+          redirect_to '/'
         else
           @user_session = UserSession.create(@identity.user)
           if session[:openid_return_to] # for openid login, redirects back to openid auth process

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -54,13 +54,18 @@ class UserSessionsController < ApplicationController
         # The identity we found had a user associated with it so let's
         # just log them in here
         @user = @identity.user
-        @user_session = UserSession.create(@identity.user)
-        if session[:openid_return_to] # for openid login, redirects back to openid auth process
-          return_to = session[:openid_return_to]
-          session[:openid_return_to] = nil
-          redirect_to return_to + hash_params
+        if @user.status == 0
+          flash[:error] = "You have been banned!"
+          redirect_to root_url
         else
-          redirect_to return_to + hash_params, notice: "Signed in!"
+          @user_session = UserSession.create(@identity.user)
+          if session[:openid_return_to] # for openid login, redirects back to openid auth process
+            return_to = session[:openid_return_to]
+            session[:openid_return_to] = nil
+            redirect_to return_to + hash_params
+          else
+            redirect_to return_to + hash_params, notice: I18n.t('user_sessions_controller.logged_in')
+          end
         end
       else # identity does not exist so we need to either create a user with identity OR link identity to existing user
         if User.where(email: auth["info"]["email"]).empty?

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -54,7 +54,7 @@ class UserSessionsController < ApplicationController
         # The identity we found had a user associated with it so let's
         # just log them in here
         @user = @identity.user
-        if @user.status == 0
+        if @user.status.zero?
           flash[:error] = "You have been banned!"
           redirect_to root_url
         elsif @user.status == 5

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -54,7 +54,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'sign up and login via provider alternative flow for google' do
@@ -70,7 +70,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
 
@@ -111,7 +111,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'sign up and login via provider alternative flow for github' do
@@ -127,7 +127,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'login user with an email and then connect github provider' do
@@ -168,7 +168,7 @@ class UserSessionsControllerTest < ActionController::TestCase
       assert_equal "Successfully logged out.",  flash[:notice]
       #auth hash is present so login via a provider
       post :create
-      assert_equal "Signed in!",  flash[:notice]
+      assert_equal "Successfully logged in.",  flash[:notice]
     end
 
     test 'sign up and login via provider alternative flow for twitter' do
@@ -184,7 +184,7 @@ class UserSessionsControllerTest < ActionController::TestCase
       assert_equal "Successfully logged out.",  flash[:notice]
       #auth hash is present so login via a provider
       post :create
-      assert_equal "Signed in!",  flash[:notice]
+      assert_equal "Successfully logged in.",  flash[:notice]
     end
 
     test 'login user with an email and then contwitter provider' do
@@ -224,7 +224,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'sign up and login via provider alternative flow for facebook' do
@@ -240,7 +240,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'login user with an email and then connect facebook provider' do


### PR DESCRIPTION
Fixes #4691

Hey! I fixed the problems you exposed in the video:

1. Logging in as a banned user with oauth was flashing "User was logged in." although he has been banned and does not log in. I fixed this by adding a conditional statement to check whether or not the user is banned or moderated. If he is, it flashes the corresponding message instead.
2. When a moderator banned a user. two flashes would display saying "User has been banned". The first one is in the `users#profile` route: 
https://github.com/publiclab/plots2/blob/fd5683d47ba235ac38e0e16a0d8675b53a1f289/app/controllers/users_controller.rb#L221.
and in the `admins#ban` route:
https://github.com/publiclab/plots2/blob/fd5683d47ba235abc38e0e16a0d8675b53a1f289/app/controllers/admin_controller.rb#L289.
I removed the second one to fix this duplication.
3. In the video, I also noticed when the user logs in through oauth, the message `Signed in!` is displayed instead of the `locales` version: ` I18n.t('user_sessions_controller.logged_in')`. I replaced the message with the translatable version.

What do you think?
@SidharthBansal has allowed me to work on other tasks and submit pull request for them but I cannot claim the task yet. I will claim it when I can! :+1: