### PR TITLE
Removed duplicate ban message

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -286,7 +286,6 @@ class AdminController < ApplicationController
     user = User.find params[:id]
     if logged_in_as(['admin', 'moderator'])
       user.ban
-      flash[:notice] = 'The user has been banned.'
     else
       flash[:error] = 'Only moderators can ban other users.'
     end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -77,6 +77,17 @@ class UsersControllerTest < ActionController::TestCase
 
   end
 
+  test "banning user should display correct flash message" do
+    UserSession.create(users(:admin))
+    banned = User.find(2)
+    banned.ban
+    get :profile, params: { id: banned.username }
+    # checks flash
+    assert_equal flash[:error], I18n.t('users_controller.user_has_been_banned')
+    # checks duplicated flash is not present
+    assert_equal flash[:notice], nil
+  end
+  
   test 'generate user reset key' do
     user = users(:jeff)
     assert_nil user.reset_key


### PR DESCRIPTION
Partially fixes #4691

When a moderator banned a user. two flashes would display saying "User has been banned". The first one is in the `users#profile` route: 
https://github.com/publiclab/plots2/blob/fd5683d47ba235ac38e0e16a0d8675b53a1f289/app/controllers/users_controller.rb#L221.
and in the `admins#ban` route:
https://github.com/publiclab/plots2/blob/fd5683d47ba235abc38e0e16a0d8675b53a1f289/app/controllers/admin_controller.rb#L289.
I removed the second one to fix this duplication.

Thanks! :+1:
