### PR TITLE
Uniformised flash messages for sign in

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -60,7 +60,7 @@ class UserSessionsController < ApplicationController
           session[:openid_return_to] = nil
           redirect_to return_to + hash_params
         else
-          redirect_to return_to + hash_params, notice: "Signed in!"
+          redirect_to return_to + hash_params, notice: I18n.t('user_sessions_controller.logged_in')
         end
       else # identity does not exist so we need to either create a user with identity OR link identity to existing user
         if User.where(email: auth["info"]["email"]).empty?

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -54,7 +54,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'sign up and login via provider alternative flow for google' do
@@ -70,7 +70,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
 
@@ -111,7 +111,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'sign up and login via provider alternative flow for github' do
@@ -127,7 +127,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'login user with an email and then connect github provider' do
@@ -168,7 +168,7 @@ class UserSessionsControllerTest < ActionController::TestCase
       assert_equal "Successfully logged out.",  flash[:notice]
       #auth hash is present so login via a provider
       post :create
-      assert_equal "Signed in!",  flash[:notice]
+      assert_equal "Successfully logged in.",  flash[:notice]
     end
 
     test 'sign up and login via provider alternative flow for twitter' do
@@ -184,7 +184,7 @@ class UserSessionsControllerTest < ActionController::TestCase
       assert_equal "Successfully logged out.",  flash[:notice]
       #auth hash is present so login via a provider
       post :create
-      assert_equal "Signed in!",  flash[:notice]
+      assert_equal "Successfully logged in.",  flash[:notice]
     end
 
     test 'login user with an email and then contwitter provider' do
@@ -224,7 +224,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'sign up and login via provider alternative flow for facebook' do
@@ -240,7 +240,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
     #auth hash is present so login via a provider
     post :create
-    assert_equal "Signed in!",  flash[:notice]
+    assert_equal "Successfully logged in.",  flash[:notice]
   end
 
   test 'login user with an email and then connect facebook provider' do


### PR DESCRIPTION
Partially fixes #4691 

In the video of the issue, I noticed when the user logs in through oauth, the message `Signed in!` is displayed instead of the `locales` version: ` I18n.t('user_sessions_controller.logged_in')`. I replaced the message with the translatable version and fixed the tests.
Thanks!
