### PR TITLE
Add zoom override to maps in sidebar and top of page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,12 +90,12 @@ module ApplicationHelper
   end
 
   # we should move this to the Node model:
-  def render_map(lat, lon)
-    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, top_map: false }
+  def render_map(lat, lon, zoom = '')
+    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, zoom: zoom, top_map: false }
   end
 
-  def render_top_map(lat, lon)
-    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, top_map: true }
+  def render_top_map(lat, lon, zoom = '')
+    render partial: 'map/leaflet', locals: { lat: lat, lon: lon, zoom: zoom, top_map: true }
   end
 
   # we should move this to the Comment model:

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -1,5 +1,6 @@
 <%= render :partial => "map/mapDependencies" %>
 <% top_map = top_map || false %>
+<% zoom = zoom || lat.to_s.length.to_i + 6 %>
 <% unique_id = rand(1000) %>
 
 <% if top_map == true %>
@@ -21,23 +22,15 @@
       var map<%= unique_id %> = L.map('top_map' , {
         maxBounds: bounds ,
         maxBoundsViscosity: 0.75
-      }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
+      }).setView([<%= lat %>,<%= lon %>], <%= zoom %>);
     <% else %>
       var map<%= unique_id %> = L.map('map<%= unique_id %>' , {
         maxBounds: bounds ,
         maxBoundsViscosity: 0.75
-      }).setView([<%= lat %>,<%= lon %>], <%= lat.to_s.length.to_i %> + 6);
+      }).setView([<%= lat %>,<%= lon %>], <%= zoom %>);
     <% end %>
 
     var markers_hash<%= unique_id %> = new Map() ;
-    var map_lat = <%= lat %> ;
-    var map_lon = <%= lon %> ;
-
-     window.setTimeout(function(){
-
-        map<%= unique_id %>.setZoom(<%= lat.to_s.length.to_i %> + 6) ; 
-    
-     }, 3500);
 
     setupLEL(map<%= unique_id %> , 0) ;
 

--- a/app/views/sidebar/_related.html.erb
+++ b/app/views/sidebar/_related.html.erb
@@ -42,9 +42,9 @@
     <%= render partial: 'sidebar/notes', locals: { notes: @node.responses, title: I18n.t('sidebar._related.responses_to_note'), node: @node } %>
   <% end %>
   <% if @node  && @node.has_tag("place") && @node.lat && @node.lon %>
-    <%= render_top_map(@node.lat, @node.lon) %>
+    <%= render_top_map(@node.lat, @node.lon, @node.zoom) %>
   <% elsif @node && @node.lat && @node.lon %>
-    <%= render_map(@node.lat, @node.lon) %>
+    <%= render_map(@node.lat, @node.lon, @node.zoom) %>
   <% elsif !@node.lat && !@node.lon %>
     <div id="map_template" style="position: relative; display: inline-block;">
       <img src="https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/0/0/0.png" style="height:69px; width: 263px; position: relative; margin-right: -10px;">


### PR DESCRIPTION
Fixes #7077 (<=== Add issue number here)

- This adds in the zoom tag being passed to the `map/leaflet` partial.
- If the contents of that tag is empty then it uses the default `lat.to_s.length.to_i + 6` as it was using before.

Wiki page that has lat and lon but no zoom tag:

![FireShot Capture 152 - 🎈 Public Lab_ Software Outreach - localhost](https://user-images.githubusercontent.com/49460529/71644591-e5c89380-2c98-11ea-8951-11cbbe2dff8b.png)

Wiki page that has lat, lon and zoom tags:

![FireShot Capture 153 - 🎈 Public Lab_ Media - localhost](https://user-images.githubusercontent.com/49460529/71644582-c6ca0180-2c98-11ea-9af3-62e592c44c2f.png)

Wiki page that has lat, lon, zoom and place tags:

![FireShot Capture 151 - 🎈 Public Lab_ Events - localhost](https://user-images.githubusercontent.com/49460529/71644596-f547dc80-2c98-11ea-947e-41bde3bfdc1e.png)

Note that has lat, lon and zoom tags:

![FireShot Capture 154 - 🎈 Public Lab_ Notes on England - localhost](https://user-images.githubusercontent.com/49460529/71644603-0bee3380-2c99-11ea-8fed-0f39d6770735.png)