### PR TITLE
Fix map on profile and add check for zoom tag

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -210,9 +210,11 @@ class UsersController < ApplicationController
         @count_activities_attempted = Tag.tagged_nodes_by_author("replication:*", @profile_user).count
         @map_lat = nil
         @map_lon = nil
+        @map_zoom = nil
         if @profile_user.has_power_tag("lat") && @profile_user.has_power_tag("lon")
           @map_lat = @profile_user.get_value_of_power_tag("lat").to_f
           @map_lon = @profile_user.get_value_of_power_tag("lon").to_f
+          @map_zoom = @profile_user.get_value_of_power_tag("zoom").to_i if @profile_user.has_power_tag("zoom")
           @map_blurred = @profile_user.has_tag('blurred:true')
         end
 

--- a/app/views/map/_userLeaflet.html.erb
+++ b/app/views/map/_userLeaflet.html.erb
@@ -15,14 +15,13 @@
     var map_lat = <%= lat %>;
     var map_lon = <%= lon %>;
     var zoom = <%= zoom || lat.to_s.length.to_i + 6 %>;
-    console.log("zoom:" + zoom);
    
     var map = L.map('map_leaflet', {
         maxBounds: bounds,
         maxBoundsViscosity: 0.75
       }).setView([<%= lat %>, <%= lon %>], zoom);
-      
-    setupLEL(map, 1);
+
+    setupLEL(map, 0);
 
     var markers_hash = new Map();
     var layerGroup = L.layerGroup();

--- a/app/views/map/_userLeaflet.html.erb
+++ b/app/views/map/_userLeaflet.html.erb
@@ -2,29 +2,40 @@
 
   <% user = user || @user # allow overriding w/ local variable %>
 
-  <% if haslocation == true %>  
+  <% if haslocation == true %>
+
     <style>
       #map_leaflet{  height:300px; width:100%; margin: auto; position: relative;}
     </style>
     <div class="leaflet-map" id="map_leaflet"></div>
     <script>
+
+    var bounds = new L.LatLngBounds(new L.LatLng(84.67351257, -172.96875), new L.LatLng(-54.36775852, 178.59375));
   
-    var map_lat = <%= @map_lat %> ;
-    var map_lon = <%= @map_lon %> ; 
-    var map = setupLeafletMap() ; 
-    var layerGroup = L.layerGroup() ; 
+    var map_lat = <%= lat %>;
+    var map_lon = <%= lon %>;
+    var zoom = <%= zoom || lat.to_s.length.to_i + 6 %>;
+    console.log("zoom:" + zoom);
    
-     map.setView([map_lat,map_lon], 2);
+    var map = L.map('map_leaflet', {
+        maxBounds: bounds,
+        maxBoundsViscosity: 0.75
+      }).setView([<%= lat %>, <%= lon %>], zoom);
       
-    setupFullScreen(map , map_lat , map_lon) ; 
-    setupLEL(map , 1) ;
-  //  var hash = new L.Hash(map);   
+    setupLEL(map, 1);
+
+    var markers_hash = new Map();
+    var layerGroup = L.layerGroup();
+    var hash = new L.Hash(map);
+
     <% if !(@map_blurred == true) %>
-      var default_Icon =new PLmarker_default() ;
-      L.marker([<%= @map_lat %>, <%= @map_lon %>] , {icon: default_Icon}).addTo(map).bindPopup("<a href='https://publiclab.org/profile/<%= user.username  %>'><%= user.username  %> </a>");
+      var default_Icon =new PLmarker_default();
+      L.marker([<%= lat %>, <%= lon %>] , {icon: default_Icon}).addTo(map).bindPopup("<a href='https://publiclab.org/profile/<%= user.username %>'><%= user.username %></a>");
     <% end %>
     </script>
+
   <% else %>
+
     <div id="map_template" style="position: relative; width: 100%; display: inline-block;">
       <img src="https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/0/0/0.png" style="height:300px; width: 100%; margin: 0; position: relative; margin-right: -10px;">  
       <button type='button' class='btn btn-default btn-lg' onclick='addLocation()' style="position: absolute;    position: absolute;top: 41% ; left: 15% ;"> <strong> Share your Location </strong> </button>
@@ -35,4 +46,5 @@
         $('.blurred-location-input').click() ;
       }
     </script>
+
   <% end %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -2,7 +2,7 @@
 <div class="col-md-7 order-last order-md-first">
 
   <% if !@map_lat.nil? && !@map_lon.nil? %>
-  <%= render :partial => "map/userLeaflet" , locals: { haslocation: true, user: @profile_user } %>
+  <%= render :partial => "map/userLeaflet" , locals: { lat: @map_lat, lon: @map_lon, zoom: @map_zoom, haslocation: true, user: @profile_user } %>
   <% elsif !current_user.nil? && current_user.id == @profile_user.id %>
   <%= render :partial => "map/userLeaflet" , locals: { haslocation: false, user: @profile_user } %>
   <% end %>


### PR DESCRIPTION
Fixes #7088  (<=== Add issue number here)

I have the map working now, and it's checking for the user's zoom value.

![FireShot Capture 163 - 🎈 Public Lab_ admin - localhost](https://user-images.githubusercontent.com/49460529/71683126-aca72680-2d5f-11ea-8165-4d8dcb7a7b58.png)


I notice this is very very similar to the maps in the page sidebar. Is there a reason we are using a separate template for this map? Should we consider consolidating into one template?