### PR TITLE
Add Vertically Align to Menu Icon

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -100,7 +100,9 @@ a .fa-white,
 .fa-white {
     color: white !important;
 }
-
+.fa-bars {
+  vertical-align: middle;
+}
 .label a {
   color:#007bff;
 }


### PR DESCRIPTION
Vertically Align on Menu Icon on Medium-sized Screens

Fixes #7095

