### PR TITLE
FIX: Username validation

### DIFF
--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -133,6 +133,8 @@ function validateUsername(obj) {
 
   if (username.length < 3) {
     restoreOriginalStyle(this);
+    obj.disableSubmitBtn();
+    removeErrorMsg(self);
   } else {
     $.get("/api/srch/profiles?query=" + username, function(data) {
       if (data.items) {
@@ -165,7 +167,7 @@ function validatePassword(confirmPasswordElement, obj) {
     obj.updateUI(
       this,
       false,
-      "Please make sure password is atleast 8 characters long with minimum one numeric value"
+      "Please make sure password is at least 8 characters long with minimum one numeric value"
     );
     return;
   }

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -37,6 +37,23 @@ class ScreenshotsTest < ApplicationSystemTestCase
     take_screenshot
   end
 
+  test 'signup modal disabled submit button on empty username' do
+    visit '/'
+    click_on 'Sign up'
+
+    fill_in 'user[username]', with: 'Bob'
+    fill_in 'user[email]', with: 'valid@email.com'
+    fill_in 'user[password]', with: 'password1'
+    fill_in 'user[password_confirmation]', with: 'password1'
+
+    fill_in 'user[username]', with: ''
+
+    submitFormButton = find('#create-form button.btn-save')
+
+    assert_equal submitFormButton.disabled?, true
+    take_screenshot
+  end
+
   test 'login modal' do
     visit '/'
     click_on 'Login'

--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -31,7 +31,7 @@ class ScreenshotsTest < ApplicationSystemTestCase
 
     assert_equal( username_error_msg, "Username already exists" )
     assert_equal( email_error_msg, "Invalid email" )
-    assert_equal( password_error_msg, "Please make sure password is atleast 8 characters long with minimum one numeric value" )
+    assert_equal( password_error_msg, "Please make sure password is at least 8 characters long with minimum one numeric value" )
     assert_equal( confirm_password_error_msg, "Passwords must be equal" )
 
     take_screenshot


### PR DESCRIPTION
When the form is filled(valid) and the user deletes username, submit button is
enabled but should be disabled(missing username).

[Demo](https://streamable.com/0509a)

Minor changes:
 - Add space in the password error message
 - Update system test to match the new password error message

This commit resolves the issue.

Part of #7086