### PR TITLE
Fix OAuth redirection to previous url after LOGIN

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,7 @@ class ApplicationController < ActionController::Base
     unless current_user
       store_location
       flash[:warning] ||= I18n.t('application_controller.must_be_logged_in_to_access')
-      redirect_to login_url
+      redirect_to "/login?return_to=" + request.fullpath
       false
     end
     return current_user

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -76,16 +76,9 @@ class UserSessionsController < ApplicationController
           if session[:openid_return_to] # for openid login, redirects back to openid auth process
             return_to = session[:openid_return_to]
             session[:openid_return_to] = nil
-            redirect_to return_to + hash_params
-          elsif params[:return_to] && params[:return_to].split('/')[0..3] == ["", "subscribe", "multiple", "tag"]
-            flash[:notice] = "You are now following '#{params[:return_to].split('/')[4]}'."
-            subscribe_multiple_tag(params[:return_to].split('/')[4])
-            redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
-          elsif params[:return_to] && params[:return_to] != "/signup" && params[:return_to] != "/login"
-            flash[:notice] += " " + I18n.t('users_controller.continue_where_you_left_off', url1: params[:return_to].to_s)
-            redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            redirect_to "/dashboard"
           else
-            redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            redirect_to "/dashboard", notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
           end
         else # email exists so link the identity with existing user and log in the user
           user = User.where(email: auth["info"]["email"])

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -76,7 +76,7 @@ class UserSessionsController < ApplicationController
           if session[:openid_return_to] # for openid login, redirects back to openid auth process
             return_to = session[:openid_return_to]
             session[:openid_return_to] = nil
-            redirect_to "/dashboard"
+            redirect_to return_to + hash_params
           else
             redirect_to "/dashboard", notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
           end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -77,8 +77,15 @@ class UserSessionsController < ApplicationController
             return_to = session[:openid_return_to]
             session[:openid_return_to] = nil
             redirect_to return_to + hash_params
+          elsif params[:return_to] && params[:return_to].split('/')[0..3] == ["", "subscribe", "multiple", "tag"]
+            flash[:notice] = "You are now following '#{params[:return_to].split('/')[4]}'."
+            subscribe_multiple_tag(params[:return_to].split('/')[4])
+            redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+          elsif params[:return_to] && params[:return_to] != "/signup" && params[:return_to] != "/login"
+            flash[:notice] += " " + I18n.t('users_controller.continue_where_you_left_off', url1: params[:return_to].to_s)
+            redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
           else
-            redirect_to "/dashboard", notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
           end
         else # email exists so link the identity with existing user and log in the user
           user = User.where(email: auth["info"]["email"])

--- a/app/views/layouts/_social_icons.html.erb
+++ b/app/views/layouts/_social_icons.html.erb
@@ -1,22 +1,22 @@
 <div class="container">
 	
 	<div class="text-center">
-		<a href="/auth/google_oauth2?origin=<%= params[:return_to] || root_url %>" id="connect-google">
+		<a href="/auth/google_oauth2?origin=<%= request.original_url %>" id="connect-google">
 			<span class="btn btn-outline-light" style="margin-right:2px;background-color: #d34836;">
 				<i class="fa fa-google fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
-		<a href="/auth/github?origin=<%= params[:return_to] || root_url %>" id="connect-github">
+		<a href="/auth/github?origin=<%= request.original_url %>" id="connect-github">
 			<span class="btn btn-default" style="margin-left:2px;background-color: #333;">
 				<i class="fa fa-github fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
-		<a href="/auth/twitter?origin=<%= params[:return_to] || root_url %>" id="connect-twitter">
+		<a href="/auth/twitter?origin=<%= request.original_url %>" id="connect-twitter">
 			<span class="btn btn-outline-light" style="margin-left:2px;background-color: #1da1f2;">
 				<i class="fa fa-twitter fa-fw" style="font-size:20px;color:white;margin-left:2px;"></i>
 			</span>
 		</a>
-		<a href="/auth/facebook?origin=<%= params[:return_to] || root_url %>" id="connect-facebook">
+		<a href="/auth/facebook?origin=<%= request.original_url %>" id="connect-facebook">
             <span class="btn btn-outline-light" style="margin-left:2px;background-color: #3b5998">
                 <i class="fa fa-facebook fa-fw" style="font-size:20px;color:white;"></i>
 			</span>

--- a/app/views/layouts/_social_icons.html.erb
+++ b/app/views/layouts/_social_icons.html.erb
@@ -1,22 +1,22 @@
 <div class="container">
 	
 	<div class="text-center">
-		<a href="/auth/google_oauth2?origin=<%= request.original_url %>" id="connect-google">
+		<a href="/auth/google_oauth2?origin=<%= params[:return_to] || request.original_url %>" id="connect-google">
 			<span class="btn btn-outline-light" style="margin-right:2px;background-color: #d34836;">
 				<i class="fa fa-google fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
-		<a href="/auth/github?origin=<%= request.original_url %>" id="connect-github">
+		<a href="/auth/github?origin=<%= params[:return_to] || request.original_url %>" id="connect-github">
 			<span class="btn btn-default" style="margin-left:2px;background-color: #333;">
 				<i class="fa fa-github fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
-		<a href="/auth/twitter?origin=<%= request.original_url %>" id="connect-twitter">
+		<a href="/auth/twitter?origin=<%= params[:return_to] || request.original_url %>" id="connect-twitter">
 			<span class="btn btn-outline-light" style="margin-left:2px;background-color: #1da1f2;">
 				<i class="fa fa-twitter fa-fw" style="font-size:20px;color:white;margin-left:2px;"></i>
 			</span>
 		</a>
-		<a href="/auth/facebook?origin=<%= request.original_url %>" id="connect-facebook">
+		<a href="/auth/facebook?origin=<%= params[:return_to] || request.original_url %>" id="connect-facebook">
             <span class="btn btn-outline-light" style="margin-left:2px;background-color: #3b5998">
                 <i class="fa fa-facebook fa-fw" style="font-size:20px;color:white;"></i>
 			</span>

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -129,7 +129,7 @@ class AdminControllerTest < ActionController::TestCase
     get :spam
 
     assert_equal 'You must be logged in to access this page', flash[:warning]
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/spam'
   end
 
   test 'normal user should not be able to see spam page' do
@@ -333,7 +333,7 @@ class AdminControllerTest < ActionController::TestCase
     get :spam_revisions
 
     assert_equal 'You must be logged in to access this page', flash[:warning]
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/spam/revisions'
   end
 
   test 'normal user should not be able to see spam_revisions page' do
@@ -511,7 +511,7 @@ class AdminControllerTest < ActionController::TestCase
 
     post :mark_comment_spam, params: { id: comment.id }
 
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/admin/mark_comment_spam/309456473'
   end
 
   test 'should not mark comment as spam if normal user' do
@@ -602,7 +602,7 @@ class AdminControllerTest < ActionController::TestCase
     post :publish_comment, params: { id: comment.id }
 
     assert_equal 0, comment.status
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/admin/publish_comment/3449440'
   end
 
   test 'should not publish comment from spam if any other user' do
@@ -636,7 +636,7 @@ class AdminControllerTest < ActionController::TestCase
     get :spam_comments
 
     assert_equal 'You must be logged in to access this page', flash[:warning]
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/spam/comments'
   end
 
   test 'normal user should not be able to see spam_comments page' do

--- a/test/functional/csvfiles_controller_test.rb
+++ b/test/functional/csvfiles_controller_test.rb
@@ -17,7 +17,7 @@ class CsvfilesControllerTest < ActionController::TestCase
 
 	test 'should not get user files if not logged in'  do
 		get :user_files, params: {id: 2}
-		assert_redirected_to '/login'
+		assert_redirected_to '/login?return_to=/graph/data/2'
 	end
 
 	test 'should save graph object' do
@@ -27,7 +27,7 @@ class CsvfilesControllerTest < ActionController::TestCase
 
 	test 'should not delete a user file if not logged in'  do
 		get :delete, params: {id: 60, uid: 2}
-		assert_redirected_to '/login'
+		assert_redirected_to '/login?return_to=/graph/file/2/60'
 	end
     
 end

--- a/test/functional/editor_controller_test.rb
+++ b/test/functional/editor_controller_test.rb
@@ -7,22 +7,22 @@ class EditorControllerTest < ActionController::TestCase
 
   test 'should not get legacy form if not logged in' do
     get :legacy
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/legacy'
   end
 
   test 'should not get post form if not logged in' do
     get :post
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/post'
   end
 
   test 'should not get editor form if not logged in' do
     get :editor
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/editor'
   end
 
   test 'should not get rich form if not logged in' do
     get :rich
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/rich'
   end
 
   test 'should get legacy form' do
@@ -100,7 +100,7 @@ class EditorControllerTest < ActionController::TestCase
         template: 'question',
         redirect: 'question'
         }
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/legacy?redirect=question&tags=question%3Aquestion&template=question'
     # uses ASCII format instead of utf-8
     assert_equal '/legacy?redirect=question&tags=question%3Aquestion&template=question', session[:return_to]
   end

--- a/test/functional/editor_controller_test.rb
+++ b/test/functional/editor_controller_test.rb
@@ -22,7 +22,7 @@ class EditorControllerTest < ActionController::TestCase
 
   test 'should not get rich form if not logged in' do
     get :rich
-    assert_redirected_to '/login?return_to=/rich'
+    assert_redirected_to '/login?return_to=/editor/rich'
   end
 
   test 'should get legacy form' do

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -234,7 +234,7 @@ class NotesControllerTest < ActionController::TestCase
          }
     # , main_image: "/images/testimage.jpg"
 
-    assert_redirected_to('/login')
+    assert_redirected_to('/login?return_to=/notes/create')
   end
 
   test 'non-first-timer posts note' do
@@ -896,7 +896,7 @@ class NotesControllerTest < ActionController::TestCase
      assert_equal "You must be logged in to access this page", flash[:warning]
      assert_equal 3, node.status
      assert_equal 1, node.author.status
-     assert_redirected_to '/login'
+     assert_redirected_to '/login?return_to=/notes/publish_draft/21'
      assert_equal ActionMailer::Base.deliveries.size, 0
    end
 
@@ -914,7 +914,7 @@ class NotesControllerTest < ActionController::TestCase
           draft: "true"
          }
 
-     assert_redirected_to('/login')
+     assert_redirected_to('/login?return_to=/notes/create')
    end
 
    test 'non-first-timer posts draft' do

--- a/test/functional/subscription_controller_test.rb
+++ b/test/functional/subscription_controller_test.rb
@@ -15,7 +15,7 @@ class SubscriptionControllerTest < ActionController::TestCase
   test 'should redirect to login if user is not logged in and trying to access digest' do
       get :digest
 
-      assert_redirected_to '/login'
+      assert_redirected_to '/login?return_to=/subscriptions/digest'
   end
 
   test 'should show digest if user logged in' do

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -133,7 +133,7 @@ class TagControllerTest < ActionController::TestCase
          uid: 1
          }
 
-    assert_redirected_to('/login')
+    assert_redirected_to('/login?return_to=/tag/create/1')
   end
 
   test 'related tags' do

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -267,7 +267,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
   end
   
-  test "redirects tto previous page when logging in through oauth" do
+  test "redirects to previous page when logging in through oauth" do
     request.env['omniauth.origin'] = "/notes/liked"
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
     # sign up

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -266,4 +266,12 @@ class UserSessionsControllerTest < ActionController::TestCase
     post :destroy
     assert_equal "Successfully logged out.",  flash[:notice]
   end
+  
+  test "redirects to same page on oauth" do
+    request.env['omniauth.origin'] = "/notes/liked"
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
+    # sign in
+    post :create
+    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
+  end
 end

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -267,15 +267,10 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
   end
   
-  test "redirects to dashboard on signup with oauth and redirects to previous page when logging in through oauth" do
+  test "redirects tto previous page when logging in through oauth" do
+    request.env['omniauth.origin'] = "/notes/liked"
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
     # sign up
-    post :create
-    assert_redirected_to "/dashboard"
-    # logout
-    post :destroy
-    request.env['omniauth.origin'] = "/notes/liked"
-    # login
     post :create
     assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
   end

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -267,10 +267,15 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
   end
   
-  test "redirects to same page on oauth" do
-    request.env['omniauth.origin'] = "/notes/liked"
+  test "redirects to dashboard on signup with oauth and redirects to previous page when logging in through oauth" do
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
-    # sign in
+    # sign up
+    post :create
+    assert_redirected_to "/dashboard"
+    # logout
+    post :destroy
+    request.env['omniauth.origin'] = "/notes/liked"
+    # login
     post :create
     assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
   end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -257,14 +257,14 @@ class UsersControllerTest < ActionController::TestCase
     user = users(:bob)
     get :edit, params: { id: user.name }
     assert_not flash.empty?
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/profile/Bob/edit'
   end
 
   test 'should redirect update when not logged in' do
     user = users(:bob)
     post :update, params: { user: { bio: 'Hello, there!' } }
     assert_not flash.empty?
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?return_to=/users/update'
   end
 
   test 'should redirect edit when logged in as another user' do

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -96,7 +96,7 @@ class WikiControllerTest < ActionController::TestCase
          tags:  'balloon-mapping,event'
         }
 
-    assert_redirected_to('/login')
+    assert_redirected_to('/login?return_to=/wiki/create')
   end
 
   test 'post wiki' do


### PR DESCRIPTION
Fixes #6233 

The `origin` parameter for the oauth login was always empty although that was the parameter that told the omniauth where to redirect.

There were two different cases here where we need to solve the redirection. One, the user uses the signup modal to log in. Two, the user goes to a page restricted for logged in users and is redirected to the login page.

In the first one, we want to redirect the user to the page he is currently on when he is filling the signup overlay. We can access this with url in Rails with `request.origin_url`. For the second case, the user is on the "/login" page which is not where he wants to be redirected. To fix this, I edited the `require_login` filter that redirects to the login page to set a `return_to` parameter:
```ruby
def require_user
    unless current_user
      store_location
      flash[:warning] ||= I18n.t('application_controller.must_be_logged_in_to_access')
     # what I added
      redirect_to "/login?return_to=" + request.fullpath
      false
    end
end
```
So, if the user is trying to post a node at https://publiclab.org/post, the `require_login` function is called and  he will be redirected to `https://publiclab.org/login?return_to=/post`. We can then set the origin attribute for oauth to `params[:return_to]`. So now that these two problems could be solved individually, I needed to pair the two so that the origin parameter be set to the `return_to` parameter when there is one and otherwise, when the modal is being used, the origin is set to the current url. 

This is the result:
`<a href="/auth/provider?origin=<%= params[:return_to] || request.original_url %>"`

So for example, if user1 is at https://publiclab.org/about and they click the login modal, they are still on the same page and the origin will be set to `request.original_url` -> https://publiclab.org/about. But if the `params[:return_to]` is set, he will be redirected to the page he was trying to go to before logging in.

This is a demo of the working redirection for both cases:
![correct-login](https://user-images.githubusercontent.com/52892257/71781725-00b94180-2fd2-11ea-8a27-5fd0ed0f374f.gif)

I also added a test to the users_sessions controller for the oauth redirection!

Although I could not claim this task on the GCI dashboard, it has been open for a long time and I wanted to solve it because this issue was interfering with the testing of my pull request #7005 
It was really fun to investigate all the mechanisms for the issue and then documenting the fix.
I hope you're okay that I submitted the pull request without claiming it on GCI and I can retract it if you want but I could not work on tests for the other pull request because of this problem.

Thanks! :+1: 