### PR TITLE
Fix preview button text to go back editing

### DIFF
--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -127,12 +127,12 @@
 
     <div class="control-group">
       <button type="submit" class="btn btn-primary"><%= translation('comments._edit.publish') %></button>
-        <a class="btn btn-default preview-btn"  data-previewing-text="Hide Preview"
+        <a class="btn btn-outline-secondary preview-btn"  data-previewing-text="Hide Preview"
             onClick="$('#c<%= comment.id %>preview').toggle();
             $('#c<%= comment.id %>text').toggle();
             $('#c<%= comment.id %>text').next('#imagebar').toggle();
             this.previewing = !this.previewing;
-            $('#c<%= comment.id %>edit .preview-btn').button(this.previewing ? 'previewing' : 'reset');
+            $('#c<%= comment.id %>edit .preview-btn').html(this.previewing ? 'Edit' : 'Preview');
             $E.generate_preview('c<%= comment.id %>preview',$('#c<%= comment.id %>text').val())">
           Preview
         </a>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -116,7 +116,7 @@
               </a>
               <a class="btn btn-outline-secondary" onClick="$('#c<%= comment.cid %>show').toggle();$('#c<%= comment.cid %>edit').toggle()"><%= translation('comments._form.cancel') %></a>
             <% else %>
-              <a class="btn btn-outline-secondary preview-btn>" id="post_comment" data-previewing-text="Hide Preview" onClick="handleClick();$E.toggle_preview()"><%= translation('comments._form.preview') %></a>
+              <a class="btn btn-outline-secondary preview-btn>" id="post_comment" data-previewing-text="Hide Preview" onClick="handleClick();$E.toggle_preview(preview_btn=this)"><%= translation('comments._form.preview') %></a>
             <% end %>
 
             <span style="color:#888;"> &nbsp;

--- a/app/views/editor/post.html.erb
+++ b/app/views/editor/post.html.erb
@@ -107,7 +107,7 @@
           <% end %>
 
           <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg">Publish</a>
-          <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()">Preview</a>
+          <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview(preview_btn=this)">Preview</a>
 
           <%= render partial: 'editor/event' %>
 

--- a/app/views/editor/question.html.erb
+++ b/app/views/editor/question.html.erb
@@ -108,7 +108,7 @@
           <% end %>
 
           <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg">Publish</a>
-          <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()">Preview</a>
+          <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview(preview_btn=this)">Preview</a>
 
           <%= render partial: 'editor/event' %>
 

--- a/app/views/features/_form.html.erb
+++ b/app/views/features/_form.html.erb
@@ -23,5 +23,5 @@
 
 <div>
   <input type="submit" id="publish" tabindex="5" class="publish btn btn-primary btn-lg" value="Save" />
-  <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()">Preview</a>
+  <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview(preview_btn=this)">Preview</a>
 </div>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -72,7 +72,7 @@
           <%= render partial: 'editor/editor' %>
 
           <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg"><%= t('wiki.edit.publish') %></a>
-          <a tabindex="6" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
+          <a tabindex="6" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview(preview_btn=this)"><%= t('wiki.edit.preview') %></a>
           <a class="btn btn-outline-secondary btn-lg" href="/wiki/<%= params["id"] %>">Cancel</a>
 
         </div>

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -122,5 +122,23 @@ class CommentTest < ApplicationSystemTestCase
     # Make sure that image has been uploaded
     page.assert_selector('#preview img', count: 1)
   end
+ 
+  test 'the text change on preview button click' do
+    visit '/'
 
+    click_on 'Login'
+
+    fill_in("username-login", with: "jeff")
+    fill_in("password-signup", with: "secretive")
+    click_on "Log in"
+
+    visit "/wiki/wiki-page-path/comments"
+
+    click_on 'Preview'
+    assert_selector('.preview-btn', text: "Edit")
+
+
+    click_on 'Edit'
+    assert_selector('.preview-btn', text: "Preview")
+  end
 end


### PR DESCRIPTION
## Fixes #7122 

### Bug:

The preview button text was not being altered when clicked. With this you would need to click 'Preview' again to go back to editing.

I found this happening both in comments (create and edit) and in the legacy editor.

* Old behaviour:
![Not working new comment](https://user-images.githubusercontent.com/33282336/71922121-1c0a8500-3169-11ea-8e6f-c915c4a755d8.gif)

### How it was fixed:

There were two bugs in `app/assets/javascripts/editor.js` file, the `toggle_preview` was getting the button by it's class but there were cases that multiple preview buttons were in the same page causing it to fail. Also the jquery `.button('text')` function was not altering the button text.

It has been created a parameter to receive the button object to ensure the right button is being accessed.

* New behaviour:
![Working new comment](https://user-images.githubusercontent.com/33282336/71922150-29c00a80-3169-11ea-9af4-8909f42e3d25.gif)
