### PR TITLE
FIX: Comments image upload progress bar

### DIFF
--- a/app/assets/javascripts/dragdrop.js
+++ b/app/assets/javascripts/dragdrop.js
@@ -51,15 +51,14 @@ jQuery(document).ready(function() {
                 'nid':$D.nid
             },
             start: function(e) {
-                elem = $(this).closest('div.comment-form-wrapper').eq(0);
+                elem = $($D.selected).closest('div.comment-form-wrapper').eq(0);
                 elem.find('#create_progress').eq(0).show();
                 elem.find('#create_uploading').eq(0).show();
                 elem.find('#create_prompt').eq(0).hide();
                 elem.find('.dropzone').eq(0).removeClass('hover');
             },
             done: function (e, data) {
-                elem = $(e.target.closest('div.comment-form-wrapper')).eq(0);
-                // $D.selected = elem;
+                elem = $($D.selected).closest('div.comment-form-wrapper').eq(0);
                 elem.find('#create_progress').hide();
                 elem.find('#create_uploading').hide();
                 elem.find('#create_prompt').show();
@@ -99,7 +98,8 @@ jQuery(document).ready(function() {
 
             },
             progressall: function (e, data) {
-                return progressAll('#create_progress-bar', data);
+                var progressElement = $($D.selected).find('#create_progress-bar');
+                return progressAll(progressElement, data);
             }
         });
     });


### PR DESCRIPTION
During the image upload in comments, a progress bar would show up in the
wrong textarea. This occurred because the progress bar from the first
textarea was selected and not the one that we are in.

The issue description was a bit unclear to me, here is the video demonstrating the bug:
[Demo](https://streamable.com/icq9o)

How it behaves now: 
[Demo](https://streamable.com/j30wy)

Resolves #6833

@jywarren could you review this? Thanks.