### PR TITLE
Created new page that lists wikis for a specific author

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -467,4 +467,13 @@ class WikiController < ApplicationController
       @node.save
     end
   end
+
+  def author
+    @user = User.find_by(name: params[:id])
+    @title = @user.name
+    @wikis = Node.paginate(page: params[:page], per_page: 24)
+      .order('nid DESC')
+      .where("uid = ? AND type = 'page' OR type = 'place' OR type = 'tool' AND status = 1", @user.uid)
+    render template: 'wiki/index'
+  end
 end

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -259,7 +259,7 @@
     <ul>
     <li class="mt-3"><h5>@<%= @profile_user.name %> has</h5></li>
       <li><h5><a href='/notes/author/<%= @profile_user.name %>'><%= @profile_user.note_count %> research notes</a></h5></li>
-      <li><h5><%= @profile_user.revisions.count %> wiki edits</h5></li>
+      <li><h5><a href="/wikis/author/<%= @profile_user.name %>"><%= @profile_user.revisions.count %> wiki edits</a></h5></li>
       <li><h5><a href = "/tag/question:*/author/<%= params[:id] %>"><%= Node.questions.where(status: 1, uid: @profile_user.id).length %> questions </a></h5></li>
       <li><h5><a href = "/profile/comments/<%= params[:id] %>"><%= Comment.where(uid: @profile_user.id).count %> comments</a></h5></li>
       <li><h5><a href = "/tag/activity:*/author/<%= params[:id] %>"><%= @count_activities_posted %> activities posted </a></h5></kli>

--- a/app/views/wiki/_wikis.html.erb
+++ b/app/views/wiki/_wikis.html.erb
@@ -1,4 +1,4 @@
-<% wikis = wikis || @wikis #accept local if present, default to instance %>
+<% wikis ||= @wikis #accept local if present, default to instance %>
 <% if local_assigns[:digest] and wikis.length == 0 %>
   <div class="alert alert-warning" role="alert">
     You haven't subscribed to any topic yet. Visit <a href="https://publiclab.org/subscriptions">https://publiclab.org/subscriptions</a> to subscribe to more topics.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Plots2::Application.routes.draw do
   get 'methods' => 'wiki#methods'
   get 'methods/:topic' => 'wiki#methods'
   get 'techniques' => 'wiki#techniques'
+  get "/wikis/author/:id" => "wiki#author"
 
   get 'report/:id' => 'legacy#report'
   get 'node/:id' => 'legacy#node'

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -635,4 +635,15 @@ class WikiControllerTest < ActionController::TestCase
       assert_equal 'text/html', @response.content_type
   end
 
+  test "should get author wikis of which none are banned" do
+    user = users(:jeff)
+    get :author, params: { id: user.name }
+    wikis = assigns(:wikis)
+    # check they are not banned
+    assert wikis.all? { |wiki| wiki.status == 1 }
+    # test their type
+    assert wikis.none? { |wiki| wiki.type == "question" || wiki.status == "note"}
+    # check correct author
+    assert wikis.all? { |wiki| wiki.uid == user.uid }
+  end
 end


### PR DESCRIPTION
Fixes #6253 

I created the `/wikis/author/:author_name` endpoint and made a route for it. I also added a link to it on the profile page and am building a test. I also want to render a message when there are no wikis for the author.

This is the result:
![wiki-authors](https://user-images.githubusercontent.com/52892257/72110002-79543100-3337-11ea-8d8e-d8aab1933fe0.png)

What do you think @publiclab/reviewers?