### PR TITLE
ADD: System test for return_to query parameter

### DIFF
--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -71,6 +71,14 @@ class ScreenshotsTest < ApplicationSystemTestCase
     take_screenshot
   end
 
+  test 'return_to query parameter preserved while switching from /login to /signup' do
+    visit '/login?return_to=page'
+    click_on 'sign up'
+
+    path = URI.parse(current_url).request_uri
+    assert_equal path, '/signup?return_to=page'
+  end
+
   test 'tags' do
     visit '/tags'
     take_screenshot


### PR DESCRIPTION
Tests that return_to query parameter is preserved while switching from
/login to /signup.

Resolves #5585

@SidharthBansal @jywarren could you review this? Thanks.