### PR TITLE
FIX: Comments section page redirection after login

### DIFF
--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -162,7 +162,7 @@
               <%= render :partial => "comments/form", :locals => { title: "Reply to this comment", reply_to: comment.cid, comment: false, placeholder: "Help the author refine their post, or point them at other helpful information on the site. Mention users by @username to notify them of this thread by email" } %>
             </div>
           <% else %>
-            <p><%= link_to "Log in", new_user_session_path( return_to: request.path )%> to comment</p>
+            <p><%= link_to "Log in", "/login?return_to=#{request.path}" %> to comment</p>
           <% end %>
         </div>
       </div>

--- a/test/system/sessions_test.rb
+++ b/test/system/sessions_test.rb
@@ -10,4 +10,18 @@ class SessionsTest < ApplicationSystemTestCase
     assert_equal path, '/signup?return_to=page'
   end
 
+  test 'the user after login is redirected to the note he was trying to comment' do
+    visit '/wiki/wiki-page-path/comments'
+
+    find('a[data-target="#loginModal"]', text: 'Login').click()
+
+    fill_in 'user_session[username]', with: 'jeff'
+    fill_in 'user_session[password]', with: 'secretive'
+
+    click_on 'Log in'
+
+    path = URI.parse(current_url).request_uri
+    assert_equal path, '/wiki/wiki-page-path/comments'
+  end
+
 end


### PR DESCRIPTION
If a user tries to comment on a note, he is redirected to log in page,
but after successful login, he is not returned to that note.
Instead, he is redirected to dashboard.

[Demo](https://streamable.com/tj34g)

Resolves #5291

@Uzay-G @jywarren @ananyaarun @SidharthBansal could you review this? Thanks.