### PR TITLE
Turn off admin emails for users with "no-moderation-emails" tag

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -13,7 +13,7 @@ class AdminMailer < ActionMailer::Base
     all_moderators = User.where(role: %w(moderator admin)).collect(&:email)
     moderators = []
     all_moderators.each do |mod_user|
-      moderators << mod_user unless .has_tag('no-moderation-emails')
+      moderators << mod_user unless mod_user.has_tag('no-moderation-emails')
     end
     if node.status == 4 # only if it remains unmoderated
       mail(

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,10 +10,10 @@ class AdminMailer < ActionMailer::Base
     @node = node
     @user = node.author
     @footer = feature('email-footer')
-    all_moderators = User.where(role: %w(moderator admin)).collect(&:email)
+    all_moderators = User.where(role: %w(moderator admin))
     moderators = []
     all_moderators.each do |mod_user|
-      moderators << mod_user unless mod_user.has_tag('no-moderation-emails')
+      moderators << mod_user.email unless mod_user.has_tag('no-moderation-emails')
     end
     if node.status == 4 # only if it remains unmoderated
       mail(

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,7 +10,11 @@ class AdminMailer < ActionMailer::Base
     @node = node
     @user = node.author
     @footer = feature('email-footer')
-    moderators = User.where(role: %w(moderator admin)).collect(&:email)
+    all_moderators = User.where(role: %w(moderator admin)).collect(&:email)
+    moderators = []
+    all_moderators.each do |mod_user|
+      moderators << mod_user unless .has_tag('no-moderation-emails')
+    end
     if node.status == 4 # only if it remains unmoderated
       mail(
         to: "moderators@#{ActionMailer::Base.default_url_options[:host]}",


### PR DESCRIPTION
Fixes #6282

Modified app/mailers/admin_mailer.rb to check for "no-moderation-emails" tag before sending emails.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
