### PR TITLE
push map below floating nav bar

### DIFF
--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -8,7 +8,7 @@
     max-width: 100%;
   }
   body>.container {
-    padding-top: 28px;
+    padding-top: 0px;
   }
   .footer {
     margin: 0;
@@ -29,6 +29,9 @@
 
    <script>
 
+      // set the map just under the navbar
+      $('.body-container').css('padding-top', $('#header').css('height'));
+
       var urlHash = urlMapHash();
 
         // if there are location params in URL let them override, otherwise save lat/lon/zoom from controller
@@ -41,7 +44,7 @@
             <% end %>
           <% end %>
         }
-
+        
       const params = urlHash.getUrlHashParameters();
      
       var lat = parseFloat(params.lat);

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -30,7 +30,11 @@
    <script>
 
       // set the map just under the navbar
-      $('.body-container').css('padding-top', $('#header').css('height'));
+      setTopPadding();
+      $(window).resize(setTopPadding);
+      function setTopPadding() {
+        $('.body-container').css('padding-top', $('#header').css('height'));
+      }
 
       var urlHash = urlMapHash();
 


### PR DESCRIPTION
Fixes #7188  (<=== Add issue number here)

Because the #header is has a fixed position it does not take up space on the page flow. Most of the content relies on a large margin at the top so it won't get covered, but the map is supposed to be positioned directly below it.

I used javascript to check the height of the navbar and set the gap to that size. Now no matter what size the header is the map should be directly below it.