### PR TITLE
FIX: Cross wired comment preview buttons

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -121,30 +121,46 @@ $E = {
   generate_preview: function(id,text) {
     $('#'+id)[0].innerHTML = marked(text)
   },
-  toggle_preview: function(comment_id=null) {
-    let preview_btn
-    let dropzone
+  toggle_preview: function (comment_id = null) {
+    let previewBtn;
+    let dropzone;
 
     // if the element is part of a multi-comment page,
     // ensure to grab the current element and not the other comment element.
     if (comment_id) {
-      preview_btn = $('#'+comment_id)
+      previewBtn = $('#' + comment_id);
       const currentComment = $('#'+comment_id).parent('.control-group')
       $E.preview = currentComment.siblings('#preview')
       dropzone = currentComment.siblings('.dropzone')
       $E.textarea = dropzone.children('#text-input')
     } else {
-      preview_btn = $('.preview-btn')
-      dropzone = $('.dropzone')
+      previewBtn = $(this.textarea.context).find('#post_comment');
+      dropzone = $(this.textarea.context).find('.dropzone');
     }
 
     $E.preview[0].innerHTML = marked($E.textarea.val())
     $E.preview.toggle()
     dropzone.toggle()
 
-    // if $E.previewing flags true, change button text with button('previewing')
-    $E.previewing = !$E.previewing
-    if ($E.previewing) preview_btn.button('previewing');
-    else preview_btn.button('reset');
+    this.toggleButtonPreviewMode(previewBtn);
+  },
+  toggleButtonPreviewMode: function (previewBtn) {
+    let isPreviewing = previewBtn.attr('data-previewing');
+
+    // If data-previewing attribute is not present -> we are not in "preview" mode
+    if (!isPreviewing) {
+      previewBtn.attr('data-previewing', 'false');
+      isPreviewing = 'false';
+    }
+
+    if (isPreviewing === 'false') {
+      previewBtn.attr('data-previewing', 'true');
+
+      let previewText = previewBtn.attr('data-previewing-text');
+      previewBtn.text(previewText);
+    } else {
+      previewBtn.attr('data-previewing', 'false');
+      previewBtn.text('Preview');
+    }
   }
 }

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -57,4 +57,21 @@ class CommentTest < ApplicationSystemTestCase
     find(".noty_body", text: "Comment Added!")
     find("p", text: "Awesome comment! :)")
   end
+
+  test 'comment preview button' do
+    visit "/wiki/wiki-page-path/comments"
+
+    find("p", text: "Reply to this comment...").click()
+
+    reply_preview_button = page.all('#post_comment')[0]
+    comment_preview_button = page.all('#post_comment')[1]
+
+    # Toggle preview
+    reply_preview_button.click()
+
+    # Make sure that buttons are not binded with each other
+    assert_equal( reply_preview_button.text, "Hide Preview" )
+    assert_equal( comment_preview_button.text, "Preview" )
+  end
+
 end


### PR DESCRIPTION
Previously when a user clicks on 'Preview' it would collapse multiple textareas. Now it only collapses the textarea that a user is currently in. It handles state very well by dynamically recognizing if we are in "edit" or "preview" mode.

[Demo](https://streamable.com/917ks)

Resolves #6297

@IshaGupta18 @jywarren @sashadev-sky @SidharthBansal could you review this? Thanks.