### PR TITLE
Add screenshot for tags stats

### DIFF
--- a/test/system/screenshots_test.rb
+++ b/test/system/screenshots_test.rb
@@ -84,6 +84,11 @@ class ScreenshotsTest < ApplicationSystemTestCase
     take_screenshot
   end
 
+  test "tag stats" do
+    visit "/tag/#{node_tags(:awesome).name}/stats"
+    take_screenshot
+  end
+  
   test 'tag page' do
     nodes(:activity).add_tag('pin:test', users(:bob)) # ensure a pinned note appears
     visit '/tag/test'


### PR DESCRIPTION
Fixes #6879. 

Now. the system tests also visit the `tag/:tag_name/stats` endpoint and take a screenshot.
I ran the tests and everything worked correctly :smile:
What do you think @keshav234156 @publiclab/reviewers ?