### PR TITLE
add tooltip for number of authors

### DIFF
--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -30,10 +30,10 @@
   <div class="d-print-none">
 
     <div style="padding-top:8px;text-align:center">
-      <span>
-        <i style="color:#888;" class="fa fa-user"></i> <%= number_with_delimiter(@node.authors.length)  %>  |
+      <span class="d-none d-lg-inline">
+        <span rel="tooltip" title="The number of authors for this page." data-placement="top"><i style="color:#888;" class="fa fa-user"></i> <%= number_with_delimiter(@node.authors.length) %></span>  |
         <a rel="tooltip" title="View all revisions for this page." data-placement="top" href="/wiki/revisions/<%= @node.slug_from_path %>"><i style="color:#888;" class="fa fa-history"></i> <%= @node.revisions.length %></a> |
-        <a href="/talk/<%= @node.slug_from_path %>" rel="tooltip" title="Practice in a realtime doc." data-placement="top"><i class="fa fa-comment"></i></a> | 
+        <a href="/talk/<%= @node.slug_from_path %>" rel="tooltip" title="Practice in a realtime doc." data-placement="top"><i class="fa fa-comment"></i></a> |
         <a href="/n/<%= @node.id %>"><i style="color:#888;" class="fa fa-link"></i></a> <span class="d-none d-xl-inline"><a href="/n/<%= @node.id %>">#<%= @node.id %></a></span>
       </span>
     </div>


### PR DESCRIPTION

Fixes #7170 

app/views/wiki/_header.html.erb modified to add a tooltip for number of authors.

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [X] ask `@publiclab/reviewers` for help, in a comment below

# Screenshots attached  
![Screenshot from 2020-01-15 23-20-26](https://user-images.githubusercontent.com/33806116/72458008-c9c30700-37ed-11ea-85da-fc13d75e5187.png)

