### PR TITLE
FIX: Newsletter title dropdown

### DIFF
--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -30,7 +30,7 @@
   <div class="d-print-none">
 
     <div style="padding-top:8px;text-align:center">
-      <span class="d-none d-lg-inline">
+      <span>
         <i style="color:#888;" class="fa fa-user"></i> <%= number_with_delimiter(@node.authors.length)  %>  |
         <a rel="tooltip" title="View all revisions for this page." data-placement="top" href="/wiki/revisions/<%= @node.slug_from_path %>"><i style="color:#888;" class="fa fa-history"></i> <%= @node.revisions.length %></a> |
         <a href="/talk/<%= @node.slug_from_path %>" rel="tooltip" title="Practice in a realtime doc." data-placement="top"><i class="fa fa-comment"></i></a> | 


### PR DESCRIPTION
Dropdown wasn't working on screens < 992px.
This occurs on pl.o/newsletter page and all others pl.org/wiki/pages.

[Demo](https://streamable.com/ltiuw)

Resolves #7037 

@SidharthBansal it's ready.

