### PR TITLE
FIX: Oauth redirection after signup

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -90,11 +90,8 @@ class UserSessionsController < ApplicationController
             flash[:notice] = "You are now following '#{params[:return_to].split('/')[4]}'."
             subscribe_multiple_tag(params[:return_to].split('/')[4])
             redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
-          elsif params[:return_to] && params[:return_to] != "/signup" && params[:return_to] != "/login"
-            flash[:notice] += " " + I18n.t('users_controller.continue_where_you_left_off', url1: params[:return_to].to_s)
-            redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
           else
-            redirect_to return_to + hash_params, notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            redirect_to "/dashboard", notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
           end
         else # email exists so link the identity with existing user and log in the user
           user = User.where(email: auth["info"]["email"])

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -90,6 +90,16 @@ Rails.application.configure do
       }
     })
 
+  # This config is has the same email as one of the fixture users. When it is used to login, instead of signing up a new user
+  # it should link this oauth config to the fixture user.
+  OmniAuth.config.mock_auth[:github4] = OmniAuth::AuthHash.new({
+      'provider' => 'github',
+      'uid' => '135799134741',
+      'info' => {
+        'name' => 'Bob',
+        'email' => 'bob@publiclab.org'
+      }
+    }) 
     #facebook Provider
     OmniAuth.config.mock_auth[:facebook1] = OmniAuth::AuthHash.new({
         'provider' => 'facebook',

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,7 +109,7 @@ Rails.application.configure do
           'email' => 'bansal.sidharth309@gmail.com'
         }
       })
-  
+
     #Twitter Provider
     OmniAuth.config.mock_auth[:twitter1] = OmniAuth::AuthHash.new({
         'provider' => 'twitter',
@@ -155,5 +155,40 @@ Rails.application.configure do
           'email' => 'emila.buffet309@gmail.com'
         }
       })
-
+  
+  
+  # This config is has the same email as one of the fixture users. When it is used to login, instead of signing up a new user
+  # it should link this oauth config to the fixture user.
+  OmniAuth.config.mock_auth[:facebook4] = OmniAuth::AuthHash.new({
+      'provider' => 'facebook',
+      'uid' => '135799134741',
+      'info' => {
+        'name' => 'Bob',
+        'email' => 'bob@publiclab.org'
+      }
+    }) 
+  
+  
+  # This config is has the same email as one of the fixture users. When it is used to login, instead of signing up a new user
+  # it should link this oauth config to the fixture user.
+  OmniAuth.config.mock_auth[:twitter4] = OmniAuth::AuthHash.new({
+      'provider' => 'twitter',
+      'uid' => '135799134741',
+      'info' => {
+        'name' => 'Bob',
+        'email' => 'bob@publiclab.org'
+      }
+    }) 
+  
+  
+  # This config is has the same email as one of the fixture users. When it is used to login, instead of signing up a new user
+  # it should link this oauth config to the fixture user.
+  OmniAuth.config.mock_auth[:google_oauth2_4] = OmniAuth::AuthHash.new({
+      'provider' => 'google_oauth2',
+      'uid' => '135799134741',
+      'info' => {
+        'name' => 'Bob',
+        'email' => 'bob@publiclab.org'
+      }
+    }) 
 end

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -266,30 +266,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     post :destroy
     assert_equal "Successfully logged out.",  flash[:notice]
   end
-  
-  test "logging in with banned user through oauth should fail and redirect correctly" do
-    request.env['omniauth.origin'] = "/notes/liked"
-    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
-    post :create
-    post :destroy
-    # name of omniauth user
-    User.find_by(name: "bansal_sidharth309").ban
-    post :create
-    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
-    assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_banned', username: "bansal_sidharth309").html_safe
-  end
-  
-  test "logging in with moderated user through oauth should fail and redirect correctly" do
-    request.env['omniauth.origin'] = "/notes/liked"
-    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
-    post :create
-    post :destroy
-    User.find_by(name: "bansal_sidharth309").moderate
-    post :create
-    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
-    assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_moderated', username: "bansal_sidharth309").html_safe
-  end
-  
+ 
   test "redirects dashboard on signup with oauth and redirects to previous page when logging in" do
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
     post :create

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -266,7 +266,30 @@ class UserSessionsControllerTest < ActionController::TestCase
     post :destroy
     assert_equal "Successfully logged out.",  flash[:notice]
   end
- 
+  
+  test "logging in with banned user through oauth should fail and redirect correctly" do
+    request.env['omniauth.origin'] = "/notes/liked"
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
+    post :create
+    post :destroy
+    # name of omniauth user
+    User.find_by(name: "bansal_sidharth309").ban
+    post :create
+    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
+    assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_banned', username: "bansal_sidharth309").html_safe
+  end
+  
+  test "logging in with moderated user through oauth should fail and redirect correctly" do
+    request.env['omniauth.origin'] = "/notes/liked"
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
+    post :create
+    post :destroy
+    User.find_by(name: "bansal_sidharth309").moderate
+    post :create
+    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
+    assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_moderated', username: "bansal_sidharth309").html_safe
+  end
+  
   test "redirects dashboard on signup with oauth and redirects to previous page when logging in" do
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
     post :create
@@ -306,29 +329,6 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_redirected_to root_url
     assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_moderated', username: user.username).html_safe
   end
-  
-    test "logging in with banned user through normal login should fail" do
-    user = users(:bob)
-    user.ban
-    post :create, params: { user_session: { username: user.username, password: 'secretive' } }
-    assert_redirected_to root_url
-    assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_banned', username: user.username).html_safe
-  end
-  
-  test "redirects dashboard on signup with oauth and redirects to previous page when logging in" do
-    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
-    # sign in
-    post :create
-    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.", flash[:notice]
-    assert_redirected_to "/dashboard"
-    post :destroy
-    assert_equal I18n.t('user_sessions_controller.logged_out'), flash[:notice]
-    request.env['omniauth.origin'] = "/notes/liked"
-    post :create
-    assert_equal I18n.t('user_sessions_controller.logged_in'), flash[:notice]
-    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
-  end
-  
   test "user that links provider to existing account should not be redirected to dashboard on oauth signup for Github provider" do
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github4]
     request.env['omniauth.origin'] = "/notes/liked"

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -329,12 +329,33 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_redirected_to root_url
     assert_equal flash[:error], I18n.t('user_sessions_controller.user_has_been_moderated', username: user.username).html_safe
   end
-
-  test "user that links provider to existing account should not be redirected to dashboard on oauth signup" do
-    # this omniauth config user has the same email as a user in the database
+  test "user that links provider to existing account should not be redirected to dashboard on oauth signup for Github provider" do
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github4]
     request.env['omniauth.origin'] = "/notes/liked"
-    # the controller notices this link between the emails and links the accounts
+    post :create
+    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
+    assert_equal "Successfully linked to your account!", flash[:notice]
+  end
+
+  test "user that links provider to existing account should not be redirected to dashboard on oauth signup for Google provider" do
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:google_oauth2_4]
+    request.env['omniauth.origin'] = "/notes/liked"
+    post :create
+    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
+    assert_equal "Successfully linked to your account!", flash[:notice]
+  end
+
+  test "user that links provider to existing account should not be redirected to dashboard on oauth signup for Facebook provider" do
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:facebook4]
+    request.env['omniauth.origin'] = "/notes/liked"
+    post :create
+    assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
+    assert_equal "Successfully linked to your account!", flash[:notice]
+  end
+
+  test "user that links provider to existing account should not be redirected to dashboard on oauth signup for Twitter provider" do
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter4]
+    request.env['omniauth.origin'] = "/notes/liked"
     post :create
     assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
     assert_equal "Successfully linked to your account!", flash[:notice]


### PR DESCRIPTION
Fixes #7240 

Now, when a user signs up for the first time through oauth they will be redirected to the dashboard instead of the previous page:
![signup-redirection](https://user-images.githubusercontent.com/52892257/72416924-094f0c00-3778-11ea-996b-cd9d47d48dc5.gif)

I have added an omniauth test user in the config that has the same email as one of the users in the fixtures. That way, I could use this mock omniauth user to login and verify that the oauth was successfully linked to the fixture user with the same email.