### PR TITLE
ADD: Comment HTML sanitization and tests for it

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -473,7 +473,14 @@ class Comment < ApplicationRecord
     if !trimmed_content? && parsed.present?
       body = parsed[:body] + COMMENT_FILTER + parsed[:boundary] + parsed[:quote]
     end
-    body
+
+    allowed_tags = %w(a acronym b strong i em li ul ol h1 h2 h3 h4 h5 h6 blockquote br cite sub sup ins p iframe del hr img input code table thead tbody tr th td span dl dt dd div)
+
+    # Sanitize the HTML (remove malicious attributes, unallowed tags...)
+    sanitized_body = ActionController::Base.helpers.sanitize(body, tags: allowed_tags)
+
+    # Properly parse HTML (close incomplete tags...)
+    Nokogiri::HTML::DocumentFragment.parse(sanitized_body).to_html
   end
 
   def self.find_by_tag_and_author(tagname, userid)

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -677,7 +677,7 @@ class NotesControllerTest < ActionController::TestCase
     assert (notes & expected).present?
     assert !(notes & questions).present?
   end
-  
+
     test 'first note in /liked endpoint should be highest liked' do
     get :liked
     notes = assigns(:notes)
@@ -696,7 +696,7 @@ class NotesControllerTest < ActionController::TestCase
     actual = notes.first
     assert expected == actual.created
   end
-     
+
   test 'first three posts in /liked should be sorted by likes' do
     get :liked
     # gets first notes
@@ -704,7 +704,7 @@ class NotesControllerTest < ActionController::TestCase
      # sort_by is from lowest to highest so it needs to be reversed
     assert notes.sort_by { |note| note.cached_likes }.reverse ==  notes
   end
-   
+
   test 'should choose I18n for notes controller' do
     available_testing_locales.each do |lang|
       old_controller = @controller

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -260,12 +260,15 @@ class CommentTest < ActiveSupport::TestCase
     comment = Comment.new({
       comment: "Thank you! On Tuesday, 3 July 2018, 11:20:57 PM IST, RP <rp@email.com> wrote:  Here you go."
     })
+
     parsed = comment.parse_quoted_text
+    output = comment.render_body
+
     assert_equal "Thank you! ", parsed[:body]
     assert_equal "On Tuesday, 3 July 2018, 11:20:57 PM IST, RP <rp@email.com> wrote:", parsed[:boundary]
     assert_equal "  Here you go.", parsed[:quote]
     assert_equal "Thank you! ", comment.scrub_quoted_text
-    assert_equal "Thank you! <!-- @@$$%% Trimmed Content @@$$%% -->On Tuesday, 3 July 2018, 11:20:57 PM IST, RP <rp@email.com> wrote:  Here you go.", comment.render_body
+    assert_equal output, "Thank you! On Tuesday, 3 July 2018, 11:20:57 PM IST, RP  wrote:  Here you go."
   end
 
   test 'should give the domain of gmail correctly' do
@@ -313,4 +316,38 @@ class CommentTest < ActiveSupport::TestCase
   test 'find comments using tagname and user id' do
     assert_equal('Admin comment', Comment.find_by_tag_and_author("awesome", 5).first.comment)
   end
+
+  test 'sanitizing comment body for XSS' do
+    comment = Comment.new
+    comment.comment = "<img src=x onerror=prompt(133)>" # inserting executable javascript into a comment
+    assert comment.save
+
+    output = comment.render_body
+
+    # Ensure that malicious attributes have been removed
+    assert_equal [], output.scan('src=x')
+    assert_equal [], output.scan('onerror=prompt')
+
+    # Ensure all the OK attributes are preserved, for a wide range of comment types:
+    comment.comment = "<iframe src='/hello' width='100' height='100' border='0'></iframe><p style='color:red;' class='nice' id='cool' title='sweet'></p>"
+    assert comment.save
+    output = comment.render_body
+
+    assert_equal [], output.scan("src='/hello' width='100' height='100' border='0'")
+    assert_equal [], output.scan("class='nice' id='cool' title='sweet'")
+  end
+
+  test 'should close incomplete tags' do
+    comment = Comment.new
+
+    # <iframe> is not closed (</iframe>)
+    comment.comment = "Let’s see how this works with images or an embedded video.\n\n&nbsp;\n\n![](cid:image001.jpg@01D45C10.01D90920)\n\n&nbsp;\n\n\\<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/Kt\\_MSMpxy7Y\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen\\>\\\n\n&nbsp;\n\nIs \\ ***markdown** \\* parsed?\n\n&nbsp;\n\n1. 1. Number 1\n\n2. 4. Number 4\n\n3. 3. Number 3\n\n&nbsp;"
+
+    assert comment.save
+    output = comment.render_body
+
+    # Make sure that <iframe> is closed (</iframe>)
+    assert_not_equal [], output.scan('<iframe width="560" height="315" src="https://www.youtube.com/embed/Kt%5C_MSMpxy7Y">\</iframe>')
+  end
+
 end


### PR DESCRIPTION
This PR resolves 2 other PRs, they are closely related so I didn't want to separate them.

I've added HTML sanitization as explained in the comments.

```ruby
   allowed_tags = %w(a acronym b strong i em li ul ol h1 h2 h3 h4 h5 h6 blockquote br...)

   # Sanitize the HTML (remove malicious attributes, unallowed tags...)
   sanitized_body = ActionController::Base.helpers.sanitize(body, tags: allowed_tags)

   # Properly parse HTML (close incomplete tags...)
   Nokogiri::HTML::DocumentFragment.parse(sanitized_body).to_html
```

There is no need to specify allowed attributes because `.sanitize` automatically strips malicious attributes.

Unit tests:
 - "sanitizing comment body for XSS"
 - "should close incomplete tags"

[Demo](https://streamable.com/hoifc)

Resolves #3630 & #3553
