### PR TITLE
Fix location modal jumping off-screen at small screen sizes

### DIFF
--- a/app/assets/stylesheets/location.css
+++ b/app/assets/stylesheets/location.css
@@ -20,6 +20,9 @@
   margin: 0;
 }
 
+#blurred-location-modal .modal-content {
+  margin-top: 0;
+}
 #blurred-location-modal .small-description {
   font-size: 0.9rem;
   color: #808080;


### PR DESCRIPTION
Fixes #7283  (<=== Add issue number here)

I'm not sure where the negative margin is coming from, but setting it to 0 for `#blurred-location-modal .modal-content` fixes the problem.