### PR TITLE
FIX: "password not set" error for oauth

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -276,6 +276,7 @@ class UsersController < ApplicationController
             if @user.changed? && @user.save
               flash[:notice] = I18n.t('users_controller.password_change_success')
               @user.password_checker = 0
+              @user.save
               redirect_to "/dashboard"
             else
               flash[:error] = I18n.t('users_controller.password_reset_failed').html_safe

--- a/test/integration/login_flow_test.rb
+++ b/test/integration/login_flow_test.rb
@@ -147,4 +147,38 @@ class LoginFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/dashboard'
   end
 
+  test "omniauth user should be able to reset password and login with it" do
+    
+    # login user through oauth
+    get '/auth/google_oauth2'
+    assert_redirected_to '/auth/google_oauth2/callback'
+
+    Rails.application.env_config["omniauth.auth"] =  OmniAuth.config.mock_auth[:google_oauth2]
+    #Sign Up through oauth
+    post "/user_sessions"
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
+
+    # find new user in db
+    user = User.find_by(name: "jeff")
+
+    # setup reset key to create password
+    key = user.generate_reset_key
+    user.save
+
+    user_attributes = user.attributes
+    user_attributes[:password] = 'newpassword'
+    user_attributes[:password_confirmation] = 'newpassword'
+
+    get "/reset", params: { key: key, user: user_attributes }
+
+    assert_equal 'Your password was successfully changed.', flash[:notice]
+
+    # logout
+    delete "/user_sessions/#{user.id}"
+    assert_equal "Successfully logged out.",  flash[:notice]
+
+    # login successfully with new password
+    post "/user_sessions", params: { password: "newpassword", username: user.name }
+    assert_equal "Successfully logged in.",  flash[:notice]
+  end
 end

--- a/test/integration/login_flow_test.rb
+++ b/test/integration/login_flow_test.rb
@@ -180,5 +180,8 @@ class LoginFlowTest < ActionDispatch::IntegrationTest
     # login successfully with new password
     post "/user_sessions", params: { password: "newpassword", username: user.name }
     assert_equal "Successfully logged in.",  flash[:notice]
+    
+    # !!IMPORTANT!! hash must be set to nil or it will be preserved and all the tests will fail
+    Rails.application.env_config["omniauth.auth"] =  nil
   end
 end

--- a/test/integration/login_flow_test.rb
+++ b/test/integration/login_flow_test.rb
@@ -147,8 +147,9 @@ class LoginFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/dashboard'
   end
 
-  test "omniauth user should be able to reset password and login with it" do
-    
+ 
+test 'reset password for google oauth user' do
+
     # login user through oauth
     get '/auth/google_oauth2'
     assert_redirected_to '/auth/google_oauth2/callback'
@@ -159,7 +160,7 @@ class LoginFlowTest < ActionDispatch::IntegrationTest
     assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
 
     # find new user in db
-    user = User.find_by(name: "jeff")
+    user = User.find_by(username: "bansal_sidharth309")
 
     # setup reset key to create password
     key = user.generate_reset_key
@@ -180,8 +181,117 @@ class LoginFlowTest < ActionDispatch::IntegrationTest
     # login successfully with new password
     post "/user_sessions", params: { password: "newpassword", username: user.name }
     assert_equal "Successfully logged in.",  flash[:notice]
-    
-    # !!IMPORTANT!! hash must be set to nil or it will be preserved and all the tests will fail
+    Rails.application.env_config["omniauth.auth"] =  nil
+  end
+
+
+  test 'reset password for github oauth user' do
+
+    # login user through oauth
+    get '/auth/github'
+    assert_redirected_to '/auth/github/callback'
+
+    Rails.application.env_config["omniauth.auth"] =  OmniAuth.config.mock_auth[:github1]
+    #Sign Up through oauth
+    post "/user_sessions"
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
+
+    # find new user in db
+    user = User.find_by(username: "bansal_sidharth309")
+
+    # setup reset key to create password
+    key = user.generate_reset_key
+    user.save
+
+    user_attributes = user.attributes
+    user_attributes[:password] = 'newpassword'
+    user_attributes[:password_confirmation] = 'newpassword'
+
+    get "/reset", params: { key: key, user: user_attributes }
+
+    assert_equal 'Your password was successfully changed.', flash[:notice]
+
+    # logout
+    delete "/user_sessions/#{user.id}"
+    assert_equal "Successfully logged out.",  flash[:notice]
+
+    # login successfully with new password
+    post "/user_sessions", params: { password: "newpassword", username: user.name }
+    assert_equal "Successfully logged in.",  flash[:notice]
+    Rails.application.env_config["omniauth.auth"] =  nil
+  end
+
+
+  test 'reset password for twitter oauth user' do
+
+    # login user through oauth
+    get '/auth/twitter'
+    assert_redirected_to '/auth/twitter/callback'
+
+    Rails.application.env_config["omniauth.auth"] =  OmniAuth.config.mock_auth[:twitter1]
+    #Sign Up through oauth
+    post "/user_sessions"
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
+
+    # find new user in db
+    user = User.find_by(username: "bansal_sidharth309")
+
+    # setup reset key to create password
+    key = user.generate_reset_key
+    user.save
+
+    user_attributes = user.attributes
+    user_attributes[:password] = 'newpassword'
+    user_attributes[:password_confirmation] = 'newpassword'
+
+    get "/reset", params: { key: key, user: user_attributes }
+
+    assert_equal 'Your password was successfully changed.', flash[:notice]
+
+    # logout
+    delete "/user_sessions/#{user.id}"
+    assert_equal "Successfully logged out.",  flash[:notice]
+
+    # login successfully with new password
+    post "/user_sessions", params: { password: "newpassword", username: user.name }
+    assert_equal "Successfully logged in.",  flash[:notice]
+    Rails.application.env_config["omniauth.auth"] =  nil
+  end
+
+
+  test 'reset password for facebook oauth user' do
+
+    # login user through oauth
+    get '/auth/facebook'
+    assert_redirected_to '/auth/facebook/callback'
+
+    Rails.application.env_config["omniauth.auth"] =  OmniAuth.config.mock_auth[:facebook1]
+    #Sign Up through oauth
+    post "/user_sessions"
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
+
+    # find new user in db
+    user = User.find_by(username: "bansal_sidharth309")
+
+    # setup reset key to create password
+    key = user.generate_reset_key
+    user.save
+
+    user_attributes = user.attributes
+    user_attributes[:password] = 'newpassword'
+    user_attributes[:password_confirmation] = 'newpassword'
+
+    get "/reset", params: { key: key, user: user_attributes }
+
+    assert_equal 'Your password was successfully changed.', flash[:notice]
+
+    user = User.find_by(name: "jeff")
+    delete "/user_sessions/#{user.id}"
+    assert_equal "Successfully logged out.",  flash[:notice]
+
+    # login successfully with new password
+    post "/user_sessions", params: { password: "newpassword", username: user.name }
+    assert_equal "Successfully logged in.",  flash[:notice]
     Rails.application.env_config["omniauth.auth"] =  nil
   end
 end


### PR DESCRIPTION
Fixes #5918

This error was happening because in the `users_controller` when an oauth user would update their password, the `password_checker` value that is used to indicate that a user has a password, was not updated.

This is where the problem was:
https://github.com/publiclab/plots2/blob/d8c644a5304211ad461374d2bba4c90b25f86100/app/controllers/users_controller.rb#L271-L280

Although the `password_checker` is set to 0, the user is not saved so the changes are not saved.
This is is fixed in the pr. You can see it working here:
![login-successful](https://user-images.githubusercontent.com/52892257/72666731-5ac7f700-3a15-11ea-8785-a5ad9ffdbbc5.gif)

