### PR TITLE
FIX: messages when logging in without password for oauth

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -117,7 +117,7 @@ class UserSessionsController < ApplicationController
 
   def handle_site_login_flow
     username = params[:user_session][:username] if params[:user_session]
-    u = User.find_by(username: username)
+    u = User.find_by(username: username) || User.find_by(email: username)
     if u && u.password_checker != 0
       n = u.password_checker
       hash = { 1 => "Facebook", 2 => "Github", 3 => "Google", 4 => "Twitter"  }

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -18,7 +18,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_redirected_to '/dashboard'
   end
 
-  test 'should login and redirect to corresct url' do
+  test 'should login and redirect to correct url' do
     session[:return_to] = '/post?tags=question:question&template=question'
     post :create, params: { user_session: { username: users(:jeff).username, password: 'secretive' } }
     assert_redirected_to '/post?tags=question:question&template=question'
@@ -303,7 +303,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_redirected_to "/notes/liked?_=#{Time.now.to_i.to_s}"
   end
   
-  test "logging in through omniauth and then through normal login should display error and redirect" do
+  test "logging in through omniauth and then logging in with username should display correct error and redirect" do
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
     # login through omniauth 
     post :create
@@ -311,6 +311,17 @@ class UserSessionsControllerTest < ActionController::TestCase
     post :destroy
     request.env['omniauth.auth'] = nil
     post :create, params: { user_session: { username: "bansal_sidharth309", password: "random"} }
+    assert_equal flash[:error], "This account doesn't have a password set. It may be logged in with Github account, or you can set a new password via Forget password feature"
+  end
+  
+  test "logging in through omniauth and then logging in with email should display correct error and redirect" do
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:github1]
+    # login through omniauth 
+    post :create
+    # logout
+    post :destroy
+    request.env['omniauth.auth'] = nil
+    post :create, params: { user_session: { username: "bansal_sidharth309@gmail.com", password: "random"} }
     assert_equal flash[:error], "This account doesn't have a password set. It may be logged in with Github account, or you can set a new password via Forget password feature"
   end
   

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -321,7 +321,7 @@ class UserSessionsControllerTest < ActionController::TestCase
     # logout
     post :destroy
     request.env['omniauth.auth'] = nil
-    post :create, params: { user_session: { username: "bansal_sidharth309@gmail.com", password: "random"} }
+    post :create, params: { user_session: { username: "bansal.sidharth309@gmail.com", password: "random"} }
     assert_equal flash[:error], "This account doesn't have a password set. It may be logged in with Github account, or you can set a new password via Forget password feature"
   end
   


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/pull/7291#issuecomment-575913424.

This problem is now fixed:
> If a user signs up with Oauth but does not set their password, and then tries to login with their email as username, they will get a `password_invalid` error instead of a message prompting them to set their password.
> 
> On the other hand, the correct message is displayed when trying to login with username.

