### PR TITLE
ADD: Tests for wiki revisions

### DIFF
--- a/app/views/like/_like.html.erb
+++ b/app/views/like/_like.html.erb
@@ -17,7 +17,7 @@
           <i class="ml-1 ff fa fa-lock"></i>
         </a>
       <% else %>
-        <a class="btn-circle btn btn-outline-secondary" href='<%= node.edit_path %>?t=<%= Time.now.to_i %>'>
+        <a class="btn-circle btn btn-outline-secondary" id="edit-btn" href='<%= node.edit_path %>?t=<%= Time.now.to_i %>'>
           <i class='ml-1 ff fa fa-pencil'></i>
         </a>
       <% end %>

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -127,26 +127,22 @@ class PostTest < ApplicationSystemTestCase
     # save text of wiki before edit
     old_wiki_content = find("#content").text
 
-    # edit content
-    find("a[data-original-title='Try the beta inline Rich Wiki editor.']").click()
-    first("div.inline-section").hover()
-    using_wait_time(2) { first("a.inline-edit-btn").click() }
-    find("div.wk-wysiwyg").set("wiki text")
-    click_on "Save"
+    find("a#edit-btn").click()
+    find("#text-input").set("wiki text")
+    find("a#publish").click()
 
     # view wiki
-    find("a[href='#{wiki.path}'").click()
     current_wiki_content = find("#content").text
     # make sure edits worked and text is different
     assert current_wiki_content != old_wiki_content
 
-    find("a[data-original-title='View previous versions of this page.']").click()
+    find("a[data-original-title='View all revisions for this page.']").click()
     accept_confirm "Are you sure?" do
       # revert to previous version of wiki
       all("a", text: "Revert")[1].click()
     end
     visit wiki.path
-    
+
     # check old wiki content is the same as current content after revert
     assert old_wiki_content == find("#content").text 
   end
@@ -156,16 +152,11 @@ class PostTest < ApplicationSystemTestCase
 
     visit wiki.path
 
-    # edit content
-    find("a[data-original-title='Try the beta inline Rich Wiki editor.']").click()
-    first("div.inline-section").hover()
-    using_wait_time(2) { first("a.inline-edit-btn").click() }
-    find("div.wk-wysiwyg").native.send_keys(:enter, "wiki text")
-    click_on "Save"
+    find("a#edit-btn").click()
+    find("#text-input").native.send_keys(:enter, :enter, "wiki text")
+    find("a#publish").click()
 
-    find("a[href='#{wiki.path}'").click()
-    find("a[data-original-title='View previous versions of this page.']").click()
-
+    find("a[data-original-title='View all revisions for this page.']").click()
 
     # verify additions are displayed as green `<ins>` tags
     page.assert_selector("ins", text: "<p>wiki")

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -9,7 +9,7 @@ class PostTest < ApplicationSystemTestCase
     visit '/'
 
     find(".nav-link.loginToggle").click()
-    fill_in("username-login", with: "jeff")
+    fill_in("username-login", with: "palpatine")
     fill_in("password-signup", with: "secretive")
 
     find(".login-modal-form #login-button").click()
@@ -128,7 +128,7 @@ class PostTest < ApplicationSystemTestCase
     old_wiki_content = find("#content").text
 
     # edit content
-    find("a[title='Try the beta inline Rich Wiki editor.']").click()
+    find("a[data-original-title='Try the beta inline Rich Wiki editor.']").click()
     first("div.inline-section").hover()
     using_wait_time(2) { first("a.inline-edit-btn").click() }
     find("div.wk-wysiwyg").set("wiki text")
@@ -157,7 +157,7 @@ class PostTest < ApplicationSystemTestCase
     visit wiki.path
 
     # edit content
-    find("a[title='Try the beta inline Rich Wiki editor.']").click()
+    find("a[data-original-title='Try the beta inline Rich Wiki editor.']").click()
     first("div.inline-section").hover()
     using_wait_time(2) { first("a.inline-edit-btn").click() }
     find("div.wk-wysiwyg").native.send_keys(:enter, "wiki text")

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -122,12 +122,6 @@ class PostTest < ApplicationSystemTestCase
   
   test "changing and reverting versions works correctly for wiki" do
     wiki = nodes(:wiki_page)
-    visit '/'
-    click_on 'Login'
-
-    fill_in("username-login", with: "palpatine")
-    fill_in("password-signup", with: "secretive")
-    click_on "Log in"
 
     visit wiki.path
     # save text of wiki before edit
@@ -159,12 +153,6 @@ class PostTest < ApplicationSystemTestCase
 
   test "revision diff is displayed when comparing versions" do
     wiki = nodes(:wiki_page)
-    visit '/'
-    click_on 'Login'
-
-    fill_in("username-login", with: "palpatine")
-    fill_in("password-signup", with: "secretive")
-    click_on "Log in"
 
     visit wiki.path
 

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -128,7 +128,7 @@ class PostTest < ApplicationSystemTestCase
     old_wiki_content = find("#content").text
 
     # edit content
-    find("a[data-original-title='Try the beta inline Rich Wiki editor.']").click()
+    find("a[title='Try the beta inline Rich Wiki editor.']").click()
     first("div.inline-section").hover()
     using_wait_time(2) { first("a.inline-edit-btn").click() }
     find("div.wk-wysiwyg").set("wiki text")
@@ -157,7 +157,7 @@ class PostTest < ApplicationSystemTestCase
     visit wiki.path
 
     # edit content
-    find("a[data-original-title='Try the beta inline Rich Wiki editor.']").click()
+    find("a[title='Try the beta inline Rich Wiki editor.']").click()
     first("div.inline-section").hover()
     using_wait_time(2) { first("a.inline-edit-btn").click() }
     find("div.wk-wysiwyg").native.send_keys(:enter, "wiki text")

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -9,7 +9,7 @@ class PostTest < ApplicationSystemTestCase
     visit '/'
 
     find(".nav-link.loginToggle").click()
-    fill_in("username-login", with: "palpatine")
+    fill_in("username-login", with: "jeff")
     fill_in("password-signup", with: "secretive")
 
     find(".login-modal-form #login-button").click()


### PR DESCRIPTION
For #5316.

These tests verify different parts of the wiki revisions feature:
- verifies that reverting to previous versions after editing works correctly
- checks that the diff when comparing versions (see below) is displayed correctly:
![revision-diff](https://user-images.githubusercontent.com/52892257/72669211-60cad180-3a2f-11ea-94fd-010d0c7b77a7.png)

What do you think @SidharthBansal @jywarren @VladimirMikulic?
