### PR TITLE
ADD: Keyboard shortcut to publish a comment and tests for it

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -36,11 +36,11 @@
         var isPostCommentShortcut = (e.ctrlKey && e.keyCode === 10) || (e.metaKey && e.keyCode === 13);
 
         if (isPostCommentShortcut) {
-        $(this).find(".btn-primary").click();
+          $(this).find(".btn-primary").click();
         }
       });
     }
-    
+
   });
 }());
 
@@ -48,7 +48,7 @@ function insertTitleSuggestionTemplate() {
   var element = $('#text-input');
   var currentText = $('#text-input').val().trim();
   var template = "\n[propose:title]Propose your title here[/propose]";
-  if (currentText.length === 0) { 
+  if (currentText.length === 0) {
     template = "[propose:title]Propose your title here[/propose]";
   }
   var newText = currentText+template;

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -31,11 +31,14 @@
 
     if(!$(this).hasClass('bound-keypress')) {
       $(this).addClass('bound-keypress');
-      $(this).find('#text-input').bind('keypress',function(e){
-        if (e.ctrlKey && e.keyCode === 10) {
+
+      $(this).on('keypress', function (e) {
+        var isPostCommentShortcut = (e.ctrlKey && e.keyCode === 10) || (e.metaKey && e.keyCode === 13);
+
+        if (isPostCommentShortcut) {
         $(this).find(".btn-primary").click();
         }
-      })
+      });
     }
     
   });

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -53,7 +53,7 @@
         <i data-toggle="tooltip" title="This comment was posted by email." class="fa fa-envelope"></i>
       <% end %>
       <% if current_user && comment.uid == current_user.uid %>
-        <a class="btn btn-outline-secondary btn-sm" href="javascript:void(0)" onClick="$('#c<%= comment.cid %>edit').toggle();$('#c<%= comment.cid %>show').toggle();setInit(<%= comment.cid %>);">
+        <a class="btn btn-outline-secondary btn-sm" id="edit-comment-btn" href="javascript:void(0)" onClick="$('#c<%= comment.cid %>edit').toggle();$('#c<%= comment.cid %>show').toggle();setInit(<%= comment.cid %>);">
           <i class="fa fa-pencil"></i>
         </a>
       <% end %>

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -180,11 +180,11 @@ class CommentTest < ApplicationSystemTestCase
 
     # Create a comment
     page.execute_script <<-JS
-      var commentForm = $(".comment-form-wrapper")[1];
-      var submitCommentBtn = $(commentForm).find(".btn")[0];
-      var commentTextarea = $(commentForm).find("#text-input")[0]
+      var commentForm = $('.comment-form-wrapper')[1];
+      var submitCommentBtn = $(commentForm).find('.btn')[0];
+      var commentTextarea = $(commentForm).find('#text-input')[0]
 
-      $(commentTextarea).val("Great post Jeff!")
+      $(commentTextarea).val('Great post Jeff!')
       $(submitCommentBtn).click()
     JS
 
@@ -196,6 +196,43 @@ class CommentTest < ApplicationSystemTestCase
 
     assert_selector('#comments-list .comment', count: 1)
     assert_selector('.noty_body', text: 'Comment deleted')
+  end
+
+  test 'comment editing' do
+    visit "/wiki/wiki-page-path/comments"
+
+    # Create a comment
+    page.execute_script <<-JS
+      var commentForm = $('.comment-form-wrapper')[1];
+      var submitCommentBtn = $(commentForm).find('.btn')[0];
+      var commentTextarea = $(commentForm).find('#text-input')[0]
+
+      // Fill the form
+      $(commentTextarea).val('Great post Jeff!')
+      $(submitCommentBtn).click()
+    JS
+
+    # Wait for comment to upload
+    wait_for_ajax
+
+    # Edit the comment
+    page.execute_script <<-JS
+      var comment = $(".comment")[1];
+      var commentID = comment.id;
+      var editCommentBtn = $(comment).find('.navbar-text #edit-comment-btn')
+
+      // Toggle edit mode
+      $(editCommentBtn).click()
+
+      var commentTextarea = $('#' + commentID + 'text');
+      $(commentTextarea).val('Updated comment.')
+
+      var submitCommentBtn = $('#' + commentID + ' .control-group .btn-primary')[1];
+      $(submitCommentBtn).click()
+    JS
+
+    message = find('.alert-success', match: :first).text
+    assert_equal( "×\nComment updated.", message)
   end
 
 end

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -123,4 +123,79 @@ class CommentTest < ApplicationSystemTestCase
     page.assert_selector('#preview img', count: 1)
   end
 
+  test 'ctrl/cmd + enter comment publishing keyboard shortcut' do
+    visit "/wiki/wiki-page-path/comments"
+
+    find("p", text: "Reply to this comment...").click()
+
+    # Write a comment
+    page.all("#text-input")[1].set("Great post!")
+
+    page.execute_script <<-JS
+      // Remove first text-input field
+      $("#text-input").remove()
+
+      var $textBox = $("#text-input");
+
+      // Generate fake CTRL + Enter event
+      var press = jQuery.Event("keypress");
+      press.altGraphKey = false;
+      press.altKey = false;
+      press.bubbles = true;
+      press.cancelBubble = false;
+      press.cancelable = true;
+      press.charCode = 10;
+      press.clipboardData = undefined;
+      press.ctrlKey = true;
+      press.currentTarget = $textBox[0];
+      press.defaultPrevented = false;
+      press.detail = 0;
+      press.eventPhase = 2;
+      press.keyCode = 10;
+      press.keyIdentifier = "";
+      press.keyLocation = 0;
+      press.layerX = 0;
+      press.layerY = 0;
+      press.metaKey = false;
+      press.pageX = 0;
+      press.pageY = 0;
+      press.returnValue = true;
+      press.shiftKey = false;
+      press.srcElement = $textBox[0];
+      press.target = $textBox[0];
+      press.type = "keypress";
+      press.view = Window;
+      press.which = 10;
+
+      // Emit fake CTRL + Enter event
+      $textBox.trigger(press);
+    JS
+
+    assert_selector('#comments-list .comment', count: 2)
+    assert_selector('.noty_body', text: 'Comment Added!')
+  end
+
+  test 'comment deletion' do
+    visit "/wiki/wiki-page-path/comments"
+
+    # Create a comment
+    page.execute_script <<-JS
+      var commentForm = $(".comment-form-wrapper")[1];
+      var submitCommentBtn = $(commentForm).find(".btn")[0];
+      var commentTextarea = $(commentForm).find("#text-input")[0]
+
+      $(commentTextarea).val("Great post Jeff!")
+      $(submitCommentBtn).click()
+    JS
+
+    # Delete a comment
+    find('.btn[data-original-title="Delete comment"]', match: :first).click()
+
+    # Click "confirm" on modal
+    page.evaluate_script('document.querySelector(".jconfirm-buttons .btn:first-of-type").click()')
+
+    assert_selector('#comments-list .comment', count: 1)
+    assert_selector('.noty_body', text: 'Comment deleted')
+  end
+
 end

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -142,8 +142,6 @@ class PostTest < ApplicationSystemTestCase
       find('#row0 a[data-confirm="Are you sure?"]', text: "Revert").click()
     end
 
-    visit '/wiki/wiki-page-path/'
-
     wiki_content = find("#content p").text
 
     # check old wiki content is the same as current content after revert


### PR DESCRIPTION
Pressing CTRL/CMD + Enter will publish a comment.

Comment tests:
 - CTRL/CMD + enter comment publishing keyboard shortcut
 - comment deletion

Resolves #5193 & #5473