### PR TITLE
ADD: system tests for moderation, posts and comments

### DIFF
--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -235,4 +235,18 @@ class CommentTest < ApplicationSystemTestCase
     assert_equal( "×\nComment updated.", message)
   end
 
+  test "reacting and unreacting to comment" do
+    note = nodes(:one)
+    visit note.path
+    
+    first(".comment #dropdownMenuButton").click()
+
+    # click on thumbs up
+    find("img[src='https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png']").click()
+    page.assert_selector("button[data-original-title='jeff reacted with thumbs up emoji']")
+
+    first("img[src='https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png']").click()
+    page.assert_no_selector("button[data-original-title='jeff reacted with thumbs up emoji'")
+  end
+
 end

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -9,7 +9,7 @@ class PostTest < ApplicationSystemTestCase
     visit '/'
 
     find(".nav-link.loginToggle").click()
-    fill_in("username-login", with: "jeff")
+    fill_in("username-login", with: "palpatine")
     fill_in("password-signup", with: "secretive")
 
     find(".login-modal-form #login-button").click()
@@ -226,6 +226,18 @@ class PostTest < ApplicationSystemTestCase
     message = find('.alert-success', match: :first).text
 
     assert_equal( "×\nContent deleted.", message )
+  end
+
+  test "awarding barnstar functions correctly" do
+    note = nodes(:one)
+    visit note.path
+
+    find("span[data-original-title='Tools']").click()
+    find("input[value='Give']").click()
+
+    page.assert_selector("div.alert-success", text: "You awarded the basic barnstar to #{note.author.name}")
+    page.assert_selector("p", text: "#{note.author.name} was awarded the Basic Barnstar by palpatine for their work in this research note.")
+    page.assert_selector(".comment-body p", text: "@palpatine awards a barnstar to #{note.author.name} for their awesome contribution!")
   end
 
 end


### PR DESCRIPTION
For #5316

I have included tests for the following functionality in this pr:

- spamming and unspamming a page using the `/spam` admin dashboard
- spamming a comment
- reacting to a comment in the same way we can react on github
- giving barnstar works correctly

What do you think @SidharthBansal?