### PR TITLE
Refresh markers on initial page load

### DIFF
--- a/app/assets/javascripts/leaflet_helper.js
+++ b/app/assets/javascripts/leaflet_helper.js
@@ -108,6 +108,7 @@
 
        if(typeof mainLayer !== "undefined" && mainLayer !== ""){
            if(mainLayer === "people"){
+               peopleLayerParser(map, markers_hash);
                
                map.on('zoomend' , function () {
                   peopleLayerParser(map, markers_hash);
@@ -118,6 +119,7 @@
                }) ;
            }
            else if(mainLayer === "content"){
+               contentLayerParser(map, markers_hash);
                
                map.on('zoomend' , function () {
                    contentLayerParser(map, markers_hash);
@@ -128,6 +130,7 @@
                }) ;
            }
            else { // it is a tagname
+               contentLayerParser(map, markers_hash, mainLayer);
 
                map.on('zoomend' , function () {
                    contentLayerParser(map, markers_hash, mainLayer);

--- a/app/assets/javascripts/leaflet_helper.js
+++ b/app/assets/javascripts/leaflet_helper.js
@@ -93,54 +93,39 @@
 
    function setupInlineLEL(map , layers, mainLayer, markers_hash) {
 
-       layers = layers.split(',');
+      layers = layers.split(',');
 
-       L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png').addTo(map) ;
+      L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png').addTo(map) ;
 
-       var oms = omsUtil(map, {
-          keepSpiderfied: true,
-          circleSpiralSwitchover: 0
-       });
+      var oms = omsUtil(map, {
+         keepSpiderfied: true,
+         circleSpiralSwitchover: 0
+      });
 
-       L.LayerGroup.EnvironmentalLayers({
-           include: layers,
-       }).addTo(map);
+      L.LayerGroup.EnvironmentalLayers({
+         include: layers,
+      }).addTo(map);
 
-       if(typeof mainLayer !== "undefined" && mainLayer !== ""){
-           if(mainLayer === "people"){
-               peopleLayerParser(map, markers_hash);
-               
-               map.on('zoomend' , function () {
-                  peopleLayerParser(map, markers_hash);
-               }) ;
+      if(typeof mainLayer !== "undefined" && mainLayer !== ""){
+         if(mainLayer === "people"){
+            peopleMap();
+            map.on('zoomend', peopleMap);
+            map.on('moveend', peopleMap);
+         }
+         else {
+            mainLayer = (mainLayer === "content") ? null : mainLayer;
+            contentMap();
+            map.on('zoomend', contentMap);
+            map.on('moveend', contentMap);
+         }
+      }
 
-               map.on('moveend' , function () {
-                   peopleLayerParser(map, markers_hash);
-               }) ;
-           }
-           else if(mainLayer === "content"){
-               contentLayerParser(map, markers_hash);
-               
-               map.on('zoomend' , function () {
-                   contentLayerParser(map, markers_hash);
-               }) ;
-
-               map.on('moveend' , function () {
-                   contentLayerParser(map, markers_hash);
-               }) ;
-           }
-           else { // it is a tagname
-               contentLayerParser(map, markers_hash, mainLayer);
-
-               map.on('zoomend' , function () {
-                   contentLayerParser(map, markers_hash, mainLayer);
-               }) ;
-
-               map.on('moveend' , function () {
-                   contentLayerParser(map, markers_hash, mainLayer);
-               }) ;
-           }
-       }
+      function contentMap() {
+         contentLayerParser(map, markers_hash, mainLayer);
+      }
+      function peopleMap() {
+         peopleLayerParser(map, markers_hash);
+      }
    }
 
    function setupLEL(map , sethash){


### PR DESCRIPTION
Fixes #6910 (<=== Add issue number here)

I don't know why the LEL layers aren't showing up at all on my localhost, but this shows on a page refresh that the content markers are behaving as they should be.

![Peek 2020-01-24 11-49](https://user-images.githubusercontent.com/49460529/73087188-23879900-3ea0-11ea-9131-0d1b55ed85c6.gif)
