### PR TITLE
Set map default zoom level

### DIFF
--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -51,9 +51,9 @@
         
       const params = urlHash.getUrlHashParameters();
      
-      var lat = parseFloat(params.lat);
-      var lon = parseFloat(params.lon);
-      var zoom = parseFloat(params.zoom);
+      var lat = parseFloat(params.lat) || 10;
+      var lon = parseFloat(params.lon) || 1;
+      var zoom = parseFloat(params.zoom) || 6;
 
       const bounds = new L.LatLngBounds(
         new L.LatLng(84.67351257, -172.96875),


### PR DESCRIPTION
Fixes #7357 (<=== Add issue number here)

This sets a default zoom, lat and lon in the map page so that even if a parameter is missing the map still loads.