### PR TITLE
Move map dependencies to header to fix error with map popups not working

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -197,3 +197,5 @@
       opacity:0.5;
   }
 </style>
+
+<%= render :partial => "map/mapDependencies" %>

--- a/app/views/map/_inlineLeaflet.html.erb
+++ b/app/views/map/_inlineLeaflet.html.erb
@@ -1,5 +1,3 @@
-<%= render :partial => "map/mapDependencies" %>
-
 <% unique_id = rand(1000) %>
 
   <style>

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -1,4 +1,3 @@
-<%= render :partial => "map/mapDependencies" %>
 <% top_map ||= false %>
 <% zoom ||= lat.to_s.length.to_i + 6 %>
 <% unique_id = rand(1000) %>

--- a/app/views/map/_peopleLeaflet.html.erb
+++ b/app/views/map/_peopleLeaflet.html.erb
@@ -1,4 +1,3 @@
-<%= render :partial => "map/mapDependencies" %>
 <% unique_id = rand(1000) %>
 
   <style>

--- a/app/views/map/_plainInlineLeaflet.html.erb
+++ b/app/views/map/_plainInlineLeaflet.html.erb
@@ -1,5 +1,3 @@
-<%= render :partial => "map/mapDependencies" %>
-
 <% unique_id = rand(1000) %>
 
   <style>

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -1,5 +1,3 @@
-<%= render :partial => "map/mapDependencies" %>
-
 <div style="width:100%;margin-left:0;height:300px;" id="map"></div>
 <p><i><small>
   <% if !@map_lat.nil? && !@map_lon.nil? %>

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -1,12 +1,9 @@
-<%= render :partial => "map/mapDependencies" %>
-  
   <style>
   body, body>.container, body>.container>.row {
     margin: 0;
     padding: 0;
     width: 100vw;
-    max-width: 100%;
-  }
+    max-width: 100%;  }
   body>.container {
     padding-top: 0px;
   }
@@ -101,9 +98,9 @@
 
 
       L.LayerGroup.EnvironmentalLayers({
-        baseLayers: {
-         'Gray-scale': baselayer
-        },
+        // baseLayers: {
+        //  'Gray-scale': baselayer
+        // },
         // include: layersname,
         hash: false,
         embed: true,


### PR DESCRIPTION
Fixes #7281  (<=== Add issue number here)

Map dependencies cannot be included multiple times on a map without causing an error with the map popups. I have moved the include to the header file and removed it from the other pages. Now the popups work and all the other maps are still working as well.

![FireShot Capture 241 - 🎈 Public Lab_ Inline Maps - localhost](https://user-images.githubusercontent.com/49460529/73279021-76bc5d00-41ba-11ea-8134-091fdb358ad0.png)

![FireShot Capture 243 - 🎈 Public Lab_ Notes on England - localhost](https://user-images.githubusercontent.com/49460529/73279032-7b811100-41ba-11ea-97a7-b70e122e1730.png)

![FireShot Capture 244 - 🎈 Public Lab_ Map - localhost](https://user-images.githubusercontent.com/49460529/73279051-8045c500-41ba-11ea-9977-bf6ed820125c.png)
