### PR TITLE
Move password confirmation field that was in wrong place

### DIFF
--- a/app/views/users/_create_form.html.erb
+++ b/app/views/users/_create_form.html.erb
@@ -59,7 +59,7 @@
       </div>
 
       <div class="form-group col-md-6">
-        <label for="password_confirmation"><%= t('users._form.confirmation') %></label>
+        <label for="password_confirmation"><%= t('users._form.password_confirmation') %></label>
         <%= f.password_field :password_confirmation, { placeholder: I18n.t('users._form.confirm_password'),
                                                        tabindex: 5,
                                                        class: 'form-control',

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -25,45 +25,40 @@
       </div>
 
       <div class="form-group col-md-6">
-
         <label for="email"><%= t('users._form.email') %></label>
         <%= f.text_field :email, { tabindex: 3, required: true, placeholder: "you@email.com", class: 'form-control', id: 'email'} %>
       </div>
 
     </div>
 
-    <!-- <div class="form-group">
-      <label for="email"><%= t('users._form.email') %></label>
-      <%= f.text_field :email, { tabindex: 3, placeholder: "you@email.com", class: 'form-control', id: 'email' } %>
-    </div> -->
-
     <div class="form-group">
-      <% if @user.crypted_password.nil? %>
-        <label for="password"><%= t('users._form.create_password') %></label>
-      <% else %>
-        <label for="password"><%= t('users._form.change_password') %></label>
-      <% end %>
-      <%= f.password_field :password, { placeholder: "Enter your new password",
-                                        tabindex: 4,
-                                        class: 'form-control',
-                                        id: 'password1',
-                                        onpaste: 'return false;' }
+      <label for="current_password"><%= t('users._form.current_password') %></label>
+      <%= f.password_field :current_password, { placeholder: "Type your current password for verification",
+                                                      tabindex: 4,
+                                                      class: 'form-control',
+                                                      id: 'current-password' }
       %>
     </div>
+
     <div class="row">
       <div class="form-group col-md-6">
-        <label for="current_password"><%= t('users._form.current_password') %></label>
-        <%= f.password_field :current_password, { placeholder: "Type your current password for verification",
-                                                       tabindex: 7,
-                                                       class: 'form-control',
-                                                       id: 'current-password' }
+        <% if @user.crypted_password.nil? %>
+          <label for="password"><%= t('users._form.create_password') %></label>
+        <% else %>
+          <label for="password"><%= t('users._form.change_password') %></label>
+        <% end %>
+        <%= f.password_field :password, { placeholder: "Enter your new password",
+                                          tabindex: 5,
+                                          class: 'form-control',
+                                          id: 'password1',
+                                          onpaste: 'return false;' }
         %>
       </div>
 
       <div class="form-group col-md-6">
         <label for="password_confirmation"><%= t('users._form.confirmation') %></label>
         <%= f.password_field :password_confirmation, { placeholder: I18n.t('users._form.confirm_password'),
-                                                       tabindex: 5,
+                                                       tabindex: 6,
                                                        class: 'form-control',
                                                        id: 'password-confirmation',
                                                        onpaste: 'return false;' }
@@ -76,14 +71,14 @@
       <%= f.text_area :bio, { placeholder: I18n.t('users._form.add_bio'),
                                           rows: 8,
                                           class: 'form-control',
-                                          tabindex: 6 }
+                                          tabindex: 7 }
       %>
     </div>
 
     <div class="form-group form-inline" style="clear:both;padding-top:10px;">
 
         <!-- button for saving edits for existing users -->
-        <button class="btn btn-lg btn-primary btn-save" type="submit" tabindex="7"><%= t('users._form.save') %></button>
+        <button class="btn btn-lg btn-primary btn-save" type="submit" tabindex="8"><%= t('users._form.save') %></button>
 
       <script>
         (function() {

--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -56,7 +56,7 @@
       </div>
 
       <div class="form-group col-md-6">
-        <label for="password_confirmation"><%= t('users._form.confirmation') %></label>
+        <label for="password_confirmation"><%= t('users._form.password_confirmation') %></label>
         <%= f.password_field :password_confirmation, { placeholder: I18n.t('users._form.confirm_password'),
                                                        tabindex: 6,
                                                        class: 'form-control',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,7 +112,7 @@ en:
       create_password: "Create a password"
       change_password: "Change your password"
       password: "password"
-      confirmation: "Confirmation"
+      password_confirmation: "Password Confirmation"
       confirm_password: "Retype your password to confirm"
       bio: "Bio"
       add_bio: "Add a short bio to appear on your profile page"


### PR DESCRIPTION
Fixes #7391

Altered field order in the form and the tab indexes.

Page after alterations:
![change-password](https://user-images.githubusercontent.com/33282336/73471096-9b096c80-4367-11ea-927a-ddbe52ac8c1b.gif)
