### PR TITLE
FIX: Wiki revisions test

### DIFF
--- a/app/views/wiki/revisions.html.erb
+++ b/app/views/wiki/revisions.html.erb
@@ -28,7 +28,7 @@
 	  | <%= distance_of_time_in_words(revision.created_at, Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %>
           <div style="display:none;" id="body_<%= @node.revisions.length-1-index %>"><%= raw RDiscount.new(revision.body).to_html %></div>
         </td>
-        <td><small><a class="btn btn-sm btn-outline-secondary" href="/wiki/revert/<%= revision.vid %>" data-confirm="<%= translation('wiki.revisions.are_you_sure') %>"><i class="fa fa-arrow-reload"></i> <%= translation('wiki.revisions.revert') %></a></small></td>
+        <td><small><a class="btn btn-sm btn-outline-secondary btn-revert" href="/wiki/revert/<%= revision.vid %>" data-confirm="<%= translation('wiki.revisions.are_you_sure') %>"><i class="fa fa-arrow-reload"></i> <%= translation('wiki.revisions.revert') %></a></small></td>
         <% if logged_in_as(['admin', 'moderator']) %>
           <% if revision.status == 1 %>
             <td><small><a class='btn btn-sm btn-outline-secondary' data-toggle="tooltip" title="Mark as Spam" data-placement="top" href='/moderate/revision/spam/<%= revision.vid %>' data-confirm="<%= translation('wiki.revisions.are_you_sure') %>"><i class='fa fa-ban'></i></a></small></td>

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -148,7 +148,7 @@ class PostTest < ApplicationSystemTestCase
 
     accept_confirm "Are you sure?" do
       # revert to the previous version of wiki
-      find('#row0 a[data-confirm="Are you sure?"]', text: "Revert").click()
+      find('#row0 .btn-revert').click()
     end
 
     wiki_content = find("#content p").text


### PR DESCRIPTION
This test has already been fixed before but recently it has failed again
in #7319. The problem might be related to our selection of "Revert"
button.

Inside of the button, we have an empty space before the text
and a font-awesome icon(\<i>).
We were selecting the button with #row0 and the text of "Revert" which
probably caused the issue.

I've added the `btn-revert` class to avoid this strange behaviour.