### PR TITLE
Maps cleanup to fix sidebar and inline map problems

### DIFF
--- a/app/assets/javascripts/leaflet_helper.js
+++ b/app/assets/javascripts/leaflet_helper.js
@@ -89,8 +89,6 @@
        });
    }
 
-   
-
    function setupLEL(map, markers_hash = null, params = {}) {
       var options = {};
       options.layers = params.layers || [];
@@ -98,11 +96,9 @@
       options.mainContent = params.mainContent || "";
       options.displayLayers = params.displayLayers || false;
 
-      if (typeof options.layers == "string") {
+      if (typeof options.layers === "string") {
         options.layers = options.layers.split(',');
       }
-
-      // L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png').addTo(map) ;
 
       var oms = omsUtil(map, {
          keepSpiderfied: true,
@@ -117,14 +113,18 @@
       }
       L.LayerGroup.EnvironmentalLayers(optionsLEL).addTo(map);
 
-      if(typeof options.mainContent !== "undefined" && options.mainContent !== ""){
-         if(options.mainContent === "people"){
+      displayMapContent(map, markers_hash, options.mainContent);
+   }
+
+   function displayMapContent(map, markers_hash, mainContent) {
+      if(typeof mainContent !== "undefined" && mainContent !== ""){
+         if(mainContent === "people"){
             peopleMap();
             map.on('zoomend', peopleMap);
             map.on('moveend', peopleMap);
          }
          else {
-            options.mainContent = (options.mainContent === "content") ? null : options.mainContent;
+            mainContent = (mainContent === "content") ? null : mainContent;
             contentMap();
             map.on('zoomend', contentMap);
             map.on('moveend', contentMap);
@@ -132,7 +132,7 @@
       }
 
       function contentMap() {
-         contentLayerParser(map, markers_hash, options.mainContent);
+         contentLayerParser(map, markers_hash, mainContent);
       }
       function peopleMap() {
          peopleLayerParser(map, markers_hash);

--- a/app/assets/javascripts/leaflet_helper.js
+++ b/app/assets/javascripts/leaflet_helper.js
@@ -91,29 +91,40 @@
 
    
 
-   function setupInlineLEL(map , layers, mainLayer, markers_hash) {
+   function setupLEL(map, markers_hash = null, params = {}) {
+      var options = {};
+      options.layers = params.layers || [];
+      options.setHash = params.setHash || false;
+      options.mainContent = params.mainContent || "";
+      options.displayLayers = params.displayLayers || false;
 
-      layers = layers.split(',');
+      if (typeof options.layers == "string") {
+        options.layers = options.layers.split(',');
+      }
 
-      L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png').addTo(map) ;
+      // L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png').addTo(map) ;
 
       var oms = omsUtil(map, {
          keepSpiderfied: true,
          circleSpiralSwitchover: 0
       });
 
-      L.LayerGroup.EnvironmentalLayers({
-         include: layers,
-      }).addTo(map);
+      var optionsLEL = {
+        addLayersToMap: options.displayLayers,
+      };
+      if (options.layers.length > 0) {
+         optionsLEL.include = options.layers;
+      }
+      L.LayerGroup.EnvironmentalLayers(optionsLEL).addTo(map);
 
-      if(typeof mainLayer !== "undefined" && mainLayer !== ""){
-         if(mainLayer === "people"){
+      if(typeof options.mainContent !== "undefined" && options.mainContent !== ""){
+         if(options.mainContent === "people"){
             peopleMap();
             map.on('zoomend', peopleMap);
             map.on('moveend', peopleMap);
          }
          else {
-            mainLayer = (mainLayer === "content") ? null : mainLayer;
+            options.mainContent = (options.mainContent === "content") ? null : options.mainContent;
             contentMap();
             map.on('zoomend', contentMap);
             map.on('moveend', contentMap);
@@ -121,24 +132,9 @@
       }
 
       function contentMap() {
-         contentLayerParser(map, markers_hash, mainLayer);
+         contentLayerParser(map, markers_hash, options.mainContent);
       }
       function peopleMap() {
          peopleLayerParser(map, markers_hash);
       }
-   }
-
-   function setupLEL(map , sethash){
-      L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-      }).addTo(map) ;
-
-      var oms = omsUtil(map, {
-        keepSpiderfied: true,
-        circleSpiralSwitchover: 0
-      });
-
-      L.LayerGroup.EnvironmentalLayers({
-          hash: !!sethash,
-      }).addTo(map);
    }

--- a/app/views/map/_inlineLeaflet.html.erb
+++ b/app/views/map/_inlineLeaflet.html.erb
@@ -55,8 +55,14 @@
 
     $("#iframeID<%= unique_id %>").click(function() {
       prompt('Use this HTML code to embed this map on another site.', '<iframe style="border:none;" width="100%" height="900px" src="' + "//publiclab.org/map/" + primary_layers<%= unique_id %> + "#lat=<%= lat %>&lon=<%= lon %>&zoom=6" + '"></iframe>')
-      });
+    });
 
-    setupInlineLEL(map<%= unique_id %> , primary_layers<%= unique_id %>, main_layer<%= unique_id %>, markers_hash<%= unique_id %>) ;
+    var options<%= unique_id %> = {
+      mainContent: main_layer<%= unique_id %>,
+      layers: primary_layers<%= unique_id %>,
+      setHash: false,
+      displayLayers: true
+    }
+    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>, options<%= unique_id %>);
 
 </script>

--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -33,7 +33,7 @@
 
     var markers_hash<%= unique_id %> = new Map() ;
 
-    setupLEL(map<%= unique_id %> , 0) ;
+    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>);
 
     map<%= unique_id %>.on('zoomend' , function () {
        var NWlat = map<%= unique_id %>.getBounds().getNorthWest().lat ;

--- a/app/views/map/_mapDependencies.html.erb
+++ b/app/views/map/_mapDependencies.html.erb
@@ -19,3 +19,6 @@
 
 <%= javascript_include_tag('/lib/leaflet-environmental-layers/lib/glify.js') %>
 <%= javascript_include_tag('/lib/leaflet-environmental-layers/lib/leaflet-fullUrlHash.js') %>
+
+<%= javascript_include_tag('/lib/heatmap.js/build/heatmap.min.js') %>
+<%= javascript_include_tag('/lib/leaflet-heatmap/leaflet-heatmap.js') %>

--- a/app/views/map/_peopleLeaflet.html.erb
+++ b/app/views/map/_peopleLeaflet.html.erb
@@ -124,10 +124,16 @@
        });
    }) ;
 
+    var setHash = 1;
     <% if defined? url_hash != nil and url_hash == 0 %>
-      setupLEL(map<%= unique_id %> , 0) ;
-    <% else %>
-      setupLEL(map<%= unique_id %> , 1) ;
+      setHash = 0;
     <% end %>
+
+    var options<%= unique_id %> = {
+      mainContent: "people",
+      setHash: setHash
+    }
+    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>, options<%= unique_id %>);
+    
 
   </script>

--- a/app/views/map/_plainInlineLeaflet.html.erb
+++ b/app/views/map/_plainInlineLeaflet.html.erb
@@ -47,18 +47,19 @@
     
      }, 3500);
 
-    setupLEL(map<%= unique_id %> , 0) ;
+    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>);
+
     var map_tagname<%= unique_id %> = null;
      <% if (defined? tagname != nil and tagname.nil? == false) %>
            map_tagname<%= unique_id %> = "<%= tagname %>" ;
      <% end %>
 
-     map<%= unique_id %>.on('zoomend' , function () {
-        contentLayerParser(map<%= unique_id %>, markers_hash<%= unique_id %>, map_tagname<%= unique_id %>);
-    }) ;
+    //  map<%= unique_id %>.on('zoomend' , function () {
+    //     contentLayerParser(map<%= unique_id %>, markers_hash<%= unique_id %>, map_tagname<%= unique_id %>);
+    // }) ;
 
-    map<%= unique_id %>.on('moveend' , function () {
-        contentLayerParser(map<%= unique_id %>, markers_hash<%= unique_id %>, map_tagname<%= unique_id %>);
-    }) ;
+    // map<%= unique_id %>.on('moveend' , function () {
+    //     contentLayerParser(map<%= unique_id %>, markers_hash<%= unique_id %>, map_tagname<%= unique_id %>);
+    // }) ;
    
   </script>

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -53,7 +53,12 @@
       map.setView(user_latlng , 3) ;
    <% end %>
 
-   setupLEL(map , 1) ;
+    var options<%= unique_id %> = {
+      mainContent: "people",
+      setHash: setHash
+    }
+    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>);
+
    setupFullScreen(map , map.getCenter().lat , map.getCenter().lng) ;
 </script>
 

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -53,11 +53,12 @@
       map.setView(user_latlng , 3) ;
    <% end %>
 
-    var options<%= unique_id %> = {
+    var markers_hash = new Map();
+    var options = {
       mainContent: "people",
       setHash: setHash
     }
-    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>);
+    setupLEL(map, markers_hash, options);
 
    setupFullScreen(map , map.getCenter().lat , map.getCenter().lng) ;
 </script>

--- a/app/views/map/map.html.erb
+++ b/app/views/map/map.html.erb
@@ -82,29 +82,29 @@
         urlHash.setUrlHashParameter('zoom', zoom + "");
       }
 
-      <% if @layersname.nil? %>
-        var layersname = ['odorreport', 'asian', 'clouds', 'eonetFiresLayer', 'Unearthing'];
-      <% else %>
-        var layersname = "<%= @layersname %>";
-        layersname = layersname.split(',')
-      <% end %>
+      // var baseLayer = L.tileLayer(
+      //   "https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png",
+      //   {
+      //     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      //   }
+      // ).addTo(map);
 
-      var baseLayer = L.tileLayer(
-        "https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png",
-        {
-          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }
-      ).addTo(map);
+      var markers_hash = new Map();
+      var options = {
+        mainContent: "content",
+        setHash: false
+      }
+      setupLEL(map, markers_hash, options);
 
 
-      L.LayerGroup.EnvironmentalLayers({
-        // baseLayers: {
-        //  'Gray-scale': baselayer
-        // },
-        // include: layersname,
-        hash: false,
-        embed: true,
-        hostname: 'publiclab.org',
-      }).addTo(map);
+      // L.LayerGroup.EnvironmentalLayers({
+      //   // baseLayers: {
+      //   //  'Gray-scale': baselayer
+      //   // },
+      //   // include: layersname,
+      //   hash: false,
+      //   embed: true,
+      //   hostname: 'publiclab.org',
+      // }).addTo(map);
 
     </script>


### PR DESCRIPTION
Fixes #7381 (<=== Add issue number here)
#7397 
Also affects https://github.com/publiclab/leaflet-environmental-layers/issues/376

This needs to be merged after we bump to the newest version of LEL after @crisner does her fix in https://github.com/publiclab/leaflet-environmental-layers/pull/373

This DRY consolidates code from setupInlineLEL and setupLEL into one function called `setupLEL` that takes in options:
```
    var options = {
      mainContent: "content", // either "content" "people", default of neither
      layers: primary_layers, // the layer list that gets passed to LEL, default none
      setHash: false, // true = display urlHash, false (false) = don't show
      displayLayers: true // true = show all layers, false (default) = no layers are turned on
    }
    setupLEL(map, markers_hash, options);
```

This fix also removes all conflicting baselayers from the code for maps, because LEL will now have a default baselayer.