### PR TITLE
Map control layers

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -597,7 +597,7 @@ textarea, input {
 .inline-fullwidth-content {
   width:100vw !important;
   margin:0 calc((100% / 2) - 50vw) !important;
-  z-index:0 !important;
+  z-index: 10 !important;
 }
 
 @media (min-width: 992px) {

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -597,7 +597,7 @@ textarea, input {
 .inline-fullwidth-content {
   width:100vw !important;
   margin:0 calc((100% / 2) - 50vw) !important;
-  z-index: 10 !important;
+  /* z-index: 10 !important; */
 }
 
 @media (min-width: 992px) {
@@ -613,7 +613,7 @@ textarea, input {
 
 .sidebar-panel {
   background: rgba(255,255,255,0.8);
-  z-index: 9999;
+  z-index: 700;
   border-radius: 4px;
   padding: 10px; 
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,7 +90,10 @@
   <style type="text/css">
     .pac-container { z-index: 100000; }
 
-    .leaflet-control-layers {
+    #content .leaflet-pane {
+      z-index: auto;
+    }
+    #content .leaflet-control-layers {
         max-height: 200px;
         overflow: auto;
     }
@@ -101,10 +104,6 @@
 
     .leaflet-popup-content {
       width: 800px !important;
-    }
-
-    .peoplecard{
-      height:250px;
     }
 
   </style>  

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -44,7 +44,7 @@ class PostTest < ApplicationSystemTestCase
   end
 
   test 'removing tags from the post' do
-    visit '/wiki/wiki-page-path/comments'
+    visit '/wiki/wiki-page-path'
 
     find('a#tags-open').click()
 


### PR DESCRIPTION
Fixes #7395 (<=== Add issue number here)

In order to fix this bug I had to remove z-index from the fullwidth maps and lower the sidebar z-index to 700.

the way the layers should display on the page should have the content side bar BETWEEN the map display layers and the map controls.

![FireShot Capture 272 - 🎈 Public Lab_ Inline Maps - localhost](https://user-images.githubusercontent.com/49460529/73676714-db782b80-4682-11ea-9f90-b3d5fb08617b.png)

![FireShot Capture 273 - 🎈 Public Lab_ Inline Maps - localhost](https://user-images.githubusercontent.com/49460529/73676758-ef239200-4682-11ea-8f66-7b288a230595.png)

@crisner Take a look at this and tell me if you see anything that gets broken because of these changes.

=============

Z-INDEX of items on page:

`.popover : 1060`
`#header : 1030`
`#anniversary : 999`
`.leaflet-top : 1000` (changed in https://github.com/publiclab/plots2/pull/7419 to 800)
`.leaflet-bottom : 1000`
`.dropdown-menu.show : 1000`
`.sidebar-panel : 700`
`.leaflet-layer : 1`
`.leaflet-map : auto`