### PR TITLE
fix: link to MAINTAINERS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Click [here](https://github.com/publiclab/plots2/blob/master/doc/TESTING.md) for
 
 ## Maintainers
 
-See [/docs/MAINTAINERS.md](https://github.com/publiclab/plots2/blob/master/doc/LOGIN_SYSTEMS.md/docs/MAINTAINERS.md) for Public Lab's policy on feature maintainers!
+See [/doc/MAINTAINERS.md](https://github.com/publiclab/plots2/blob/master/doc/MAINTAINERS.md) for Public Lab's policy on feature maintainers!
 
 ## How to start and modify cron jobs
 


### PR DESCRIPTION
A fix to the issue  #7420 Link for MAINTAINERS.md is broken in README.md

Fixes #7420 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
