### PR TITLE
Wiki edits to Wikis created

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -182,11 +182,7 @@ class UsersController < ApplicationController
                         .order('node.nid DESC')
         ans_ques = questions.select { |q| q.comments.collect(&:uid).include?(@profile_user.id) }
         @commented_questions = ans_ques.paginate(page: params[:page], per_page: 24)
-        wikis = Revision.order("nid DESC")
-                        .where('node.type' => 'page', 'node.status' => 1, uid: @profile_user.uid)
-                        .joins(:node)
-                        .limit(20)
-        @wikis = wikis.collect(&:parent).uniq
+        @wikis = Node.where('type' => 'page', 'status' => 1, uid: @profile_user.uid)
 
         comments = Comment.limit(20)
                           .order("timestamp DESC")

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -472,8 +472,8 @@ class WikiController < ApplicationController
     @user = User.find_by(name: params[:id])
     @title = @user.name
     @wikis = Node.paginate(page: params[:page], per_page: 24)
+      .where('type' => 'page', 'status' => 1, uid: @user.uid)
       .order('nid DESC')
-      .where("uid = ? AND type = 'page' OR type = 'place' OR type = 'tool' AND status = 1", @user.uid)
     render template: 'wiki/index'
   end
 end

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -11,7 +11,7 @@
   <% elsif params[:action] == "author_topic" %>
     <h3><%= raw t('notes.index.research_on', :tags => @tagnames.join(', '), :url1 => "/people/"+@user.name, :user_name => @user.name) %> <br /><small><%= raw t('notes.index.research_notes_and_wiki_edits_with_time', :count => @user.nodes.count, :time => time_ago_in_words(@user.created_at)) %></small></h3>
   <% elsif params[:action] == "author" %>
-    <h3><%= raw t('notes.index.research_by', :url1 => "/people/"+@user.name, :user_name => @user.name) %> <small><%= raw t('notes.index.research_notes_and_wiki_edits', :count1 => @user.note_count, :word1 => 'note'.pluralize(@user.note_count), :count2 => @user.revisions.count, :word2 => 'edit'.pluralize(@user.revisions.count)) %> <% if @user.notes.length > 0 %><%= raw t('notes.index.starting_time', :time => time_ago_in_words(@user.created_at)) %><% end %></small></h3>
+    <h3><%= raw t('notes.index.research_by', :url1 => "/people/"+@user.name, :user_name => @user.name) %> <small><%= raw t('notes.index.research_notes_count', :count => @user.note_count, :word => 'note'.pluralize(@user.note_count)) %> <% if @user.notes.length > 0 %><%= raw t('notes.index.starting_time', :time => time_ago_in_words(@user.created_at)) %><% end %></small></h3>
   <% else %>
     <h2><%= raw t('notes.index.research_notes_ideas_and_documentation') %></h2>
   <% end %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -259,7 +259,7 @@
     <ul>
     <li class="mt-3"><h5>@<%= @profile_user.name %> has</h5></li>
       <li><h5><a href='/notes/author/<%= @profile_user.name %>'><%= pluralize(@profile_user.note_count, 'research note', plural: 'research notes' )%></a></h5></li>
-      <li><h5><a href="/wikis/author/<%= @profile_user.name %>"><%= pluralize(@profile_user.revisions.count, 'wiki edit', plural: 'wiki edits') %></a></h5></li>
+      <li><h5><a href="/wikis/author/<%= @profile_user.name %>"><%= pluralize(@wikis.count, 'wiki created', plural: 'wikis created') %></a></h5></li>
       <li><h5><a href = "/tag/question:*/author/<%= params[:id] %>"><%= pluralize(Node.questions.where(status: 1, uid: @profile_user.id).length, 'question', plural:'questions') %></a></h5></li>
       <li><h5><a href = "/profile/comments/<%= params[:id] %>"><%= pluralize(Comment.where(uid: @profile_user.id).count, 'comment', plural: 'comments') %></a></h5></li>
       <li><h5><a href = "/tag/activity:*/author/<%= params[:id] %>"><%= pluralize(@count_activities_posted, 'activity posted', plural:'activities posted') %> </a></h5></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,7 +155,7 @@ en:
       research_notes_and_wiki_edits_with_time: "%{count} research notes and wiki edits
         starting %{time} ago"
       research_by: "Research by <a href='%{url1}'>%{user_name}</a>"
-      research_notes_and_wiki_edits: "%{count1} research %{word1} and %{count2} wiki %{word2}"
+      research_notes_count: "%{count} research %{word}"
       starting_time: "starting %{time} ago"
       research_notes_ideas_and_documentation: "Research notes <small class=\"hidden-sm\">ideas
         & documentation from contributors like you</small>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,7 +435,7 @@ en:
     index:
       wiki_pages_tagged_with: "Wiki pages tagged with <i style='color:#aaa;'>%{tag}</i>"
       wiki_pages_by: "Wiki pages by <a href='%{url1}'>%{user}</a> <small>%{note_length}
-        research notes and wiki edits starting %{time} ago</small>"
+        research notes starting %{time} ago</small>"
       highly_liked_wiki_pages: "Highly liked wiki pages"
       create_wiki_page: "Create a new wiki page"
       by_recency: "recency"

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -642,7 +642,7 @@ class WikiControllerTest < ActionController::TestCase
     # check they are not banned
     assert wikis.all? { |wiki| wiki.status == 1 }
     # test their type
-    assert wikis.none? { |wiki| wiki.type == "question" || wiki.status == "note"}
+    assert wikis.none? { |wiki| wiki.type == "question" || wiki.status == "note" || wiki.status == "map"}
     # check correct author
     assert wikis.all? { |wiki| wiki.uid == user.uid }
   end


### PR DESCRIPTION
Fixes #7515 

### Description

#### /profile/:username

The profile page was showing '? wiki edits' with wrong number and link to the user created wikis, changed the link to '? wikis created'.
![after-profile-:username](https://user-images.githubusercontent.com/33282336/74768163-e1673280-5266-11ea-9bf1-c257f2e9756e.png)
Also did a refactor in the query.

#### /wikis/author/:username

Changed the query to get only the wiki pages created by the user.
![after-wikis-author-:username](https://user-images.githubusercontent.com/33282336/74768841-0e681500-5268-11ea-9b7f-006c806189d4.png)
Still showing the number of research notes by the user (can be altered to show the number of wikis instead since it's in wikis page).

#### /notes/author/:username

Was also showing the wrong number of wiki edits, like profile page, removed the text from the page to show only the number of notes and match the page content.
![after-notes-author-:username](https://user-images.githubusercontent.com/33282336/74769432-268c6400-5269-11ea-832d-2355ec6ea2e0.png)

