### PR TITLE
Fix margin for features page

### DIFF
--- a/app/views/features/index.html.erb
+++ b/app/views/features/index.html.erb
@@ -1,6 +1,7 @@
-<h2>Features</h2>
-
-<p>Features allow admins to edit/update text and images displayed around the site, for example banners, sidebar content, and alerts or notices.</p>
+<div class="row" style="align-items:baseline;">
+   <h2>Features</h2>
+   <p style="margin-inline-start:1rem;">Features allow admins to edit/update text and images displayed around the site, for example banners, sidebar content, and alerts or notices.</p>
+</div>
 <% if current_user.admin? %>
 <p><a class="btn btn-outline-secondary" href="/features/new">New feature</a></p>
 <% end %>
@@ -18,7 +19,7 @@
       <% if current_user.admin? %>
       <td><a href="/features/<%= feature.id %>/edit?t=<%= Time.now.to_i %>">edit</a></td>
       <% end %>
-      <td><%= time_ago_in_words(feature.latest.created_at) %> ago by 
+      <td><%= time_ago_in_words(feature.latest.created_at) %> ago by
       <a href="/profile/<%= feature.latest.author.name %>"><%= feature.latest.author.name %></td>
     </tr>
   <% end %>


### PR DESCRIPTION
Fixes #7566 
Margin added between feature heading and p tag to make it more appealing.
Before- 
![image1](https://user-images.githubusercontent.com/33183263/75544464-0ec39580-5a4a-11ea-84e5-f0510271a260.png)
After-  
![Screenshot from 2020-02-28 16-44-58](https://user-images.githubusercontent.com/33183263/75544477-171bd080-5a4a-11ea-93ab-3dc0422ccf23.png)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
