### PR TITLE
Fix text overflow in people page

### DIFF
--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -40,7 +40,7 @@
               <div class="card-info">
                 <div class="d-flex justify-content-between">
                  <div>
-                    <a href="/profile/<%= user.username %>"><%= user.username %></a>
+                    <a href="/profile/<%= user.username %>" style="word-break:break-word;"><%= user.username %></a>
                    </div>
                    <div>
                       <a class="ellipsis" data-toggle="dropdown">&nbsp<i class="fa fa-ellipsis-h" style="color: #666; font-size:15px;"></i></a>
@@ -62,7 +62,7 @@
                 <div class="sub-info">
                   <div style="padding-bottom:6px;">
                     <% if user.status == 0 %>
-                      <i class='fa fa-ban' style="color:#a00;"></i> <%= t('users.list.banned') %> | 
+                      <i class='fa fa-ban' style="color:#a00;"></i> <%= t('users.list.banned') %> |
                     <% end %>
                     Active <%= t = user.revisions.order(timestamp: :desc).first.try(:created_at);time_ago_in_words(t) if (t) %> ago
                   </div>


### PR DESCRIPTION
Fixes #7567  
Fixed text username overflow in people page.
Before   
![Screenshot from 2020-02-28 17-03-23](https://user-images.githubusercontent.com/33183263/75545560-a0cc9d80-5a4c-11ea-9f95-7f2c51087fde.png)
After  
![Screenshot from 2020-02-28 17-03-46](https://user-images.githubusercontent.com/33183263/75545568-a5915180-5a4c-11ea-8de5-2fc8f87e5239.png)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
