### PR TITLE
Fix spacing in /tag route for sort options

### DIFF
--- a/app/views/notes/_card.html.erb
+++ b/app/views/notes/_card.html.erb
@@ -4,7 +4,7 @@
   <% elsif node.scraped_image %>
     <a class="card-img-top img" style="overflow: hidden; height:10em;" href="<%= node.path %>"><img src="<%= node.scraped_image %>" style="width:100%;" /></a>
   <%  else %>
-    <a class="imgg" style="height:10em; margin-bottom: 10px;">
+    <a class="imgg" style="height:10em; margin-bottom: 10px;padding: 1rem;">
     <i class="fa fa-picture-o note-not aria-hidden="true" style="color: #ccc; font-size: 6em;"></i>
     </a>
   <% end %>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -53,10 +53,10 @@
 
             <%= render partial: 'tag/show/contributors' %>
 
-            <div class="row">
+            <div class="row" style="padding-bottom:1rem;align-items:baseline;">
               <div class="col-lg-6">
-                <p class="contributor-info"><%= Tag.find_nodes_by_type(params[:id], 'note', false).count %> posts by 
-                  <a href="/contributors/<%= params[:id] %>"><%= Tag.contributor_count(params[:id]) %> contributors</a> | 
+                <p class="contributor-info"><%= Tag.find_nodes_by_type(params[:id], 'note', false).count %> posts by
+                  <a href="/contributors/<%= params[:id] %>"><%= Tag.contributor_count(params[:id]) %> contributors</a> |
                   <a href="/contributors/<%= params[:id] %>"><%= Tag.follower_count(params[:id]) %> followers</a>
                   <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
                 </p>


### PR DESCRIPTION
Fixes #7587 
Padding added to sort options row to fix spacing between sort options and notes.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below


##  Screenshots   
![Screenshot from 2020-03-08 12-34-17](https://user-images.githubusercontent.com/33183263/76159363-b5dcb700-6145-11ea-9192-273762104673.png)
![Screenshot from 2020-03-08 12-33-58](https://user-images.githubusercontent.com/33183263/76159366-b8d7a780-6145-11ea-90d0-8614476f9e84.png)
Thanks!