### PR TITLE
center tag buttons in sidebar

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -82,7 +82,8 @@ h5,h6, h1 small, h3 small {
   height: 25px;
   width: 25px;
   margin: 13px 5px;
-  padding: 5px 3px 0px 1px;
+  display: flex;
+  justify-content: center;
   font-size: 11px;
 }
 
@@ -611,7 +612,7 @@ textarea, input {
   background: rgba(255,255,255,0.8);
   z-index: 700;
   border-radius: 4px;
-  padding: 10px; 
+  padding: 10px;
 }
 
 .btn-toolbar .btn-outline-secondary

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -5,7 +5,7 @@
   <%= render partial: 'tag/replication' %>
   <!-- This is the sidebar tagging display, also renders Subscribe button for multiple subscription -->
   <p style="font-size:0.9em;color:#666;margin-top:5px;">
-    <% if @node.normal_tags.count > 0 %> 
+    <% if @node.normal_tags.count > 0 %>
       This is part of:
     <% end %>
   </p>
@@ -47,9 +47,9 @@ $(function () {
 
 <% if current_user && (parent != :profile || (current_user.id == user.id || logged_in_as(['admin']))) %>
 
-<a id="tags-open" class="btn btn-circle btn-circle-sm" style="float:left;"><i class="fa fa-plus" style="color:#808080;margin-left:3px;"></i></a>
+<a id="tags-open" class="btn btn-circle btn-circle-sm" style="float:left;"><i class="fa fa-plus" style="color:#808080;"></i></a>
 <% if @node && @node.tags.count == 0 %>
-  <span style="float:left;color:#666;margin-top:14px;margin-left:5px;">Add tags</a> 
+  <span style="float:left;color:#666;margin-top:14px;margin-left:5px;">Add tags</a>
 <% end %>
 
 <%= render partial: 'tag/form', locals: { node: @node ||= nil, user: user ||= nil, url: url ||= nil } %>

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,7 +1,7 @@
 <% user = user || @user # allow overriding w/ local variable %>
 <div class="tags-list">
 <% if tags.length > 0 && power_tag %>
-  <a class="btn btn-circle btn-circle-sm show-more-tags" href="javascript:void(0);" style="float:left;"><i class="fa fa-ellipsis-h" style="color:#808080;margin-left:3px;"></i></a>
+  <a class="btn btn-circle btn-circle-sm show-more-tags" href="javascript:void(0);" style="float:left;"><i class="fa fa-ellipsis-h" style="color:#808080;"></i></a>
 <% end %>
 <% tags.each_with_index do |tag, i| %>
   <% if tag.class == NodeTag %>


### PR DESCRIPTION
Fixes #7644 
Tag buttons are centered in the sidebar.

# Screenshot   
Final  
![image](https://user-images.githubusercontent.com/33183263/77039721-88f99100-69dc-11ea-92e6-4185635c29d4.png)

Before (Full)
![Screenshot from 2020-03-25 14-38-10](https://user-images.githubusercontent.com/33183263/77519940-679a1880-6ea6-11ea-9c93-c5b09eeae61c.png)

After  (Full)
![Screenshot from 2020-03-25 14-35-07](https://user-images.githubusercontent.com/33183263/77519958-6c5ecc80-6ea6-11ea-9fb5-d5b211198c3d.png)




* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below



Thanks!
