### PR TITLE
Modify flash message to be more user friendly for tag follow

### DIFF
--- a/app/controllers/subscription_controller.rb
+++ b/app/controllers/subscription_controller.rb
@@ -159,7 +159,7 @@ class SubscriptionController < ApplicationController
               if request.xhr?
                 render json: true
               else
-                flash[:notice] = "You are now following '#{params[:tagnames]}'."
+                flash[:notice] = "You are now following #{params[:tagnames].join(', ')}."
                 redirect_to return_to
               end
             end

--- a/test/functional/subscription_controller_test.rb
+++ b/test/functional/subscription_controller_test.rb
@@ -28,7 +28,7 @@ class SubscriptionControllerTest < ActionController::TestCase
   test 'should subscribe to multiple tags' do
     UserSession.create(users(:bob))
     assert users(:bob).following(:awesome)
-    get :multiple_add, params: { type: 'tag', tagnames: 'blog,kites,,balloon,awesome' }
+    get :multiple_add, params: { type: 'tag', tagnames: ["blog","kites","","balloon","awesome"]}
     assert_response :redirect
     assert users(:bob).following(:blog)
     assert users(:bob).following(:awesome)
@@ -55,12 +55,12 @@ class SubscriptionControllerTest < ActionController::TestCase
     get :add, params: { type: 'tag', name: 'blog' }, xhr: true
     assert users(:bob).following(:blog)
   end
-  
+
   test "should redirect properly when subscribing to multiple tags" do
     UserSession.create((users(:bob)))
-    tagnames = 'blog,kites,,balloon,awesome'
+    tagnames = ["blog","kites","","balloon","awesome"]
     get :multiple_add, params: { type: "tag", tagnames: tagnames, return_to: "/dashboard" }
     assert_redirected_to "/dashboard"
-    assert_equal flash[:notice], "You are now following '#{tagnames}'."
+    assert_equal flash[:notice], "You are now following #{tagnames.join(', ')}."
   end
 end


### PR DESCRIPTION
Fixes #7757 
Modified the toast message to be more user friendly instead of showing the array now a comma separated string is shown.  

# Screenshot  

![Screenshot from 2020-03-31 14-47-26](https://user-images.githubusercontent.com/33183263/78009730-13d47700-735f-11ea-95f7-98edc2b1f4ca.png)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below
 
Thanks!
