### PR TITLE
Allow bio updation without current password

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,8 +57,8 @@ class UsersController < ApplicationController
     @password_verification = user_verification_params
     @user = current_user
     @user = User.find_by(username: params[:id]) if params[:id] && logged_in_as(['admin'])
-    if @user.valid_password?(user_verification_params["current_password"]) || user_verification_params["ui_update"].nil?
-      # correct password
+    if @user.valid_password?(user_verification_params["current_password"]) || user_verification_params["ui_update"].nil? || (user_verification_params["current_password"].blank? && user_verification_params["password"].blank? && user_verification_params["password_confirmation"].blank?)
+      # correct password or if any other field needs to be updated
       @user.attributes = user_params
       if @user.save
         if session[:openid_return_to] # for openid login, redirects back to openid auth process
@@ -510,7 +510,7 @@ class UsersController < ApplicationController
   end
 
   def user_verification_params
-    params.require(:user).permit(:ui_update, :current_password)
+    params.require(:user).permit(:ui_update, :current_password, :password, :password_confirmation)
   end
 
   def spamaway_params

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -88,7 +88,7 @@ class UsersControllerTest < ActionController::TestCase
     # checks duplicated flash is not present
     assert_nil flash[:notice]
   end
-  
+
   test 'generate user reset key' do
     user = users(:jeff)
     assert_nil user.reset_key
@@ -254,6 +254,20 @@ class UsersControllerTest < ActionController::TestCase
     assert_not_equal User.find(user.id).bio, 'Bio updated by user but with wrong password'
   end
 
+  test 'allowing update profile with empty password when ui_update is true' do
+    user = users(:bob)
+    bio = users(:bob).bio
+    UserSession.create(user)
+    post :update, params: {
+      user: {
+        bio: 'Bio updated by user with empty password',
+        current_password: '',
+        ui_update: 'true'     }
+    }
+    assert_response :redirect
+    assert_equal User.find(user.id).bio, 'Bio updated by user with empty password'
+  end
+
   test 'should redirect edit when not logged in' do
     user = users(:bob)
     get :edit, params: { id: user.name }
@@ -359,7 +373,7 @@ class UsersControllerTest < ActionController::TestCase
     user.save
     email =  PasswordResetMailer.reset_notify(user, key)
     assert_emails 1 do
-     email.deliver_now 
+     email.deliver_now
     end
     assert_not_nil email.to
     assert_equal 'Reset your password',email.subject


### PR DESCRIPTION
Fixes #7756 

Modified the user controller to allow bio updation without entering current password.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

## GIF 
![bio](https://user-images.githubusercontent.com/33183263/79031404-171bfe00-7bbc-11ea-8a6e-2f2b455b0eff.gif)




Thanks!
