### PR TITLE
changed default zoom level

### DIFF
--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -23,7 +23,7 @@ class MapController < ApplicationController
   def map
     @lat = 0
     @lon = 0
-    @zoom = 3
+    @zoom = 10
 
     if current_user&.has_power_tag("lat") && current_user&.has_power_tag("lon")
       @lat = current_user.get_value_of_power_tag("lat").to_f

--- a/test/functional/map_controller_test.rb
+++ b/test/functional/map_controller_test.rb
@@ -32,7 +32,7 @@ class MapControllerTest < ActionController::TestCase
     get :map
 
     assert_response :success
-    assert_equal [0, 0, 3], [assigns(:lat), assigns(:lon), assigns(:zoom)]
+    assert_equal [0, 0, 10], [assigns(:lat), assigns(:lon), assigns(:zoom)]
   end
 
   test 'renders wiki map that has location' do


### PR DESCRIPTION
Fixes #7822 
default zoom level at  https://publiclab.org/map now at 10
![Screenshot from 2020-04-27 21-56-06](https://user-images.githubusercontent.com/48386390/80425195-b4707500-88d2-11ea-9ece-493a2da2a1a0.png)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
