### PR TITLE
Configure Uglifier gem to minify js

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,7 @@ Plots2::Application.configure do
 
   # Compress JavaScripts and CSS
   config.assets.compress = true
+  config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
   config.assets.compile = true
@@ -60,7 +61,7 @@ Plots2::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
   # config.action_mailer.delivery_method = :sendmail
-  
+
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Fixes #7887 
Uglifier gem is configured to minify javascript files.

Tested in development by setting the asset compilation as true(setting the config.assets.debug to false and config.assets.compile to true in development.rb) and checking the asset files.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below



Thanks!
