### PR TITLE
sort subscription tags

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -13,7 +13,7 @@ class StatsController < ApplicationController
 #         .where("node.status = 1")
 #         .group("term_data.name")
 #         .count
-      @tags = @tags.group_by { |_k, v| v / 10 }
+      @tags = @tags.group_by { |_k, v| v / 10 }.sort_by { |k, _v| -k }
 #    end
   end
 

--- a/app/views/stats/subscriptions.html.erb
+++ b/app/views/stats/subscriptions.html.erb
@@ -11,7 +11,7 @@
     <th>Tags</th>
     </thead>
   </tr>
-  <% @tags.reverse_each do |range,tags| %>
+  <% @tags.each do |range,tags| %>
   <tr>
     <td>
       <%= range * 10 %> - <%= range * 10 + 9 %>


### PR DESCRIPTION
Fixes #7934  
It will sort subscription tags in descending order.
![Screenshot from 2020-05-21 20-46-44](https://user-images.githubusercontent.com/41363633/82574889-62ef9900-9ba5-11ea-8808-8724075720da.png)
