### PR TITLE
improve accessibility of login modal

### DIFF
--- a/app/views/layouts/_social_icons.html.erb
+++ b/app/views/layouts/_social_icons.html.erb
@@ -1,28 +1,28 @@
 <div class="container">
-	
+
 	<div class="text-center">
-		<a href="/auth/google_oauth2?origin=<%= params[:return_to] || request.original_url %>" id="connect-google">
+		<a href="/auth/google_oauth2?origin=<%= params[:return_to] || request.original_url %>" id="connect-google" aria-label="Sign Up with Google">
 			<span class="btn btn-outline-light" style="margin-right:2px;background-color: #d34836;">
 				<i class="fa fa-google fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
-		<a href="/auth/github?origin=<%= params[:return_to] || request.original_url %>" id="connect-github">
+		<a href="/auth/github?origin=<%= params[:return_to] || request.original_url %>" id="connect-github" aria-label="Sign Up with Github">
 			<span class="btn btn-default" style="margin-left:2px;background-color: #333;">
 				<i class="fa fa-github fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
-		<a href="/auth/twitter?origin=<%= params[:return_to] || request.original_url %>" id="connect-twitter">
+		<a href="/auth/twitter?origin=<%= params[:return_to] || request.original_url %>" id="connect-twitter" aria-label="Sign Up with Twitter">
 			<span class="btn btn-outline-light" style="margin-left:2px;background-color: #1da1f2;">
 				<i class="fa fa-twitter fa-fw" style="font-size:20px;color:white;margin-left:2px;"></i>
 			</span>
 		</a>
-		<a href="/auth/facebook?origin=<%= params[:return_to] || request.original_url %>" id="connect-facebook">
+		<a href="/auth/facebook?origin=<%= params[:return_to] || request.original_url %>" id="connect-facebook" aria-label="Sign Up with Facebook">
             <span class="btn btn-outline-light" style="margin-left:2px;background-color: #3b5998">
                 <i class="fa fa-facebook fa-fw" style="font-size:20px;color:white;"></i>
 			</span>
 		</a>
 	</div>
-	
+
 	<div class='hr-or'></div>
 
 </div>
@@ -38,7 +38,7 @@
     font-family:"Junction Light", lucida grande,lucida sans console,sans-serif;
     font-weight:normal;
   }
-  
+
   div.hr-or:before {
     content: 'OR';
     padding:5px;

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -25,11 +25,11 @@
 <div id="toggle" class="login-form">
 
   <div class="form-group">
-    <label for="username"><%= t('user_sessions.new.username') %></label>
+    <label for="username-login"><%= t('user_sessions.new.username') %></label>
     <%= f.text_field :username, { tabindex: 1, placeholder: "Username", class: 'form-control', id: 'username-login', required: true } %>
 
     <div class="form-group has-feedback">
-      <label class="control-label" for="password"><%= t('user_sessions.new.password') %></label>
+      <label class="control-label" for="password-signup"><%= t('user_sessions.new.password') %></label>
       <div class="input-group">
         <%= f.password_field :password, { tabindex: 2,placeholder: "Password",class: 'form-control', id: 'password-signup', onpaste: 'return false;' , required: true } %>
         <div class="input-group-append">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -618,7 +618,7 @@ en:
       username: "Username"
       password: "Password"
       remember_me: "Remember me"
-      reset_by_clicking_here: "Forgot your password? Reset it <a href='%{url1}'>here</a>"
+      reset_by_clicking_here: "Forgot your password? <a href='%{url1}'>Reset it here</a>"
   home:
     dashboard:
       welcome: "Welcome!"


### PR DESCRIPTION
Fixes #7967 

Improved accessibility of Login Modal by modifying orphaned form labels for username and password. Changed suspicious link text 'here' to 'reset it here' for password reset. And added aria-labels for social icons.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below  

## Screenshots  
Before  

![7967_before](https://user-images.githubusercontent.com/33183263/83196072-dde22200-a158-11ea-9fd3-9e10896bdd80.png)

After   
 
![7967_after](https://user-images.githubusercontent.com/33183263/83195870-9196e200-a158-11ea-90af-d7e9613a1bdc.png)



Thanks!
