### PR TITLE
improve accessibility of notifications settings

### DIFF
--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -7,6 +7,7 @@
     <span>Do you want to be notified by email for comments on your posts? </span>
     <span>
     <label class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="notify-comment-direct:false" <% unless UserTag.exists?(current_user.id, 'notify-comment-direct:false') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -20,6 +21,7 @@
     <span>Do you want to be notified by email for likes on your posts? </span>
     <span>
     <label class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="notify-likes-direct:false" <% unless UserTag.exists?(current_user.id, 'notify-likes-direct:false') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -33,6 +35,7 @@
     <span>Do you want to be notified by email for comments on all posts you've commented on? </span>
     <span>
     <label class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="notify-comment-indirect:false" <% unless UserTag.exists?(current_user.id, 'notify-comment-indirect:false') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -47,6 +50,7 @@
     <span>Do you want to be notified by email for moderation emails? </span>
     <span>
     <label class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="no-moderation-emails" <% unless UserTag.exists?(current_user.id, 'no-moderation-emails') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -62,6 +66,7 @@
     <span>Do you want to receive customized digest weekly?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="digest:weekly" <% if UserTag.exists?(current_user.id, 'digest:weekly') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -75,6 +80,7 @@
     <span>Do you want to receive customized digest daily?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="digest:daily" <% if UserTag.exists?(current_user.id, 'digest:daily') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -88,6 +94,7 @@
     <span>Do you want to receive browser notification when you are mentioned?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="notifications:mentioned" <% if UserTag.exists?(current_user.id, 'notifications:mentioned') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -101,6 +108,7 @@
     <span>Do you want to receive browser notification for all ?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="notifications:all" <% if UserTag.exists?(current_user.id, 'notifications:all') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -114,6 +122,7 @@
     <span>Do you want to receive browser notification when someone likes your work?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
+      <p> Notification switch </p>
       <input type="checkbox" name="notifications:like" <% if UserTag.exists?(current_user.id, 'notifications:like') %>checked<% end %>>
       <span class="slider round"></span>
     </label>
@@ -191,7 +200,7 @@
 
   }
 
-  .switch input {display:none;}
+  .switch input,p {display:none;}
 
   .slider {
     position: absolute;


### PR DESCRIPTION
Fixes #7994 

Improved accessibility of notifications settings by adding form labels for the empty form labels by adding hidden text.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

## Screenshots  
Before  

![notif_before](https://user-images.githubusercontent.com/33183263/83922498-0643cf00-a79e-11ea-91da-d94986207f55.png)

After  

![notif_after](https://user-images.githubusercontent.com/33183263/83922521-0d6add00-a79e-11ea-8a3a-e12fb23f8143.png)

Thanks!
