### PR TITLE
Load critical css and rest asynchronously

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,11 @@ gem 'lemmatizer', '~> 0.2.2'
 gem 'mailman', require: false
 # To implement fontawesome v4.7.0
 gem "font-awesome-rails"
- gem "lazyload-rails"
+gem "lazyload-rails"
+# To implement load critical css and rest asynchronously
+gem 'loadcss-rails', '~> 2.0.1'
+gem 'critical-path-css-rails', '~> 3.1.0'
+
 
 # To convert html to markdown
 gem 'reverse_markdown'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,9 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
+//= require loadCSS
+//= require cssrelpreload
+//= require onloadCSS
 //= require jquery
 //= require jquery_ujs
 //= require jquery-lazyload/jquery.lazyload.js

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,8 +20,20 @@
     <script type="text/javascript" async
       src="https://cdn.jsdelivr.net/npm/mathjax@2.7.3/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
+
     <link rel="stylesheet preload prefetch" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0-2/css/all.min.css" as="style" type="text/css" />
-    <%= stylesheet_link_tag "application", :media => "all" %>
+    <!-- Loading critical css and rest asynchronously #7996 -->
+    <%= javascript_include_tag "application" %>
+    <style>
+      <%= CriticalPathCss.fetch(request.path) %>
+    </style>
+    <script>
+        loadCSS("<%= stylesheet_path('application') %>");
+    </script>
+    <link rel="preload" href="<%= stylesheet_path('application') %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript>
+        <link rel="stylesheet" href="<%= stylesheet_path('application') %>">
+    </noscript>
     <% if @node && @node.has_tag('style:fancy') %>
       <%= stylesheet_link_tag "fancy", :media => "all" %>
     <% end %>
@@ -32,7 +44,6 @@
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
-    <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <meta name="google-translate-customization" content="4ce4c7c384354172-5179499fc244f592-g2b333d0d29f59663-d" />
 

--- a/config/critical_path_css.yml
+++ b/config/critical_path_css.yml
@@ -1,0 +1,22 @@
+defaults: &defaults
+  # If using the asset pipeline, provide the manifest name
+  manifest_name: application
+  # Else provide the relative path of your CSS file from the /public directory
+  # css_path: /path/to/css/from/public/main.css
+  # Or provide a separate path for each route
+  # css_paths:
+  #   - /path/to/css/from/public/main.css
+  routes:
+    - /
+
+development:
+  <<: *defaults
+  base_url: http://localhost:3000
+
+staging:
+  <<: *defaults
+  base_url: http://stable.publiclab.org
+
+production:
+  <<: *defaults
+  base_url: http://publiclab.org

--- a/lib/tasks/critical_path_css.rake
+++ b/lib/tasks/critical_path_css.rake
@@ -1,0 +1,18 @@
+require 'critical-path-css-rails'
+
+namespace :critical_path_css do
+  desc 'Generate critical CSS for the routes defined'
+  task generate: :environment do
+    CriticalPathCss.generate_all
+  end
+
+  desc 'Clear all critical CSS from the cache'
+  task clear_all: :environment do
+    # Use the following for Redis cache implmentations
+    CriticalPathCss.clear_matched('*')
+    # Some other cache implementations may require the following syntax instead
+    # CriticalPathCss.clear_matched(/.*/)
+  end
+end
+
+Rake::Task['assets:precompile'].enhance { Rake::Task['critical_path_css:generate'].invoke }


### PR DESCRIPTION
Fixes #7891 

Load only critical css and rest asynchronously for better performance. The loadcss-rails gem and the critical-path-css-rails gem is used for the same.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
