### PR TITLE
Config for dump&restore to UTF8MB4 for emojis

### DIFF
--- a/config/my.cnf
+++ b/config/my.cnf
@@ -1,3 +1,9 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
 [mysqld]
 skip-host-cache
 skip-name-resolve
@@ -15,7 +21,7 @@ pid-file = /var/lib/mysql/mysqld
 #
 # * Fine Tuning
 #
-key_buffer		= 16M
+key_buffer_size		= 16M
 max_allowed_packet	= 16M
 thread_stack		= 192K
 thread_cache_size       = 8

--- a/config/my.cnf
+++ b/config/my.cnf
@@ -2,6 +2,9 @@
 skip-host-cache
 skip-name-resolve
 datadir = /var/lib/mysql
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
 
 # To avoid single large file
 innodb_file_per_table = 1


### PR DESCRIPTION
Following
https://docs.moodle.org/32/en/Converting_your_MySQL_database_to_UTF8

This is an attempt to tackle #3007 with a new approach.
I'm deploying this to `unstable`. Then the default encoding will be `utf8mb4`.

I've exported a dump with ` --default-character-set=utf8mb4 ` and `--skip-character-set`.
With the setting in this PR it should be possible to import this dump and it should be encoded correctly.

This is a manual process that, if it works, will need to be repeated in production. I'm not sure trying to automate it is worth it.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
