### PR TITLE
spam2 delete node alert and system tests

### DIFF
--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -138,16 +138,17 @@ $(document).ready(function () {
                <a class="badge btn badge-pill badge<% if node.status != 0 %>-danger<% else %>-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a> 
                <a class="badge badge-pill badge-secondary ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
                <a class="badge badge-pill badge-secondary unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>
-               <%= link_to "/notes/delete/"+node.id.to_s, data: { confirm: 'Are you sure you want to delete "'+node.path+'"?' }, :remote => true, :class => "px-3 " do %>
-                 <i class="fa fa-trash"></i>
+               <%= link_to "/notes/delete/#{node.id}", data: { confirm: 'Are you sure you want to delete "'+node.path+'"?' }, :remote => true, :class => "px-3 delete" do %>
+                <i class="fa fa-trash"></i>
                <% end %>
                <script>
                 $('#n<%= node.id %> .delete').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').fadeOut()
+                  $('#deleted<%= node.id %>').fadeIn();
                 });
                 $('#n<%= node.id %> .publish').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').hide()
-                  $('#ndel<%= node.id %>').fadeIn(); // published!
+                  $('#npublish<%= node.id %>').fadeIn(); // published!
                 });
                 $('#n<%= node.id %> .spam').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').hide()
@@ -164,7 +165,10 @@ $(document).ready(function () {
                 </script>
               </td>
             </tr>
-            <div style="display:none;" id="ndel<%= node.id %>" class="alert alert-success alert-dismissible">
+            <div style="display:none;" id="deleted<%= node.id %>" class="alert alert-success alert-dismissible">
+              Node Deleted
+            </div> 
+            <div style="display:none;" id="npublish<%= node.id %>" class="alert alert-success alert-dismissible">
               <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
               <strong>Success!</strong> Content <a href='<%= node.path %>'>published</a>.
             </div> 

--- a/test/system/spam2_test.rb
+++ b/test/system/spam2_test.rb
@@ -1,0 +1,24 @@
+require "application_system_test_case"
+
+class SpamTest < ApplicationSystemTestCase
+    def setup
+        visit "/spam2"
+        click_on "Login"
+        fill_in 'user_session[username]', with: 'palpatine'
+        fill_in 'user_session[password]', with: 'secretive'
+        click_on "Log in"
+      end
+    
+    test "Delete post in spam2" do
+      spam_page = nodes(:one)
+      visit spam_page.path
+      first("span[data-original-title='Tools']").click()
+      click_on "Spam"
+      visit "/spam2"
+      accept_confirm 'Are you sure you want to delete "'+spam_page.path+'"?' do
+      find("a[href='/notes/delete/#{spam_page.id}'").click()
+      end
+      assert_selector('div.alert', text: 'Node Deleted')
+      end
+end
+	


### PR DESCRIPTION
There were some errors in the stable as /spam2 was not working there  
`dfc6a9d5-00fa-4d38-95e5-962d24dbf6be] ActionView::Template::Error (no implicit conversion of nil into String):
`
I made a few changes and added system tests for this. I am working on the rest of the system test.
@jywarren Please review this and merge if it is fine. So that I can test spam2 in stable and make some changes.
Thanks!!
