### PR TITLE
spam2 stable issues, UI update and modals added

### DIFF
--- a/app/assets/javascripts/spam2.js
+++ b/app/assets/javascripts/spam2.js
@@ -16,11 +16,22 @@ function table_main(id) {
 	$('#selectall').click(function () {
 		$('.selectedId').prop('checked', this.checked);
 		$('#select-count').text($('.selectedId').filter(":checked").length);
+		disable_buttons('#selectall');
 	});
 	$('.selectedId').change(function () {
 		var check = ($('.selectedId').filter(":checked").length === $('.selectedId').length);
 		$('#select-count').text($('.selectedId').filter(":checked").length);
 		$('#selectall').prop("checked", check);
+		disable_buttons('.selectedId');
 	});
 	return table;
+}
+
+function disable_buttons(id){
+	if ($(id).is(":checked")){
+		$("#batch-spam, #batch-publish, #delete-batch, #batch-ban, #batch-unban").removeClass("disabled");
+	}
+	else {
+		$("#batch-spam, #batch-publish, #delete-batch, #batch-ban, #batch-unban").addClass("disabled");
+	}
 }

--- a/app/assets/stylesheets/spam2.css
+++ b/app/assets/stylesheets/spam2.css
@@ -53,6 +53,16 @@
 	color:white !important;
 }
 
+#col-search{
+	cursor: text;
+	text-align:left !important;
+	margin-top:2px;
+}
+
+#col-select{
+	margin-top:2px;
+}
+
 @media (max-width: 750px) {
 	#table-card, #bulk-nav, .nav_top,
 	#card-top {

--- a/app/assets/stylesheets/spam2.css
+++ b/app/assets/stylesheets/spam2.css
@@ -2,152 +2,65 @@
 *= require datatables/dataTables.bootstrap4
 */
 .nav_top {
-	position: fixed;
-	top: 60px;
-	left: 0px;
 	z-index: 5;
-	height: 50px;
 	width: 100%;
-	overflow-y: hidden;
-	border-bottom: 1px solid #e1e4e8;
-}
-
-#sidebar-wrapper {
-	margin-left: -15%;
-	transition: all .4s ease 0s;
-	position: fixed;
-	top: 50px;
-	right: 0;
-	left: 0;
-	width: 15%;
-	height: 100vh;
-	z-index: 4;
-}
-
-#page-content-wrapper {
-	margin-top: 8vh;
-	width: 85vw;
-}
-
-#wrapper.active #sidebar-wrapper {
-	left: 15%;
 }
 
 #batch-spam:hover {
-	border-bottom: 2px solid red;
-	color: grey;
-	font-weight: bold;
+	color:  red !important;
+	cursor: pointer;
 }
 
 #batch-publish:hover {
-	border-bottom: 2px solid green;
-	color: grey;
-	font-weight: bold;
+	color: green !important;
+	cursor: pointer;
 }
 
 #delete-batch:hover {
-	border-bottom: 2px solid maroon;
-	color: grey;
-	font-weight: bold;
+	color: maroon !important;
+	cursor: pointer;
 }
 
 #all:hover {
-	border-bottom: 2px solid blue;
-	color: grey;
-	font-weight: bold;
+	color: blue !important;
+	cursor: pointer;
 }
 
 #batch-ban:hover {
-	border-bottom: 2px solid orange;
-	color: grey;
-	font-weight: bold;
+	color: orange !important;
+	cursor: pointer;
 }
 
 #batch-unban:hover {
-	border-bottom: 2px solid green;
-	color: grey;
-	font-weight: bold;
+	color: green !important;	
+	cursor: pointer;
 }
 
 .alert {
 	z-index: 6;
 }
 
-#wrapper.active #card-top {
-	margin-left: 10%;
-}
-
-#wrapper.active #table-card {
-	margin-left: 10%;
-}
-
 #table-card {
-	margin-top: 8vh;
-	transition: all .4s ease 0s;
+	width: 100%;
 }
 
 #card-top {
-	transition: all .4s ease 0s;
+	margin-top:2vh;
 }
 
-.sidenav {
-	font-size: 0.9rem;
-	padding-top: 3.625rem;
-	border-right: 1px solid #e1e4e8;
-}
-
-.sidenav .sidenav-menu .nav .sidenav-menu-heading {
-	padding: 1.1rem 1.4rem 0.7rem;
-	font-size: 0.9rem;
-}
-
-.sidenav .sidenav-menu .nav .nav-link {
-	display: flex;
-	align-items: center;
-	padding-top: 0.70rem;
-	padding-bottom: 0.70rem;
-	position: relative;
-	color: black;
-}
-
-.sidenav .sidenav-menu .nav .nav-link.active {
-	font-weight: bold;
-	color: #007bff!important
+#bulk-nav{
+	margin-top: 2%;
+	width:100%;
 }
 
 @media (max-width: 750px) {
-	#sidebar-wrapper {
-		margin-left: -45%;
-		width: 45%;
-	}
-	#wrapper.active #sidebar-wrapper {
-		left: 45%;
-	}
-	.nav_top {
-		font-size: small;
-	}
-	#table-card,
+	#table-card, #bulk-nav ,.nav_top,
 	#card-top {
-        margin-left: 10%;
-        width:85vw;
+        margin-left: 5vw;
+        width:90vw;
 	}
-	#wrapper.active #page-content-wrapper {
-		opacity: 0.2;
-	}
-}
-
-@media (max-width: 1050px) and (min-width: 750px) {
-	#sidebar-wrapper {
-		margin-left: -25%;
-		width: 25%;
-	}
-	#wrapper.active #sidebar-wrapper {
-		left: 25%;
-	}
-	#wrapper.active #card-top {
-		margin-left: 25%;
-	}
-	#wrapper.active #table-card {
-		margin-left: 25%;
+	.nav_title{
+		font-size: medium;
+		margin-bottom : 10px;
 	}
 }

--- a/app/assets/stylesheets/spam2.css
+++ b/app/assets/stylesheets/spam2.css
@@ -17,7 +17,7 @@
 }
 
 #delete-batch:hover {
-	color: maroon !important;
+	color: red !important;
 	cursor: pointer;
 }
 
@@ -36,10 +36,6 @@
 	cursor: pointer;
 }
 
-.alert {
-	z-index: 6;
-}
-
 #table-card {
 	width: 100%;
 }
@@ -53,8 +49,12 @@
 	width:100%;
 }
 
+.active .drop{
+	color:white !important;
+}
+
 @media (max-width: 750px) {
-	#table-card, #bulk-nav ,.nav_top,
+	#table-card, #bulk-nav, .nav_top,
 	#card-top {
         margin-left: 5vw;
         width:90vw;

--- a/app/assets/stylesheets/spam2.css
+++ b/app/assets/stylesheets/spam2.css
@@ -36,6 +36,10 @@
 	cursor: pointer;
 }
 
+#node-hover:hover{
+	color:blue !important;
+}
+
 #table-card {
 	width: 100%;
 }
@@ -46,6 +50,7 @@
 
 #bulk-nav{
 	margin-top: 2%;
+	margin-bottom: 1%;
 	width:100%;
 }
 
@@ -70,7 +75,10 @@
         width:90vw;
 	}
 	.nav_title{
-		font-size: 20px;
+		font-size: 18px;
 		margin-bottom : 10px;
+	}
+	#card-top .card-header{
+		font-size: 18px;
 	}
 }

--- a/app/assets/stylesheets/spam2.css
+++ b/app/assets/stylesheets/spam2.css
@@ -60,7 +60,7 @@
         width:90vw;
 	}
 	.nav_title{
-		font-size: medium;
+		font-size: 20px;
 		margin-bottom : 10px;
 	}
 }

--- a/app/controllers/spam2_controller.rb
+++ b/app/controllers/spam2_controller.rb
@@ -1,5 +1,5 @@
 class Spam2Controller < ApplicationController
-  before_action :require_user, only: %i(spam spam_revisions mark_comment_spam publish_comment spam_comments)
+  before_action :require_user, only: %i(_spam _spam_revisions _spam_comments)
 
   def _spam
     if logged_in_as(%w(moderator admin))

--- a/app/controllers/spam2_controller.rb
+++ b/app/controllers/spam2_controller.rb
@@ -32,7 +32,8 @@ class Spam2Controller < ApplicationController
 
   def _spam_comments
     if logged_in_as(%w(moderator admin))
-      @comments = Comment.where(status: 0)
+      @comments = Comment.order('timestamp DESC')
+                  .where(status: 0)
       render template: 'spam2/_spam'
     else
       flash[:error] = 'Only moderators can moderate comments.'

--- a/app/controllers/spam2_controller.rb
+++ b/app/controllers/spam2_controller.rb
@@ -3,16 +3,16 @@ class Spam2Controller < ApplicationController
 
   def _spam
     if logged_in_as(%w(moderator admin))
-      @nodes = Node
+      @nodes = Node.order('nid DESC')
       @nodes = if params[:type] == 'wiki'
                  @nodes.where(type: 'page', status: 1)
                else
                  @nodes.where(status: [0, 4])
                end
-      @spam_count = @nodes.where(status: 0).length.to_s
-      @unmoderated_count = @nodes.where(status: 4).length.to_s
-      @page_count = @nodes.where(type: 'page').length.to_s
-      @note_count = @nodes.where(type: 'note').length.to_s
+      @spam_count = @nodes.where(status: 0).length
+      @unmoderated_count = @nodes.where(status: 4).length
+      @page_count = @nodes.where(type: 'page').length
+      @note_count = @nodes.where(type: 'note').length
     else
       flash[:error] = 'Only moderators can moderate posts.'
       redirect_to '/dashboard'

--- a/app/views/spam2/_comments.html.erb
+++ b/app/views/spam2/_comments.html.erb
@@ -24,7 +24,7 @@ $(document).ready(function () {
             <td><input  class="selectedId" value="<%= comment.id %>" type="checkbox" /></td>
             <td>
               <% unless comment.node.nil? %>
-                <i class="fa fa-file"></i> <a href="<%= comment.node.path %>" data-toggle="modal" data-target="#ninfo<%= comment.id %>"><%= comment.node.title.truncate(40) %></a>
+                <i class="fa fa-file"></i> <a href="<%= comment.node.path %>" data-toggle="modal" data-target="#ninfo<%= comment.id %>"><%= comment.node.title.truncate(20) %></a>
               <% end %>            
               </td>
             <td style="width:200px;">

--- a/app/views/spam2/_comments.html.erb
+++ b/app/views/spam2/_comments.html.erb
@@ -31,7 +31,7 @@ $(document).ready(function () {
               <%= comment.body.truncate(40) %>
             </td>
             <td>
-              <a href="/profile/<%= comment.author.name %>"><%= comment.author.name %></a>
+              <a href="/profile/<%= comment.author&.name %>"><%= comment.author&.name %></a>
             </td>
             <td>
               <% unless comment.node.nil? %>
@@ -40,10 +40,10 @@ $(document).ready(function () {
             </td>
             <td>
               <a class="badge badge-pill badge<% if comment.status == 0 %>-success<% else %>-secondary disabled<% end %> publish" href="/admin/publish_comment/<%= comment.id %>"><i class="fa fa-check-circle fa-white"></i> Publish</a>
-              <% if comment.author.status == 0 %>
-                <a class="badge badge-pill badge-danger a<%= comment.author.id %>" href="/ban/<%= comment.author.id %>">Ban</a>
-              <% elsif comment.author.status == 1 %>
-                <a class="badge badge-pill badge-secondary unban a-unban<%= comment.author.id %>" href="/unban/<%= comment.author.id %>">Unban</a>
+              <% if comment.author&.status == 0 %>
+                <a class="badge badge-pill badge-danger a<%= comment.author&.id %>" href="/ban/<%= comment.author&.id %>">Ban</a>
+              <% elsif comment.author&.status == 1 %>
+                <a class="badge badge-pill badge-secondary unban a-unban<%= comment.author&.id %>" href="/unban/<%= comment.author&.id %>">Unban</a>
               <% end %>
             </td>
           </tr>

--- a/app/views/spam2/_comments.html.erb
+++ b/app/views/spam2/_comments.html.erb
@@ -25,8 +25,8 @@ $(document).ready(function () {
             <td>
               <% unless comment.node.nil? %>
                 <i class="fa fa-file"></i> <a href="<%= comment.node.path %>" data-toggle="modal" data-target="#ninfo<%= comment.id %>"><%= comment.node.title.truncate(40) %></a>
-              <% end %>
-            </td>
+              <% end %>            
+              </td>
             <td style="width:200px;">
               <%= comment.body.truncate(40) %>
             </td>
@@ -47,8 +47,9 @@ $(document).ready(function () {
               <% end %>
             </td>
           </tr>
-          <div class="modal fade" id="ninfo<%= comment.id %>"> 
+            <div class="modal fade" id="ninfo<%= comment.id %>"> 
             <div class="modal-dialog" >
+              <% unless comment.node.nil? %>
               <div class="modal-content">
                 <div class="modal-header">
                   <h5 class="modal-title"><a href="<%= comment.node.path %>"><%= comment.node.title %></a></h5>
@@ -63,6 +64,7 @@ $(document).ready(function () {
                   <%= time_ago_in_words(comment.timestamp.seconds.ago) %> ago
                 </div>
               </div>
+              <% end %>
             </div>
           </div>
         <% end %>

--- a/app/views/spam2/_comments.html.erb
+++ b/app/views/spam2/_comments.html.erb
@@ -21,10 +21,10 @@ $(document).ready(function () {
       <tbody> 
         <% @comments.each do |comment| %>
           <tr id="n<%= comment.id %>">
-            <td><input  class="selectedId" value="<%= comment.nid %>" type="checkbox" /></td>
+            <td><input  class="selectedId" value="<%= comment.id %>" type="checkbox" /></td>
             <td>
               <% unless comment.node.nil? %>
-                <i class="fa fa-file"></i> <a href="<%= comment.node.path %>"><%= comment.node.title.truncate(40) %></a>
+                <i class="fa fa-file"></i> <a href="<%= comment.node.path %>" data-toggle="modal" data-target="#ninfo<%= comment.id %>"><%= comment.node.title.truncate(40) %></a>
               <% end %>
             </td>
             <td style="width:200px;">
@@ -47,6 +47,24 @@ $(document).ready(function () {
               <% end %>
             </td>
           </tr>
+          <div class="modal fade" id="ninfo<%= comment.id %>"> 
+            <div class="modal-dialog" >
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title"><a href="<%= comment.node.path %>"><%= comment.node.title %></a></h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span>&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <%= comment.body %>
+                </div>
+                <div class="modal-footer">
+                  <%= time_ago_in_words(comment.timestamp.seconds.ago) %> ago
+                </div>
+              </div>
+            </div>
+          </div>
         <% end %>
       </tbody>
     </table>                       

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -128,7 +128,7 @@ $(document).ready(function () {
               <a href="/profile/<%= node.author.name %>"><%= node.author.name %> <%= node.author.new_contributor%></a>
              </td>
             <td>
-             <span style="color:grey;"><%= node.type.capitalize %> <span style="color:<% if node.status == 1 %>green;<% elsif node.status == 0 %>red;<% elsif node.status == 4 %>blue;<% end %>"%>(<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>)</span>
+             <span style="color:grey;"><%= node.type.capitalize %> <span style="color:<% if node.status == 1 %>green;<% elsif node.status == 0 %>red;<% elsif node.status == 4 %>blue;<% end %>">(<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>)</span>
             </td>
              <td>
                <%= time_ago_in_words(node.updated_at) %> ago</span>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -69,27 +69,28 @@ $(document).ready(function () {
 	});
 });
 </script>
+
 <div class="card" id="table-card">
   <div class="bg-light  navbar navbar-expand">
     <ul class="nav navbar-expand  navbar-nav-scroll">
       <li class="nav-item">
-        <a class="btn nav-link small  text-dark">Selected <span id="select-count" class="badge badge-dark">0</span></a>
+        <a class="btn nav-link small text-dark">Selected <span id="select-count" class="badge badge-dark">0</span></a>
       </li>
       <li class="nav-item">
-        <a class="btn nav-link small  text-dark"id="reset">Reset all</a>
+        <a class="btn nav-link small text-dark"id="reset">Reset all</a>
       </li>
       <% if params[:type] != "wiki" %>  
       <li class="nav-item">
-        <a class="btn nav-link small   text-dark" id="spammed">Spammed <span class="badge badge-dark"><%= @spam_count %></span></a>
+        <a class="btn nav-link small text-dark" id="spammed">Spammed <span class="badge badge-dark"><%= @spam_count %></span></a>
       </li>
       <li class="nav-item">
-        <a class="btn nav-link  text-dark" id="unmoderated">Unmoderate <span class="badge badge-dark"><%= @unmoderated_count %></span></a>
+        <a class="btn nav-link text-dark" id="unmoderated">Unmoderate <span class="badge badge-dark"><%= @unmoderated_count %></span></a>
       </li>
       <li class="nav-item">
-        <a class="btn nav-link  text-dark" id="page">Page <span class="badge badge-dark"><%= @page_count %></span></a>
+        <a class="btn nav-link text-dark" id="page">Page <span class="badge badge-dark"><%= @page_count %></span></a>
       </li>
       <li class="nav-item">
-        <a class="btn nav-link  text-dark" id="note">Note <span class="badge badge-dark"><%= @note_count %></span></a>
+        <a class="btn nav-link text-dark" id="note">Note <span class="badge badge-dark"><%= @note_count %></span></a>
       </li>   
       <li class="nav-item pt-2">
       <select name="Visible" id="extSelect" class="custom-select custom-select-sm form-control form-control-sm">
@@ -122,7 +123,7 @@ $(document).ready(function () {
             <td><input  class="selectedId" value="<%= node.nid %>" type="checkbox" /></td>
             <td>
               <i class="fa fa-file"></i> 
-              <a href="javascript:void(0);" data-toggle="modal" data-target="#ninfo<%= node.id %>"><%= node.title.truncate(28) %></a><br />
+              <a href="javascript:void(0);" data-toggle="modal" data-target="#ninfo<%= node.id %>"><%= node.title.truncate(20) %></a><br />
             </td>
             <td>  
               <a href="/profile/<%= node.author.name %>"><%= node.author.name %> <%= node.author.new_contributor%></a>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -138,7 +138,7 @@ $(document).ready(function () {
                <a class="badge btn badge-pill badge<% if node.status != 0 %>-danger<% else %>-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a> 
                <a class="badge badge-pill badge-secondary ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
                <a class="badge badge-pill badge-secondary unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>
-               <%= link_to "/notes/delete/#{node.id}", data: { confirm: 'Are you sure you want to delete "'+node.path+'"?' }, :remote => true, :class => "px-3 delete" do %>
+               <%= link_to "/notes/delete/#{node.id}", data: { confirm: "Are you sure you want to delete #{node.id}?"}, :remote => true, :class => "px-3 delete" do %>
                 <i class="fa fa-trash"></i>
                <% end %>
                <script>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -1,7 +1,7 @@
 <script>
 $(document).ready(function () {
 	var table = table_main("#node_table");
-	$("#all").click(function () { //select all button
+	$("#all").click(function () {    //select all button
 		$('.selectedId').prop('checked', !$('.selectedId').prop('checked'));
 		var check = ($('.selectedId').filter(":checked").length == $('.selectedId').length);
 		$('#select-count').text($('.selectedId').filter(":checked").length);
@@ -9,11 +9,11 @@ $(document).ready(function () {
 	});
 	function batch_nav(bulk) {
 		vals = []
-		$('.selectedId').each(function (i, a) {
+		$('.selectedId').each(function (i, a) {    // batch nav
 			if (a.checked) vals.push(a.value)
 		})
 		if (vals.length == 0) {
-			alert("You have not selected anything");
+			alert("You have not selected anything");     // if nothing is selected
 		} else {
 			window.location = "/spam2/" + bulk + "/" + vals.join(',');
 		}
@@ -33,27 +33,27 @@ $(document).ready(function () {
 	$("#delete-batch").bind('click', function (e) { // batch delete
 		batch_nav("batch_delete");
 	});
-	$('#reset').on('click', function () {
+	$('#reset').on('click', function () {    // reset filter 
 		table.search('').columns().search('').draw();
 		table.search('').columns().order('').draw();
 	});
-	$('#spammed').on('click', function () {
+	$('#spammed').on('click', function () {     //spam filter 
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Spammed").draw();
 	});
-	$('#unmoderated').on('click', function () {
-		table.search('').columns().search('').draw();
+	$('#unmoderated').on('click', function () {   // unmoderated filter
+		table.search('').columns().search('').draw();  
 		table.columns(3).search("unmoderated").draw();
 	});
-	$('#page').on('click', function () {
+	$('#page').on('click', function () {         // page filter
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Page").draw();
 	});
-	$('#note').on('click', function () {
+	$('#note').on('click', function () {        // note filter 
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Note").draw();
   });
-  $("#extSelect").change(function(e){
+  $("#extSelect").change(function(e){  // Hide coloumns
 		table.columns().visible(true);
 		if (this.value === '1') {
 			table.column(1).visible(false);
@@ -65,6 +65,26 @@ $(document).ready(function () {
 			table.columns(4).visible(false);
 		} else if (this.value === '5') {
 			table.columns(5).visible(false);
+		}
+  });
+  $( '#col-search').on('keyup click', function () {  // specific search
+    table.search('').columns().search('').draw();
+    var col_input =$("#col-select").val();
+    if (col_input === '1') {
+      table.search('').columns().search('').draw();
+			table.column(1).search(this.value).draw();
+		} else if (col_input === '2') {
+      table.search('').columns().search('').draw();
+			table.column(2).search(this.value).draw();
+		} else if (col_input === '3') {
+      table.search('').columns().search('').draw();
+			table.columns(3).search(this.value).draw();
+		} else if (col_input === '4') {
+      table.search('').columns().search('').draw();
+			table.columns(4).search(this.value).draw();
+		} else if (col_input === '5') {
+      table.search('').columns().search('').draw();
+			table.columns(5).search(this.value).draw();
 		}
 	});
 });
@@ -84,14 +104,14 @@ $(document).ready(function () {
         <a class="btn nav-link small text-dark" id="spammed">Spammed <span class="badge badge-dark"><%= @spam_count %></span></a>
       </li>
       <li class="nav-item">
-        <a class="btn nav-link text-dark" id="unmoderated">Unmoderate <span class="badge badge-dark"><%= @unmoderated_count %></span></a>
+        <a class="btn nav-link text-dark" id="unmoderated">Unmoderated <span class="badge badge-dark"><%= @unmoderated_count %></span></a>
       </li>
       <li class="nav-item">
         <a class="btn nav-link text-dark" id="page">Page <span class="badge badge-dark"><%= @page_count %></span></a>
       </li>
       <li class="nav-item">
         <a class="btn nav-link text-dark" id="note">Note <span class="badge badge-dark"><%= @note_count %></span></a>
-      </li>   
+      </li>
       <li class="nav-item pt-2">
       <select name="Visible" id="extSelect" class="custom-select custom-select-sm form-control form-control-sm">
       <option value="">Hide(Reset)</option>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -166,7 +166,8 @@ $(document).ready(function () {
               </td>
             </tr>
             <div style="display:none;" id="deleted<%= node.id %>" class="alert alert-success alert-dismissible">
-              Node Deleted
+              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                Node Deleted
             </div> 
             <div style="display:none;" id="npublish<%= node.id %>" class="alert alert-success alert-dismissible">
               <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -172,10 +172,12 @@ $(document).ready(function () {
                 $('#n<%= node.id %> .publish').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').hide()
                   $('#npublish<%= node.id %>').fadeIn(); // published!
+                  $('#npublish<%= node.id %>').fadeOut();
                 });
                 $('#n<%= node.id %> .spam').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').hide()
                   $('#nspam<%= node.id %>').fadeIn(); // spammed!
+                  $('#nspam<%= node.id %>').fadeOut();
                 });  
                 $('.a<%= node.author.id %>.ban').bind('ajax:success', function(e){
                   $('.a<%= node.author.id %>').hide()  // ban toggle
@@ -188,16 +190,14 @@ $(document).ready(function () {
                 </script>
               </td>
             </tr>
-            <div style="display:none;" id="deleted<%= node.id %>" class="alert alert-success alert-dismissible">
+            <div style="display:none;" id="deleted<%= node.id %>" class="alert alert-danger alert-dismissible">
               Node Deleted
             </div> 
             <div style="display:none;" id="npublish<%= node.id %>" class="alert alert-success alert-dismissible">
-              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-              <strong>Success!</strong> Content <a href='<%= node.path %>'>published</a>.
+              Content published
             </div> 
-            <div style="display:none;" id="nspam<%= node.id %>" class="alert alert-success alert-dismissible">
-              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-              <strong>Success!</strong> Content <a href='<%= node.path %>'>spammed</a>.
+            <div style="display:none;" id="nspam<%= node.id %>" class="alert alert-danger alert-dismissible">
+                Content spammed
             </div>
             <div class="modal fade" id="ninfo<%= node.id %>"> 
               <div class="modal-dialog" >

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -140,7 +140,7 @@ $(document).ready(function () {
                <a class="badge badge-pill badge-secondary ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
                <a class="badge badge-pill badge-secondary unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>
                <%= link_to "/notes/delete/#{node.id}", data: { confirm: "Are you sure you want to delete #{node.path}?" }, :remote => true, :class => "px-3 delete" do %>
-                <i class="fa fa-trash"></i>
+                <i class="fa fa-trash text-dark"></i>
                <% end %>
                <script>
                 $('#n<%= node.id %> .delete').bind('ajax:success', function(e){

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -147,7 +147,7 @@ $(document).ready(function () {
               <a href="javascript:void(0);" data-toggle="modal" data-target="#ninfo<%= node.id %>"><%= node.title.truncate(20) %></a><br />
             </td>
             <td>  
-              <a href="/profile/<%= node.author.name %>"><%= node.author.name %> <%= node.author.new_contributor%></a>
+              <a href="/profile/<%= node.author&.name %>"><%= node.author&.name %> <%= node.author&.new_contributor%></a>
              </td>
             <td>
              <span style="color:grey;"><%= node.type.capitalize %> <span style="color:<% if node.status == 1 %>green;<% elsif node.status == 0 %>red;<% elsif node.status == 4 %>blue;<% end %>">(<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>)</span>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -138,7 +138,7 @@ $(document).ready(function () {
                <a class="badge btn badge-pill badge<% if node.status != 0 %>-danger<% else %>-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= node.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a> 
                <a class="badge badge-pill badge-secondary ban a<%= node.author.id %>" <% if node.author.status == 0 %>style="display:none;"<% end %> data-remote="true" href="/ban/<%= node.author.id %>">Ban user</a>
                <a class="badge badge-pill badge-secondary unban a-unban<%= node.author.id %>" <% if node.author.status == 1 %>style="display:none;"<% end %> data-remote="true" href="/unban/<%= node.author.id %>">Unban user</a>
-               <%= link_to "/notes/delete/#{node.id}", data: { confirm: "Are you sure you want to delete #{node.id}?"}, :remote => true, :class => "px-3 delete" do %>
+               <%= link_to "/notes/delete/#{node.id}", data: { confirm: "Are you sure you want to delete #{node.path}?" }, :remote => true, :class => "px-3 delete" do %>
                 <i class="fa fa-trash"></i>
                <% end %>
                <script>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -5,19 +5,15 @@ $(document).ready(function () {
 		$('.selectedId').prop('checked', !$('.selectedId').prop('checked'));
 		var check = ($('.selectedId').filter(":checked").length == $('.selectedId').length);
 		$('#select-count').text($('.selectedId').filter(":checked").length);
-		$('#selectall').prop("checked", check);
-	});
-
+    $('#selectall').prop("checked", check);
+    disable_buttons('#selectall');
+  });
 	function batch_nav(bulk) {
 		vals = []
 		$('.selectedId').each(function (i, a) { // batch nav
 			if (a.checked) vals.push(a.value)
 		})
-		if (vals.length == 0) {
-			alert("You have not selected anything"); // if nothing is selected
-		} else {
 			window.location = "/spam2/" + bulk + "/" + vals.join(',');
-		}
 	}
 	$("#batch-spam").bind('click', function (e) { //batch spam
 		batch_nav("batch_spam");
@@ -34,23 +30,32 @@ $(document).ready(function () {
 	$("#delete-batch").bind('click', function (e) { // batch delete
 		batch_nav("batch_delete");
 	});
-	$('#reset').on('click', function () { // reset filter 
+  $('#reset').on('click', function () { // reset filter
+    $('#reset').addClass('text-dark');
 		table.search('').columns().search('').draw();
 		table.search('').columns().order('').draw();
 	});
-	$('#spammed').on('click', function () { //spam filter 
+  $('#spammed').on('click', function () { //spam filter 
+    $('#reset').removeClass('text-dark');
+    $('#reset').addClass('text-danger');
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Spammed").draw();
 	});
-	$('#unmoderated').on('click', function () { // unmoderated filter
+  $('#unmoderated').on('click', function () { // unmoderated filter
+    $('#reset').removeClass('text-dark');
+    $('#reset').addClass('text-danger');
 		table.search('').columns().search('').draw();
 		table.columns(3).search("unmoderated").draw();
 	});
-	$('#page').on('click', function () { // page filter
+  $('#page').on('click', function () { // page filter
+    $('#reset').removeClass('text-dark');
+    $('#reset').addClass('text-danger');
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Page").draw();
 	});
-	$('#note').on('click', function () { // note filter 
+  $('#note').on('click', function () { // note filter
+    $('#reset').removeClass('text-dark');
+    $('#reset').addClass('text-danger');
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Note").draw();
 	});
@@ -67,7 +72,7 @@ $(document).ready(function () {
 		} else if (this.value === '5') {
 			table.columns(5).visible(false);
 		}
-	});
+  });
 	$('#col-search').on('keyup click', function () { // specific search
 		table.search('').columns().search('').draw();
 		var col_input = $("#col-select").val();
@@ -98,7 +103,7 @@ $(document).ready(function () {
         <a class="btn nav-link small text-dark">Selected <span id="select-count" class="badge badge-dark">0</span></a>
       </li>
       <li class="nav-item">
-        <a class="btn nav-link small text-dark"id="reset">Reset all</a>
+        <a class="btn nav-link small"id="reset">Reset all</a>
       </li>
       <% if params[:type] != "wiki" %>  
       <li class="nav-item">
@@ -114,8 +119,8 @@ $(document).ready(function () {
         <a class="btn nav-link text-dark" id="note">Note <span class="badge badge-dark"><%= @note_count %></span></a>
       </li>
       <li class="nav-item pt-2">
-      <select name="Visible" id="extSelect" class="custom-select custom-select-sm form-control form-control-sm">
-      <option value="">Hide(Reset)</option>
+      <select name="Visible" id="extSelect" class="custom-select custom-select-sm form-control form-control-sm" data-toggle="tooltip" data-placement="top" title="Hide selected column">
+      <option value="">None</option>
       <option value="1">Title</option>
       <option value="2">Author</option>
       <option value="3">Status</option>
@@ -143,17 +148,17 @@ $(document).ready(function () {
           <tr id="n<%= node.id %>">
             <td><input  class="selectedId" value="<%= node.nid %>" type="checkbox" /></td>
             <td>
-              <i class="fa fa-file"></i> 
-              <a href="javascript:void(0);" data-toggle="modal" data-target="#ninfo<%= node.id %>"><%= node.title.truncate(20) %></a><br />
+              <i class="fa fa-file text-secondary"></i> 
+              <a href="javascript:void(0);" class="text-dark font-weight-bold" id="node-hover" data-toggle="modal" data-target="#ninfo<%= node.id %>"><%= node.title.truncate(20) %></a><br />
             </td>
             <td>  
-              <a href="/profile/<%= node.author&.name %>"><%= node.author&.name %> <%= node.author&.new_contributor%></a>
+              <a href="/profile/<%= node.author&.name %>" class="text-dark"><%= node.author&.name %> <%= node.author&.new_contributor%></a>
              </td>
             <td>
-             <span style="color:grey;"><%= node.type.capitalize %> <span style="color:<% if node.status == 1 %>green;<% elsif node.status == 0 %>red;<% elsif node.status == 4 %>blue;<% end %>">(<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>)</span>
+             <span class="text-secondary"><%= node.type.capitalize %> <span style="color:<% if node.status == 1 %>green;<% elsif node.status == 0 %>red;<% elsif node.status == 4 %>blue;<% end %>">(<% if node.status == 1 %>Published<% elsif node.status == 0 %>Spammed<% elsif node.status == 4 %>Unmoderated<% end %>)</span>
             </td>
              <td>
-               <%= time_ago_in_words(node.updated_at) %> ago</span>
+               <span class="text-dark"><%= time_ago_in_words(node.updated_at) %> ago</span>
             </td>
              <td style="height:35px !important;">
                <a class="badge btn badge-pill badge<% if node.status != 1 %>-success<% else %>-secondary<% end %> publish" data-remote="true" href="/moderate/publish/<%= node.id %>" ><i class="fa fa-check-circle fa-white"></i> Publish post</a>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -1,19 +1,20 @@
 <script>
 $(document).ready(function () {
 	var table = table_main("#node_table");
-	$("#all").click(function () {    //select all button
+	$("#all").click(function () { //select all button
 		$('.selectedId').prop('checked', !$('.selectedId').prop('checked'));
 		var check = ($('.selectedId').filter(":checked").length == $('.selectedId').length);
 		$('#select-count').text($('.selectedId').filter(":checked").length);
 		$('#selectall').prop("checked", check);
 	});
+
 	function batch_nav(bulk) {
 		vals = []
-		$('.selectedId').each(function (i, a) {    // batch nav
+		$('.selectedId').each(function (i, a) { // batch nav
 			if (a.checked) vals.push(a.value)
 		})
 		if (vals.length == 0) {
-			alert("You have not selected anything");     // if nothing is selected
+			alert("You have not selected anything"); // if nothing is selected
 		} else {
 			window.location = "/spam2/" + bulk + "/" + vals.join(',');
 		}
@@ -33,27 +34,27 @@ $(document).ready(function () {
 	$("#delete-batch").bind('click', function (e) { // batch delete
 		batch_nav("batch_delete");
 	});
-	$('#reset').on('click', function () {    // reset filter 
+	$('#reset').on('click', function () { // reset filter 
 		table.search('').columns().search('').draw();
 		table.search('').columns().order('').draw();
 	});
-	$('#spammed').on('click', function () {     //spam filter 
+	$('#spammed').on('click', function () { //spam filter 
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Spammed").draw();
 	});
-	$('#unmoderated').on('click', function () {   // unmoderated filter
-		table.search('').columns().search('').draw();  
+	$('#unmoderated').on('click', function () { // unmoderated filter
+		table.search('').columns().search('').draw();
 		table.columns(3).search("unmoderated").draw();
 	});
-	$('#page').on('click', function () {         // page filter
+	$('#page').on('click', function () { // page filter
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Page").draw();
 	});
-	$('#note').on('click', function () {        // note filter 
+	$('#note').on('click', function () { // note filter 
 		table.search('').columns().search('').draw();
 		table.columns(3).search("Note").draw();
-  });
-  $("#extSelect").change(function(e){  // Hide coloumns
+	});
+	$("#extSelect").change(function (e) { // Hide coloumns
 		table.columns().visible(true);
 		if (this.value === '1') {
 			table.column(1).visible(false);
@@ -66,24 +67,24 @@ $(document).ready(function () {
 		} else if (this.value === '5') {
 			table.columns(5).visible(false);
 		}
-  });
-  $( '#col-search').on('keyup click', function () {  // specific search
-    table.search('').columns().search('').draw();
-    var col_input =$("#col-select").val();
-    if (col_input === '1') {
-      table.search('').columns().search('').draw();
+	});
+	$('#col-search').on('keyup click', function () { // specific search
+		table.search('').columns().search('').draw();
+		var col_input = $("#col-select").val();
+		if (col_input === '1') {
+			table.search('').columns().search('').draw();
 			table.column(1).search(this.value).draw();
 		} else if (col_input === '2') {
-      table.search('').columns().search('').draw();
+			table.search('').columns().search('').draw();
 			table.column(2).search(this.value).draw();
 		} else if (col_input === '3') {
-      table.search('').columns().search('').draw();
+			table.search('').columns().search('').draw();
 			table.columns(3).search(this.value).draw();
 		} else if (col_input === '4') {
-      table.search('').columns().search('').draw();
+			table.search('').columns().search('').draw();
 			table.columns(4).search(this.value).draw();
 		} else if (col_input === '5') {
-      table.search('').columns().search('').draw();
+			table.search('').columns().search('').draw();
 			table.columns(5).search(this.value).draw();
 		}
 	});

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -145,6 +145,7 @@ $(document).ready(function () {
                 $('#n<%= node.id %> .delete').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').fadeOut()
                   $('#deleted<%= node.id %>').fadeIn();
+                  $('#deleted<%= node.id %>').fadeOut();
                 });
                 $('#n<%= node.id %> .publish').bind('ajax:success', function(e){
                   $('#n<%= node.id %>').hide()
@@ -166,8 +167,7 @@ $(document).ready(function () {
               </td>
             </tr>
             <div style="display:none;" id="deleted<%= node.id %>" class="alert alert-success alert-dismissible">
-              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                <p>Node Deleted</p>
+              Node Deleted
             </div> 
             <div style="display:none;" id="npublish<%= node.id %>" class="alert alert-success alert-dismissible">
               <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>

--- a/app/views/spam2/_nodes.html.erb
+++ b/app/views/spam2/_nodes.html.erb
@@ -167,7 +167,7 @@ $(document).ready(function () {
             </tr>
             <div style="display:none;" id="deleted<%= node.id %>" class="alert alert-success alert-dismissible">
               <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                Node Deleted
+                <p>Node Deleted</p>
             </div> 
             <div style="display:none;" id="npublish<%= node.id %>" class="alert alert-success alert-dismissible">
               <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>

--- a/app/views/spam2/_revisions.html.erb
+++ b/app/views/spam2/_revisions.html.erb
@@ -27,16 +27,16 @@ $(document).ready(function () {
               <i class="fa fa-file"></i> <a class="text-primary" data-toggle="modal" data-target="#ninfo<%= revision.vid %>"><%= revision.title.truncate(20) %></a>
             </td>
             <td>
-              <a href="/profile/<%= revision.author.name %>"><%= revision.author.name %></a> 
+              <a href="/profile/<%= revision.author&.name %>"><%= revision.author&.name %></a> 
             </td>
             <td>
               <span style="color:grey;"><%= time_ago_in_words(revision.timestamp.seconds.ago) %> ago</span>
             </td>
             <td>
               <a class="badge badge-pill badge<% if revision.status == 0 %>-success<% else %>-secondary disabled<% end %> publish" data-remote="true" href="/moderate/revision/publish/<%= revision.vid %>"><i class="fa fa-check-circle fa-white"></i> Publish post</a>
-                <% if revision.author.status == 0 %>
+                <% if revision.author&.status == 0 %>
                   <a class="badge badge-pill badge-danger ban a<%= revision.author.id %>" href="/ban/<%= revision.author.id %>">Ban</a>
-                <% elsif revision.author.status == 1 %>
+                <% elsif revision.author&.status == 1 %>
                   <a class="badge badge-pill badge-secondary unban a-unban<%= revision.author.id %>" href="/unban/<%= revision.author.id %>">Unban</a>
                 <% end %>
             </td>

--- a/app/views/spam2/_revisions.html.erb
+++ b/app/views/spam2/_revisions.html.erb
@@ -13,21 +13,18 @@ $(document).ready(function () {
         <tr>
           <th><input type="checkbox"  id="selectall" /></th>
           <th>Title</th>
-          <th>Content</th>
           <th>Author</th>
           <th>Time</th>
           <th>Action</th>                                
         </tr>       
       </thead>
+
       <tbody> 
         <% @revisions.each do |revision| %>
           <tr id="n<%= revision.vid %>">
-            <td><input  class="selectedId" value="<%= revision.nid %>" type="checkbox" /></td>
+            <td><input  class="selectedId" value="<%= revision.vid %>" type="checkbox" /></td>
             <td>
-              <i class="fa fa-file"></i> <a href="<% if !revision.parent.nil? %><%= revision.parent.path %><% end %>"><%= revision.title.truncate(40) %></a><br />
-            </td>
-            <td style="width:200px;">
-              <%= revision.body.truncate(40) %>
+              <i class="fa fa-file"></i> <a class="text-primary" data-toggle="modal" data-target="#ninfo<%= revision.vid %>"><%= revision.title.truncate(30) %></a>
             </td>
             <td>
               <a href="/profile/<%= revision.author.name %>"><%= revision.author.name %></a> 
@@ -44,8 +41,23 @@ $(document).ready(function () {
                 <% end %>
             </td>
           </tr>
+            <div class="modal fade" id="ninfo<%= revision.vid %>">
+              <div class="modal-dialog" >
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title"><a href="<% if !revision.parent.nil? %><%= revision.parent.path %><% end %>"><%= revision.title%></a></h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span>&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <%= revision.body %>
+                  </div>
+                </div>
+              </div>
+            </div>
         <% end %>
       </tbody>
-    </table>                       
+    </table>                      
   </div>
   </div>

--- a/app/views/spam2/_revisions.html.erb
+++ b/app/views/spam2/_revisions.html.erb
@@ -24,7 +24,7 @@ $(document).ready(function () {
           <tr id="n<%= revision.vid %>">
             <td><input  class="selectedId" value="<%= revision.vid %>" type="checkbox" /></td>
             <td>
-              <i class="fa fa-file"></i> <a class="text-primary" data-toggle="modal" data-target="#ninfo<%= revision.vid %>"><%= revision.title.truncate(30) %></a>
+              <i class="fa fa-file"></i> <a class="text-primary" data-toggle="modal" data-target="#ninfo<%= revision.vid %>"><%= revision.title.truncate(20) %></a>
             </td>
             <td>
               <a href="/profile/<%= revision.author.name %>"><%= revision.author.name %></a> 

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -12,7 +12,7 @@
     <% end %> </b>
   </p>
   <div class="dropdown float-right">
-    <a class="btn btn-outline-primary dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <a class="btn btn-light border text-dark dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       Menu
     </a>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -1,121 +1,68 @@
-<script>
-$(document).ready(function () {
-	//sidenav toggle
-	$("#menu-toggle").click(function (e) {
-		e.preventDefault();
-		$("#wrapper").toggleClass("active");
-	});
-	$(".collapsed").click(function () {
-		$("#wrapper").toggleClass("active");
-  });
-});
-</script>
-<% cache('feature_anniversary-banner', skip_digest: true) do %>
-  <style>
-  .nav_top{
-   margin-top:48px;
-  }
-  .sidenav{
-    margin-top:48px;
-  }
-  </style>
-<% end %>
-<nav class="navbar navbar-expand navbar-light nav_top bg-light">
-  <div class="navbar-expand navbar-nav-scroll">
-    <ul class=" navbar-nav"> 
-      <li class="nav-item">
-        <a class="btn btn-outline-light" id="menu-toggle" href="#"><i class="fa fa-bars"></i></a>
-      </li>
-      <li class="nav-item">
-        <a class="text-primary navbar-brand nav-link" href="#">
-          <% if params[:type] == "wiki" %>
-            Spam2 / <b>Wiki</b>                                                                                                                                                                                                                                                                                                                                                                                                        
-          <% elsif params[:action] == "_spam_revisions"%>
-            Spam2 / <b>Revisions</b>
-          <% elsif params[:action] == "_spam_comments"%>
-            Spam2 / <b>Comments</b>
-          <% else %>
-            <b>Spam2 /</b>
-          <% end %>
-        </a>
-      </li>
-    </ul>
+<div class="nav_top flex d-inline">
+  <h4 class="text-primary pt-2 float-left nav_title">
+    <% if params[:type] == "wiki" %>
+      Spam2 / <b>Wiki</b>                                                                                                                                                                                                                                                                                                                                                                                                        
+    <% elsif params[:action] == "_spam_revisions"%>
+      Spam2 / <b>Revisions</b>
+    <% elsif params[:action] == "_spam_comments"%>
+      Spam2 / <b>Comments</b>
+    <% else %>
+      Spam2 /<b> Bulk Moderation </b>
+    <% end %>
+  </h4>
+  <div class="dropdown float-right">
+    <a class="btn btn-light dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Menu
+    </a>
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+      <h6 class="dropdown-header">Menu</h6>
+        <a class="dropdown-item" ><i class="fa fa-list-alt text-primary"></i> Dashboard</a>
+      <div class="dropdown-divider"></div>  
+        <h6 class="dropdown-header">Spam Moderation</h6>
+        <a class="dropdown-item <% unless  params[:action] =="_spam_comments" || params[:action] =="_spam_revisions" || params[:type] == "wiki"%> active <% end %>" href="/spam2"><i class="fa fa-address-book text-primary"></i> Bulk Moderation</a>
+        <a class="dropdown-item <% if params[:type] == "wiki" %> active <% end %>" href="/spam2/wiki" ><i class="fa fa-book text-primary"></i> Wiki</a>
+        <a class="dropdown-item <% if params[:action] == "_spam_revisions" %> active <% end %>" href="/spam2/revisions"><i class="fa fa-list text-primary"></i> Revision</a>
+        <a class="dropdown-item <% if params[:action] == "_spam_comments" %> active <% end %>" href="/spam2/comments" ><i class="fa fa-comment text-primary"></i> Comments</a>
+        <a class="dropdown-item" href="/people"><i class="fa fa-user text-primary"></i> Active users</a>
+      </div>
+    </div>
+</div>
+
+<div class="card text-center" id="card-top">
+  <div class="card-header bg-light"></div>
+  <div class="card-body">
+    <h5 class="card-title text-dark">Moderate Potential Spam</h5>
+    <p class="card-text">Moderators and admins have the ability to "spam" posts if they include inappropriate content, blatant advertising, or are otherwise problematic. If you're not sure, email at <a href="mailto:organizers@<%= request.host %>" class="badge badge-info text-white">moderators@<%= request.host %></a> If we all work together, we can keep spam to a minimum. Thanks for helping out!</p>
   </div>
+</div>
+
+<nav class="navbar navbar-expand " id="bulk-nav">
   <div class="navbar-expand navbar-nav-scroll d-inline">
-    <ul class=" navbar-nav pd-1">
+    <ul class=" navbar-nav ">
       <% if params[:action] != "_spam_revisions" && params[:action] != "_spam_comments" %>
-        <li class="nav-item">
-          <a class="nav-link text-dark d-inline-flex " href="#" id="batch-spam"><i class=" pt-1 pr-2 fa fa-ban text-danger"></i>  Spam</a>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light text-dark d-inline-flex " id="batch-spam"><i class=" pt-1 pr-2 fa fa-ban text-danger"></i>  Spam</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link text-dark d-inline-flex" href="#" id="batch-publish"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i>  Publish</a>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-publish"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i>  Publish</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link text-dark d-inline-flex" href="#" id="delete-batch"><i class=" pt-1 pr-2 fa fa-trash text-danger"></i> Delete</a>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light text-dark d-inline-flex" id="delete-batch"><i class=" pt-1 pr-2 fa fa-trash text-danger"></i> Delete</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link text-dark d-inline-flex" href="#" id="all"><i class=" pt-1 pr-2 fa fa-check text-primary"></i> Select</a>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="all"><i class=" pt-1 pr-2  fa fa-check text-primary"></i> Select</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link text-dark d-inline-flex" href="#" id="batch-ban"><i class=" pt-1 pr-2 fa fa-flag text-warning"></i> Ban</a>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-ban"><i class=" pt-1 pr-2 fa fa-flag text-warning"></i> Ban</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link text-dark d-inline-flex" href="#" id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
         </li>
       <% end %>
     </ul>    
   </div>
 </nav>
 
-<div id="wrapper">
-  <nav class="sidenav bg-light flex-nowrap pt-5 d-flex h-100 flex-column" id="sidebar-wrapper">
-    <div class="sidenav-menu flex-grow-1">
-      <div class="nav flex-column flex-nowrap">
-        <div class="sidenav-menu-heading text-secondary">
-          Menu
-        </div>
-        <a class="nav-link" style="color:grey;">
-          <div class="nav-link-icon mx-1 "><i class="fa fa-tachometer text-primary"></i></div>
-          Dashboard
-        </a>
-        <hr class="w-75 self-align-center text-dark">
-        <div class="sidenav-menu-heading text-secondary font-weight-bold">
-          Spam Moderation
-        </div>
-        <a class="nav-link text-secondary <% unless  params[:action] =="_spam_comments" || params[:action] =="_spam_revisions" || params[:type] == "wiki"%> active <% end %>" href="/spam2">
-          <div class="nav-link-icon mx-1 <% unless params[:action] =="_spam_comments" ||  params[:action] =="_spam_revisions" || params[:type] == "wiki" %> active <% end %>"><i class="fa fa-address-book text-primary"></i></div>
-          Bulk Moderation
-        </a>
-        <a class="nav-link text-secondary <% if params[:type] == "wiki" %> active <% end %>" href="/spam2/wiki" >
-          <div class="nav-link-icon mx-1  <% if params[:type] == "wiki" %> active <% end %>"><i class="fa fa-book text-primary"></i></div>
-          Wiki
-        </a> 
-        <a class="nav-link text-secondary<% if params[:action] == "_spam_revisions" %> active <% end %>" href="/spam2/revisions">
-          <div class="nav-link-icon mx-1  <% if params[:action] == "_spam_revisions" %> active <% end %>"><i class="fa fa-list text-primary"></i></div>
-          Revisions 
-        </a>         
-        <a class="nav-link text-secondary <% if params[:action] == "_spam_comments" %> active <% end %>" href="/spam2/comments" >
-          <div class="nav-link-icon mx-1  <% if params[:action] == "_spam_comments" %> active <% end %>"><i class="fa fa-comment text-primary"></i></div>
-          Comments
-        </a>        
-        <a class="nav-link text-secondary" href="/people" >
-          <div class="nav-link-icon mx-1 "><i class="fa fa-user text-primary"></i></div>
-          Active Users 
-        </a>  
-      </div>
-    </div>   
-  </nav>
-  
-  <div id="page-content-wrapper">
-    <div class="card text-center" id="card-top">
-      <div class="card-header bg-light"></div>
-      <div class="card-body">
-        <h5 class="card-title">Moderate Potential Spam</h5>
-        <p class="card-text">Moderators and admins have the ability to "spam" posts if they include inappropriate content, blatant advertising, or are otherwise problematic. If you're not sure, email at <a href="mailto:organizers@<%= request.host %>" class="badge badge-info text-white">moderators@<%= request.host %></a> If we all work together, we can keep spam to a minimum. Thanks for helping out!</p>
-      </div>
-    </div>
-    <%= render partial: 'spam2/nodes' if @nodes %>
-    <%= render partial: 'spam2/revisions' if @revisions %>
-    <%= render partial: 'spam2/comments' if @comments %>
-  </div>
-</div>
+<%= render partial: 'spam2/nodes' if @nodes %>
+<%= render partial: 'spam2/revisions' if @revisions %>
+<%= render partial: 'spam2/comments' if @comments %>

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -10,7 +10,7 @@ $(document).ready(function () {
   });
 });
 </script>
-<nav class="navbar navbar-expand navbar-light nav_top bg-light" style="margin-top:<% if cache('feature_anniversary-banner', skip_digest: true) %>48px;<% else %>0px;<% end %>">
+<nav class="navbar navbar-expand navbar-light nav_top bg-light">
   <div class="navbar-expand navbar-nav-scroll">
     <ul class=" navbar-nav"> 
       <li class="nav-item">

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -10,7 +10,7 @@ $(document).ready(function () {
   });
 });
 </script>
-<nav class="navbar navbar-expand navbar-light nav_top bg-light">
+<nav class="navbar navbar-expand navbar-light nav_top bg-light" style="margin-top:<% if cache('feature_anniversary-banner', skip_digest: true) %>48px;<% else %>0px;<% end %>">
   <div class="navbar-expand navbar-nav-scroll">
     <ul class=" navbar-nav"> 
       <li class="nav-item">

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -109,3 +109,5 @@ $(document).ready(function () {
     <%= render partial: 'spam2/comments' if @comments %>
   </div>
 </div>
+<%= stylesheet_link_tag "spam2" %>
+<%= javascript_include_tag "spam2"%>

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -10,6 +10,16 @@ $(document).ready(function () {
   });
 });
 </script>
+<% cache('feature_anniversary-banner', skip_digest: true) do %>
+  <style>
+  .nav_top{
+   margin-top:48px;
+  }
+  .sidenav{
+    margin-top:48px;
+  }
+  </style>
+<% end %>
 <nav class="navbar navbar-expand navbar-light nav_top bg-light">
   <div class="navbar-expand navbar-nav-scroll">
     <ul class=" navbar-nav"> 
@@ -109,5 +119,3 @@ $(document).ready(function () {
     <%= render partial: 'spam2/comments' if @comments %>
   </div>
 </div>
-<%= stylesheet_link_tag "spam2" %>
-<%= javascript_include_tag "spam2"%>

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -59,8 +59,21 @@
         <li class="nav-item pr-4">
           <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
         </li>
+        <li class="nav-item pr-4 pt-1">
+          <input class="form-control h-75 w-100" id="col-search" type="search" placeholder="Search" aria-label="Search">
+        </li>
+        <li class="nav-item pr-4 pt-1">
+          <select name="Visible" id="col-select" class="custom-select custom-select-sm form-control form-control-sm">
+            <option value="">Coloumn Search</option>
+            <option value="1">Title</option>
+            <option value="2">Author</option>
+            <option value="3">Status</option>
+            <option value="4">Time</option>
+            <option value="5">Action</option>
+          </select> 
+        </li>
       <% end %>
-    </ul>    
+    </ul>
   </div>
 </nav>
 

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -1,18 +1,18 @@
 <div class="nav_top flex d-inline">
-  <h4 class="text-info pt-2 float-left nav_title">
-    <a href="/spam2" class="text-info">Spam2 / </a>
+  <p class="text-primary pt-2 float-left nav_title h4">
+    <a href="/spam2" class="text-primary">Spam2 / </a><b>
     <% if params[:type] == "wiki" %>
       <b>Wiki</b>                                                                                                                                                                                                                                                                                                                                                                                                        
     <% elsif params[:action] == "_spam_revisions"%>
-      <b>Revisions</b>
+      Revisions
     <% elsif params[:action] == "_spam_comments"%>
-      <b>Comments</b>
+      Comments
     <% else %>
-      <b> Bulk Moderation </b>
-    <% end %>
-  </h4>
+      Bulk Moderation 
+    <% end %> </b>
+  </p>
   <div class="dropdown float-right">
-    <a class="btn btn-light dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <a class="btn btn-outline-primary dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       Menu
     </a>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
@@ -42,25 +42,25 @@
     <ul class=" navbar-nav ">
       <% if params[:action] != "_spam_revisions" && params[:action] != "_spam_comments" %>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light text-dark d-inline-flex " id="batch-spam"><i class=" pt-1 pr-2 fa fa-ban text-danger"></i>  Spam</a>
+          <a class="nav-link btn btn-light border text-dark d-inline-flex " id="batch-spam"><i class=" pt-1 pr-2 fa fa-ban text-danger"></i>  Spam</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-publish"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i>  Publish</a>
+          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-publish"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i>  Publish</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light text-dark d-inline-flex" id="delete-batch"><i class=" pt-1 pr-2 fa fa-trash text-danger"></i> Delete</a>
+          <a class="nav-link btn btn-light border text-dark d-inline-flex" id="delete-batch"><i class=" pt-1 pr-2 fa fa-trash text-danger"></i> Delete</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="all"><i class=" pt-1 pr-2  fa fa-check text-primary"></i> Select</a>
+          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="all"><i class=" pt-1 pr-2  fa fa-check text-primary"></i> Select</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-ban"><i class=" pt-1 pr-2 fa fa-flag text-warning"></i> Ban</a>
+          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-ban"><i class=" pt-1 pr-2 fa fa-flag text-warning"></i> Ban</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
+          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
         </li>
         <li class="nav-item pr-4 pt-1">
-          <input class="form-control h-75 w-100" id="col-search" type="search" placeholder="Search" aria-label="Search">
+          <input class="form-control form-control-sm" id="col-search" type="search" placeholder="Search" aria-label="Search">
         </li>
         <li class="nav-item pr-4 pt-1">
           <select name="Visible" id="col-select" class="custom-select custom-select-sm form-control form-control-sm">

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -1,13 +1,14 @@
 <div class="nav_top flex d-inline">
-  <h4 class="text-primary pt-2 float-left nav_title">
+  <h4 class="text-info pt-2 float-left nav_title">
+    <a href="/spam2" class="text-info">Spam2 / </a>
     <% if params[:type] == "wiki" %>
-      Spam2 / <b>Wiki</b>                                                                                                                                                                                                                                                                                                                                                                                                        
+      <b>Wiki</b>                                                                                                                                                                                                                                                                                                                                                                                                        
     <% elsif params[:action] == "_spam_revisions"%>
-      Spam2 / <b>Revisions</b>
+      <b>Revisions</b>
     <% elsif params[:action] == "_spam_comments"%>
-      Spam2 / <b>Comments</b>
+      <b>Comments</b>
     <% else %>
-      Spam2 /<b> Bulk Moderation </b>
+      <b> Bulk Moderation </b>
     <% end %>
   </h4>
   <div class="dropdown float-right">
@@ -19,10 +20,10 @@
         <a class="dropdown-item" ><i class="fa fa-list-alt text-primary"></i> Dashboard</a>
       <div class="dropdown-divider"></div>  
         <h6 class="dropdown-header">Spam Moderation</h6>
-        <a class="dropdown-item <% unless  params[:action] =="_spam_comments" || params[:action] =="_spam_revisions" || params[:type] == "wiki"%> active <% end %>" href="/spam2"><i class="fa fa-address-book text-primary"></i> Bulk Moderation</a>
-        <a class="dropdown-item <% if params[:type] == "wiki" %> active <% end %>" href="/spam2/wiki" ><i class="fa fa-book text-primary"></i> Wiki</a>
-        <a class="dropdown-item <% if params[:action] == "_spam_revisions" %> active <% end %>" href="/spam2/revisions"><i class="fa fa-list text-primary"></i> Revision</a>
-        <a class="dropdown-item <% if params[:action] == "_spam_comments" %> active <% end %>" href="/spam2/comments" ><i class="fa fa-comment text-primary"></i> Comments</a>
+        <a class="dropdown-item <% unless  params[:action] =="_spam_comments" || params[:action] =="_spam_revisions" || params[:type] == "wiki"%> active <% end %>" href="/spam2"><i class="drop fa fa-address-book text-primary"></i> Bulk Moderation</a>
+        <a class="dropdown-item <% if params[:type] == "wiki" %> active <% end %>" href="/spam2/wiki" ><i class="drop fa fa-book text-primary"></i> Wiki</a>
+        <a class="dropdown-item <% if params[:action] == "_spam_revisions" %> active <% end %>" href="/spam2/revisions"><i class="drop fa fa-list text-primary"></i> Revision</a>
+        <a class="dropdown-item <% if params[:action] == "_spam_comments" %> active <% end %>" href="/spam2/comments" ><i class="drop fa fa-comment text-primary"></i> Comments</a>
         <a class="dropdown-item" href="/people"><i class="fa fa-user text-primary"></i> Active users</a>
       </div>
     </div>

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -1,8 +1,8 @@
 <div class="nav_top flex d-inline">
-  <p class="text-primary pt-2 float-left nav_title h4">
-    <a href="/spam2" class="text-primary">Spam2 / </a><b>
+  <p class="text-secondary pt-2 float-left nav_title h4">
+    <a href="/spam2" class="text-dark"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i> Spam2 / </a><b>
     <% if params[:type] == "wiki" %>
-      <b>Wiki</b>                                                                                                                                                                                                                                                                                                                                                                                                        
+       Wiki                                                                                                                                                                                                                                                                                                                                                                                                    
     <% elsif params[:action] == "_spam_revisions"%>
       Revisions
     <% elsif params[:action] == "_spam_comments"%>
@@ -12,7 +12,7 @@
     <% end %> </b>
   </p>
   <div class="dropdown float-right">
-    <a class="btn btn-light border text-dark dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <a class="btn btn-light border dropdown-toggle" type="button" id="dropdownMenuLink" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       Menu
     </a>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
@@ -30,10 +30,9 @@
 </div>
 
 <div class="card text-center" id="card-top">
-  <div class="card-header bg-light"></div>
+  <p class="card-header text-dark border-bottom-0 h5"><b>Moderate Potential <i class=" pt-1 fa fa-ban text-secondary "></i> Spam </b></p>
   <div class="card-body">
-    <h5 class="card-title text-dark">Moderate Potential Spam</h5>
-    <p class="card-text">Moderators and admins have the ability to "spam" posts if they include inappropriate content, blatant advertising, or are otherwise problematic. If you're not sure, email at <a href="mailto:organizers@<%= request.host %>" class="badge badge-info text-white">moderators@<%= request.host %></a> If we all work together, we can keep spam to a minimum. Thanks for helping out!</p>
+    <p class="card-text text-secondary font-italic">Moderators and admins have the ability to "spam" posts if they include inappropriate content, blatant advertising, or are otherwise problematic. If you're not sure, email at <a href="mailto:organizers@<%= request.host %>" class="badge badge-info text-white">moderators@<%= request.host %></a> If we all work together, we can keep spam to a minimum. Thanks for helping out!</p>
   </div>
 </div>
 
@@ -42,35 +41,38 @@
     <ul class=" navbar-nav ">
       <% if params[:action] != "_spam_revisions" && params[:action] != "_spam_comments" %>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light border text-dark d-inline-flex " id="batch-spam"><i class=" pt-1 pr-2 fa fa-ban text-danger"></i>  Spam</a>
+          <a class="nav-link btn btn-light border disabled text-dark d-inline-flex " id="batch-spam"><i class=" pt-1 pr-2 fa fa-ban text-danger"></i>  Spam</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-publish"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i>  Publish</a>
+          <a class="nav-link btn btn-light border disabled text-dark d-inline-flex"  id="batch-publish"><i class=" pt-1 pr-2 fa fa-check-circle text-success"></i>  Publish</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light border text-dark d-inline-flex" id="delete-batch"><i class=" pt-1 pr-2 fa fa-trash text-danger"></i> Delete</a>
+          <a class="nav-link btn btn-light border disabled text-dark d-inline-flex" id="delete-batch"><i class=" pt-1 pr-2 fa fa-trash text-danger"></i> Delete</a>
         </li>
         <li class="nav-item pr-4">
           <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="all"><i class=" pt-1 pr-2  fa fa-check text-primary"></i> Select</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-ban"><i class=" pt-1 pr-2 fa fa-flag text-warning"></i> Ban</a>
+          <a class="nav-link btn btn-light border disabled text-dark d-inline-flex"  id="batch-ban"><i class=" pt-1 pr-2 fa fa-flag text-warning"></i> Ban</a>
         </li>
         <li class="nav-item pr-4">
-          <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
+          <a class="nav-link btn btn-light border disabled text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
         </li>
         <li class="nav-item pr-4">
-          <input class="btn border" id="col-search" type="search" placeholder="Search" aria-label="Search">
-        </li>
-        <li class="nav-item pr-4">
-          <select  id="col-select" class="custom-select custom-select-sm form-control form-control-md">
-            <option value="">Select column </option>
-            <option value="1">Title</option>
-            <option value="2">Author</option>
-            <option value="3">Status</option>
-            <option value="4">Time</option>
-            <option value="5">Action</option>
+        <div class="btn-group" role="group">
+          <input class="btn border" id="col-search" type="search" placeholder="Filter by column" aria-label="Search">
+          <select  id="col-select" class=" btn bg-light text-dark custom-select custom-select-sm form-control form-control-md" data-toggle="tooltip" data-placement="top" title="Select column here and then search to filter">
+            <option value="">Select filter </option>
+            <option value="1">Filter by Title</option>
+            <option value="2">Filter by Author</option>
+            <option value="3">Filter by Status</option>
+            <option value="4">Filter by Time</option>
+            <option value="5">Filter by Action</option>
           </select> 
+          </div>
+        </li>
+        <li class="nav-item pr-4">
+          <a class="nav-link btn btn-light border d-inline-flex" data-toggle="tooltip" data-placement="top" title="Wiki page for info will be added later"><i class=" pt-1 pr-2 fa fa-info-circle text-info"></i> Info</a>
         </li>
       <% end %>
     </ul>

--- a/app/views/spam2/_spam.html.erb
+++ b/app/views/spam2/_spam.html.erb
@@ -59,12 +59,12 @@
         <li class="nav-item pr-4">
           <a class="nav-link btn btn-light border text-dark d-inline-flex"  id="batch-unban"><i class=" pt-1 pr-2 fa fa-flag text-success"></i> Unban</a>
         </li>
-        <li class="nav-item pr-4 pt-1">
-          <input class="form-control form-control-sm" id="col-search" type="search" placeholder="Search" aria-label="Search">
+        <li class="nav-item pr-4">
+          <input class="btn border" id="col-search" type="search" placeholder="Search" aria-label="Search">
         </li>
-        <li class="nav-item pr-4 pt-1">
-          <select name="Visible" id="col-select" class="custom-select custom-select-sm form-control form-control-sm">
-            <option value="">Coloumn Search</option>
+        <li class="nav-item pr-4">
+          <select  id="col-select" class="custom-select custom-select-sm form-control form-control-md">
+            <option value="">Select column </option>
             <option value="1">Title</option>
             <option value="2">Author</option>
             <option value="3">Status</option>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -54,4 +54,5 @@ Rails.application.config.assets.precompile += [
   'async_tag_subscriptions.js',
   'cable.js',
   'spam2.css',
+  'spam2.js',
 ]

--- a/test/system/spam2_test.rb
+++ b/test/system/spam2_test.rb
@@ -23,32 +23,27 @@ class SpamTest < ApplicationSystemTestCase
     publish_page = nodes(:first_timer_note)
     visit "/spam2"
     find("a[href='/moderate/publish/#{publish_page.id}'").click()    
-    page.assert_selector("div.alert", text: "Content published.")
+    page.assert_selector("div.alert", text: "Content published")
   end
 
   test "spam post in spam2" do
     spam_page = nodes(:first_timer_note)
     visit "/spam2"
     find("a[href='/moderate/spam/#{spam_page.id}'").click()    
-    page.assert_selector("div.alert", text: "Content spammed.")
+    page.assert_selector("div.alert", text: "Content spammed")
   end
 
-  test "ban and unban authors in spam2" do
+  test "banning of a user in spam2" do
     ban_page = nodes(:first_timer_note)
-    visit "/spam2"    
+    visit "/spam2"
     within "#n#{ban_page.id}" do
       find("a[href='/ban/#{ban_page.author.id}'").click()
     end
+    visit "/"
     visit "/profile/#{ban_page.author.username}"
+    assert find("div.alert", text: "That user has been banned.")
     find("a#info-ellipsis").click()
     page.assert_selector "a[href='/unban/#{ban_page.author.id}'"
-    visit "/spam2"
-    within "#n#{ban_page.id}" do
-      find("a[href='/unban/#{ban_page.author.id}'").click()
-    end
-    visit "/profile/#{ban_page.author.username}"
-    find("a#info-ellipsis").click()
-    page.assert_selector "a[href='/ban/#{ban_page.author.id}'"
   end
 
   test "batch spam nodes" do

--- a/test/system/spam2_test.rb
+++ b/test/system/spam2_test.rb
@@ -18,7 +18,7 @@ class SpamTest < ApplicationSystemTestCase
       accept_confirm 'Are you sure you want to delete "'+spam_page.path+'"?' do
       find("a[href='/notes/delete/#{spam_page.id}'").click()
       end
-      assert_selector('div.alert', text: 'Node Deleted')
+      assert_selector('div.alert.p', text: 'Node Deleted')
       end
 end
 	

--- a/test/system/spam2_test.rb
+++ b/test/system/spam2_test.rb
@@ -1,24 +1,24 @@
 require "application_system_test_case"
 
 class SpamTest < ApplicationSystemTestCase
-    def setup
-        visit "/spam2"
-        click_on "Login"
-        fill_in 'user_session[username]', with: 'palpatine'
-        fill_in 'user_session[password]', with: 'secretive'
-        click_on "Log in"
-      end
-    
-    test "Delete post in spam2" do
-      spam_page = nodes(:one)
-      visit spam_page.path
-      first("span[data-original-title='Tools']").click()
-      click_on "Spam"
-      visit "/spam2"
-      accept_confirm 'Are you sure you want to delete "'+spam_page.path+'"?' do
-      find("a[href='/notes/delete/#{spam_page.id}'").click()
-      end
-      assert_selector('div.alert.p', text: 'Node Deleted')
-      end
+
+  def setup
+    visit "/"
+    click_on "Login"
+    fill_in 'user_session[username]', with: 'palpatine'
+    fill_in 'user_session[password]', with: 'secretive'
+    click_on "Log in"
+  end
+
+  test "Delete post in spam2" do
+    spam_page = nodes(:one)
+    visit spam_page.path
+    first("span[data-original-title='Tools']").click()
+    click_on "Spam"
+    visit "/spam2"
+    accept_confirm 'Are you sure you want to delete "'+spam_page.path+'"?' do
+    find("a[href='/notes/delete/#{spam_page.id}'").click()
+    end
+    assert_selector('div.alert', text: 'Node Deleted')
+  end
 end
-	

--- a/test/system/spam2_test.rb
+++ b/test/system/spam2_test.rb
@@ -16,7 +16,7 @@ class SpamTest < ApplicationSystemTestCase
     first("span[data-original-title='Tools']").click()
     click_on "Spam"
     visit "/spam2"
-    accept_confirm 'Are you sure you want to delete "'+spam_page.path+'"?' do
+    accept_confirm "Are you sure you want to delete #{spam_page.path}?" do
     find("a[href='/notes/delete/#{spam_page.id}'").click()
     end
     assert_selector('div.alert', text: 'Node Deleted')


### PR DESCRIPTION
There were few bugs in the UI of the spam management dashboard. 
- Wrong ids in /comments and /revisions 
- created modal for comment and revisions 
- default order nodes wrt time 
- **UI is updated** as there were few issues related to banner in stable. Apart from that this new UI requires very less external css and it is based on bootstrap mostly. it has everything which was in old UI. This is fully responsive and better than the previous UI. I have attached some screenshots and gifs.
![Screenshot from 2020-06-20 18-14-00](https://user-images.githubusercontent.com/36025262/85202196-4bc9d580-b322-11ea-928f-ce5d10ebef8c.png)
![Screenshot from 2020-06-20 18-10-04](https://user-images.githubusercontent.com/36025262/85202197-4ec4c600-b322-11ea-9f27-1080c2e1fdbc.png)
![Screenshot from 2020-06-20 18-09-47](https://user-images.githubusercontent.com/36025262/85202199-51272000-b322-11ea-9a7d-ea99927cc95e.png)

There are a few issues that I am facing currently: 
1. /spam2 and /spam2/revision are giving error in stable while wiki and comment are fine, I think it might be due to invalid ID or something. I have changed it but not sure if it is the only issue. 
I have added (&.) instead of (.) it will discard all values where node.author is nill. Please review this.
` <a href="/profile/<%= node.author&.name %>"><%= node.author&.name %> <%= node.author&.new_contributor%></a> `
Please review @jywarren @SidharthBansal @cesswairimu @pydevsg @ananyaarun @VladimirMikulic @Uzay-G @emilyashley 
Thanks!!