### PR TITLE
fix icons error by preloading FA 5 first

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
     <script type="text/javascript" async
       src="https://cdn.jsdelivr.net/npm/mathjax@2.7.3/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
-
+    <link rel="stylesheet preload prefetch" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0-2/css/all.min.css" as="style" type="text/css" />
     <%= stylesheet_link_tag "application", :media => "all" %>
     <% if @node && @node.has_tag('style:fancy') %>
       <%= stylesheet_link_tag "fancy", :media => "all" %>

--- a/app/views/map/_mapDependencies.html.erb
+++ b/app/views/map/_mapDependencies.html.erb
@@ -9,7 +9,6 @@
 <%= javascript_include_tag('/lib/leaflet-environmental-layers/dist/LeafletEnvironmentalLayers.js') %>
 <%= javascript_include_tag('/lib/leaflet-environmental-layers/src/windRoseLayer.js') %>
 <%= javascript_include_tag('/lib/leaflet-fullhash/leaflet-fullHash.js') %>
-<%= stylesheet_link_tag('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0-2/css/all.min.css') %>
 <%= javascript_include_tag('https://unpkg.com/esri-leaflet@2.2.3/dist/esri-leaflet.js') %>
 <%= javascript_include_tag('https://unpkg.com/esri-leaflet-renderers@2.0.6') %>
 


### PR DESCRIPTION
Fixes #8023 

Fixed icons error by preloading FA 5 first thus preventing it to overwrite css properties of FA 4.7 icons and only being used to cater to classes fas far fab etc.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
