### PR TITLE
tag page tab overhaul, removing sidebar, styling/spacing tweaks

### DIFF
--- a/app/views/notes/_card.html.erb
+++ b/app/views/notes/_card.html.erb
@@ -40,7 +40,7 @@
           <%= node.comments.size %> &nbsp; | &nbsp; <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope:'datetime.time_ago_in_words' }).gsub('about ','') %>
         </span>
       <% end %>
-      <a class="ellipsis bottom-right" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-h" style="color : #666; font-size:15px; float:right;"></i></a>
+      <a class="ellipsis bottom-right" data-toggle="dropdown"><i class="fa fa-ellipsis-h" style="color : #666; font-size:15px; float:right;"></i></a>
 
       <ul class="dropdown-menu" style = "width: 150px; font-size:10px;">
         <% if node.type == 'note' %>

--- a/app/views/tag/_contributors.html.erb
+++ b/app/views/tag/_contributors.html.erb
@@ -28,7 +28,7 @@
   <% end %>
 
 <% end %>
-
+<br />
 <% if @wildcard %>
   <p><%= raw translation('tag.contributors.wild_card_search_detected', :tag => params[:id]) %></p>
 <% elsif @note_count.nil? || @note_count == 0 %>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -50,17 +50,7 @@
       <div class="col-md-12">
 
         <%= render partial: 'tag/show/contributors' %>
-
         <%= render partial: 'tag/show/sort' %>
-
-        <div class="row" style="padding-bottom:1rem;align-items:baseline;">
-          <p class="contributor-info"><%= @total_posts %> posts by
-            <a href="/contributors/<%= params[:id] %>"><%= Tag.contributor_count(params[:id]) %> contributors</a> |
-            <a href="/contributors/<%= params[:id] %>"><%= Tag.follower_count(params[:id]) %> followers</a>
-            <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
-          </p>
-        </div>
-
         <%= render partial: 'tag/show/nav_tabs' %>
         <%= render partial: 'tag/show/tab_content' %>
         <div>

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -1,6 +1,6 @@
 <script src="/assets/wikis.js" type="text/javascript"></script>
 
-<div class="container tag-header" style="height:400px;">
+<div class="container tag-header">
   <%= render partial: 'tag/show/header' %>
   <div class= "card tag-card">
     <div class="card-body">
@@ -78,6 +78,9 @@
 <%= stylesheet_link_tag "dashboard" %>
 
 <style>
+  .node-types .nav-link {
+    color: #495057;
+  }
   .tag-card {
     position: absolute;
     top: 100px;
@@ -98,8 +101,9 @@
      top: 90px;
      width: 90%;
    }
-   .tag-header {
-   }
+  }
+  .tag-header {
+    height: 355px;
   }
   .wiki-sub{
     overflow: hidden;

--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -48,36 +48,27 @@
   <div class="box">
     <div class="row">
       <div class="col-md-12">
-        <div class="row">
-          <div class="col-lg-9">
 
-            <%= render partial: 'tag/show/contributors' %>
+        <%= render partial: 'tag/show/contributors' %>
 
-            <div class="row" style="padding-bottom:1rem;align-items:baseline;">
-              <div class="col-lg-6">
-                <p class="contributor-info"><%= @total_posts %> posts by
-                  <a href="/contributors/<%= params[:id] %>"><%= Tag.contributor_count(params[:id]) %> contributors</a> |
-                  <a href="/contributors/<%= params[:id] %>"><%= Tag.follower_count(params[:id]) %> followers</a>
-                  <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
-                </p>
-              </div>
-              <div class="col-lg-6 d-flex justify-content-lg-end">
-                <%= render partial: 'tag/show/nav_tabs' %>
-              </div>
-            </div>
+        <%= render partial: 'tag/show/sort' %>
 
-            <%= render partial: 'tag/show/tab_content' %>
-            <div>
-              <script type="text/javascript">
-                $('#questions .btn-group .btn').click(function(){
-                  $(this).addClass('active').siblings().removeClass('active');
-                });
-              </script>
-            </div>
-          </div>
-          <div class="col-md-3">
-            <%= render partial: "tag/show/related_tags" %>
-          </div>
+        <div class="row" style="padding-bottom:1rem;align-items:baseline;">
+          <p class="contributor-info"><%= @total_posts %> posts by
+            <a href="/contributors/<%= params[:id] %>"><%= Tag.contributor_count(params[:id]) %> contributors</a> |
+            <a href="/contributors/<%= params[:id] %>"><%= Tag.follower_count(params[:id]) %> followers</a>
+            <a href="https://publiclab.org/wiki/contributors"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
+          </p>
+        </div>
+
+        <%= render partial: 'tag/show/nav_tabs' %>
+        <%= render partial: 'tag/show/tab_content' %>
+        <div>
+          <script type="text/javascript">
+            $('#questions .btn-group .btn').click(function(){
+              $(this).addClass('active').siblings().removeClass('active');
+            });
+          </script>
         </div>
       </div>
     </div>

--- a/app/views/tag/show/_header.html.erb
+++ b/app/views/tag/show/_header.html.erb
@@ -13,44 +13,12 @@
                       class: "img-fluid d-sm-none",
                       id: "tag-wiki-header-image2") %>
         </div>
-        <div class="bottom-right">
-          <a href="/contributors/<%= params[:id] %>">
-            <%= Tag.follower_count(params[:id]) %> following
-          </a>
-        </div>
       </div>
-
-    <% else %>
-
-    <div class="im d-none d-md-block" id="wiki-empty1">
-      <div class="bottom-right">
-        <a href="/contributors/<%= params[:id] %>">
-          <%= Tag.follower_count(params[:id]) %> following 
-        </a>
-      </div>
-    </div>
-    <div class="im d-sm-none" id="wiki-empty2">
-      <div class="bottom-right"><%= Tag.follower_count(params[:id]) %> following</div>
-    </div>
 
     <% end %>
 
   </div>
 
-<% elsif @wildcard %>
-
-<% else %>
-
-<div class="im d-none d-md-block" id="wiki-empty1">
-  <div class="bottom-right">
-    <a href="/contributors/<%= params[:id] %>"><%= pluralize(Tag.follower_count(params[:id]), 'person') %> following</a>
-  </div>
-</div>
-<div class="im d-sm-none" id="wiki-empty2">
-  <div class="bottom-right">
-    <a href="/contributors/<%= params[:id] %>"><%= pluralize(Tag.follower_count(params[:id]), 'person') %> following</a>
-  </div>
-</div>
 <% end %>
 
 <style>

--- a/app/views/tag/show/_header.html.erb
+++ b/app/views/tag/show/_header.html.erb
@@ -132,22 +132,20 @@
   margin-top: -20px;
 }
 
-.bottom-right {
+.card .bottom-right {
   position: absolute;
   bottom: 10px;
   right: 40px;
   color: #fff;
   overflow-x: hidden;
-  text-shadow: 0.5px 0.5px #333;
-  /* text-decoration: underline; */
 }
-.bottom-right a {
+.card .bottom-right a {
   color: #fff;
 }
 
 @media (min-width: 576px) {
-  .d-md-block {
-      display: block !important;
+  .card .d-md-block {
+    display: block !important;
   }
 }
 </style>

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -1,33 +1,19 @@
-
-<div class="dropdown" style="margin-top:10px; float:right; margin-right: 5px;">
-
-  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">by type</button>
-
-  <!-- when will it not be show...? -->
+<div class="node-types">
   <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
+
     <% if params[:action] == "show" %>
-      <!-- #Enhancement #6306 - Add counts to `by type` dropdown on tag pages  -->
-        <% unless params[:id].match("question:") %><a class="dropdown-item <% if @node_type == "note" %> active<% end %>" href="/tag/<%= params[:id] %>"><i class="fa fa-file"></i> <span class="d-lg-inline"><%= raw t('tag.show.research_notes') %> <span class="badge badge-primary"><%= params[:counts][:posts] %></span></span></a><% end %>
-      <!-- can we create a generic node type hash, and give it href and class and content classes? -->
-      <!-- this should be an if/else, because @node_type should only be one value -->
+      <% unless params[:id].match("question:") %><a class="dropdown-item <% if @node_type == "note" %> active<% end %>" href="/tag/<%= params[:id] %>"><i class="fa fa-file"></i> <span class="d-lg-inline"><%= raw t('tag.show.research_notes') %> <span class="badge badge-primary"><%= params[:counts][:posts] %></span></span></a><% end %>
       <a class="dropdown-item <% if @node_type == "questions" %> active<% end %>" href="/questions/tag/<%= params[:id] %>"><i class="fa fa-question-circle"></i> <span class="d-lg-inline"><%= t('tag.show.questions') %> <span class="badge badge-primary"><%= params[:counts][:questions] %></span></span></a>
       <a class="dropdown-item <% if @node_type=="wiki" %> active <% end %>" href="/wiki/tag/<%= params[:id] %>"><i class="fa fa-book"></i> <span class="d-lg-inline"><%= raw t('tag.show.wiki_pages') %> <span class="badge badge-primary"><%= params[:counts][:wiki] %></span></span></a>
-      <!-- END #Enhancement #6306 - Add counts to `by type` dropdown on tag pages  -->
-
       <a class="dropdown-item <% if @node_type == "maps" %> active <% end %>" href="/maps/tag/<%= params[:id] %>"><i class="fa fa-map-marker"></i> <span class="d-lg-inline"><%= t('tag.show.maps') %></span></a>
-
-      <!-- show if we can see the list of contributors
-      again, can we have a generic list of contributors that is
-
-      calculated in the controller? -->
       <% if !@wildcard %>
-      <a class="dropdown-item <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>"><i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.people') %> </span><span class="badge badge-primary"><%=@length %></span></a>
+        <a class="dropdown-item <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>"><i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.people') %> </span><span class="badge badge-primary"><%=@length %></span></a>
       <% else %>
-    <a class="disabled" class="dropdown-item<% if @node_type == "contributors" %> active <% end %>" href="#" rel="tooltip" title="Contributors cannot be listed for wildcard tag searches" ><i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.contributors') %></span></a>
+        <a class="disabled" class="dropdown-item<% if @node_type == "contributors" %> active <% end %>" href="#" rel="tooltip" title="Contributors cannot be listed for wildcard tag searches" ><i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.contributors') %></span></a>
       <% end %>
 
     <% else %>
-      <!-- calculate whatever this should be in the controller -->
+
       <% unless params[:id].match("question:") %>
         <a class="dropdown-item" <% if @node_type == "note" %> class="active"<% end %> href="/tag/<%= params[:id] %>/author/<%= params[:author] %>"><i class="fa fa-file"></i> <span class="d-lg-inline"><%= raw t('tag.show.research_notes') %></span>
         </a>
@@ -49,7 +35,7 @@
   </div>
 </div>
 
-<div class="dropdown" style="margin-top:10px; float:right; margin-left:5px;">
+<div class="dropdown pull-right">
   <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Sort by</button>
 <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
   <% if params[:action] == "show" %>

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -1,15 +1,59 @@
 <div class="node-types">
-  <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
+  <ul class="nav nav-tabs" aria-labelledby="dropdownMenuButton">
 
     <% if params[:action] == "show" %>
-      <% unless params[:id].match("question:") %><a class="dropdown-item <% if @node_type == "note" %> active<% end %>" href="/tag/<%= params[:id] %>"><i class="fa fa-file"></i> <span class="d-lg-inline"><%= raw t('tag.show.research_notes') %> <span class="badge badge-primary"><%= params[:counts][:posts] %></span></span></a><% end %>
-      <a class="dropdown-item <% if @node_type == "questions" %> active<% end %>" href="/questions/tag/<%= params[:id] %>"><i class="fa fa-question-circle"></i> <span class="d-lg-inline"><%= t('tag.show.questions') %> <span class="badge badge-primary"><%= params[:counts][:questions] %></span></span></a>
-      <a class="dropdown-item <% if @node_type=="wiki" %> active <% end %>" href="/wiki/tag/<%= params[:id] %>"><i class="fa fa-book"></i> <span class="d-lg-inline"><%= raw t('tag.show.wiki_pages') %> <span class="badge badge-primary"><%= params[:counts][:wiki] %></span></span></a>
-      <a class="dropdown-item <% if @node_type == "maps" %> active <% end %>" href="/maps/tag/<%= params[:id] %>"><i class="fa fa-map-marker"></i> <span class="d-lg-inline"><%= t('tag.show.maps') %></span></a>
+      <% unless params[:id].match("question:") %>
+        <li class="nav-item">
+          <a class="nav-link <% if @node_type == "note" %> active<% end %>" href="/tag/<%= params[:id] %>">
+            <i class="fa fa-file"></i> 
+            <span class="d-lg-inline"> 
+              <span class="d-none d-sm-block"><%= t('tag.show.research_notes') %></span>
+              <span class="badge badge-primary"><%= params[:counts][:posts] %></span>
+            </span>
+          </a>
+        </li>
+      <% end %>
+      <li class="nav-item">
+        <a class="nav-link <% if @node_type == "questions" %> active<% end %>" href="/questions/tag/<%= params[:id] %>">
+          <i class="fa fa-question-circle"></i> 
+          <span class="d-lg-inline">
+            <span class="d-none d-sm-block"><%= t('tag.show.questions') %></span>
+            <span class="badge badge-primary"><%= params[:counts][:questions] %></span>
+          </span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link <% if @node_type=="wiki" %> active <% end %>" href="/wiki/tag/<%= params[:id] %>">
+          <i class="fa fa-book"></i> 
+          <span class="d-lg-inline">
+            <span class="d-none d-sm-block"><%= t('tag.show.wiki_pages') %></span>
+            <span class="badge badge-primary"><%= params[:counts][:wiki] %></span>
+          </span>
+        </a>
+      </li>
+      <!--
+      <li class="nav-item">
+        <a class="nav-link <% if @node_type == "maps" %> active <% end %>" href="/maps/tag/<%= params[:id] %>">
+          <i class="fa fa-map-marker"></i> 
+          <span class="d-lg-inline"><%= t('tag.show.maps') %></span>
+        </a>
+      </li>
+      -->
       <% if !@wildcard %>
-        <a class="dropdown-item <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>"><i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.people') %> </span><span class="badge badge-primary"><%=@length %></span></a>
+        <li class="nav-item">
+          <a class="nav-link <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>">
+            <i class="fa fa-user"></i> 
+            <span class="d-lg-inline">
+              <span class="d-none d-sm-block"><%= raw t('tag.show.people') %></span>
+              <span class="badge badge-primary"><%=@length %></span>
+            </span>
+          </a>
+        </li>
       <% else %>
-        <a class="disabled" class="dropdown-item<% if @node_type == "contributors" %> active <% end %>" href="#" rel="tooltip" title="Contributors cannot be listed for wildcard tag searches" ><i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.contributors') %></span></a>
+        <a class="disabled" class="dropdown-item<% if @node_type == "contributors" %> active <% end %>" href="#" rel="tooltip" title="Contributors cannot be listed for wildcard tag searches" >
+          <i class="fa fa-user"></i> 
+          <span class="d-lg-inline d-none d-sm-block"><%= raw t('tag.show.contributors') %></span>
+        </a>
       <% end %>
 
     <% else %>
@@ -25,23 +69,14 @@
       <a class="dropdown-item" <% if @node_type == "wiki" %> class="active"<% end %> href="/wiki/tag/<%= params[:id] %>/author/<%= params[:author] %>" >
         <i class="fa fa-book"></i> <span class="d-lg-inline"><%= raw t('tag.show.wiki_pages') %></span>
       </a>
+      <!--
       <a class="dropdown-item" <% if @node_type == "maps" %> class="active"<% end %> href="/maps/tag/<%= params[:id] %>/author/<%= params[:author] %>" >
         <i class="fa fa-map-marker"></i> <span class="d-lg-inline"><%= t('tag.show.maps') %></span>
       </a>
+      -->
       <a class="dropdown-item"<% if @node_type == "contributors" %> class="active"<% end %> href="#" rel="tooltip" title="Contributors can't be listed for tag searches with Authors" >
         <i class="fa fa-user"></i> <span class="d-lg-inline"><%= raw t('tag.show.contributors') %></span>
       </a>
     <% end %>
-  </div>
-</div>
-
-<div class="dropdown pull-right">
-  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Sort by</button>
-<div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
-  <% if params[:action] == "show" %>
-    <a class="dropdown-item <% if params[:order] == 'last_updated' %> active<% end %>" href="/tag/<%= params[:id] %>"><i class="fa fa-clock-o"></i> <span class="d-lg-inline">by last updated</span></a>
-    <a class="dropdown-item <% if params[:order] == 'views' %> active<% end %>" href="?order=views"><i class="fa fa-eye"></i> <span class="d-lg-inline">by views</span></a>
-    <a class="dropdown-item <% if params[:order] == 'likes' %> active<% end %>" href="?order=likes"><i class="fa fa-star"></i> <span class="d-lg-inline">by likes</span></a>
-<% end %>
-</div>
+  </ul>
 </div>

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -44,7 +44,7 @@
           <a class="nav-link <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>">
             <i class="fa fa-user"></i> 
             <span class="d-lg-inline">
-              <span class="d-none d-md-inline"><%= raw t('tag.show.people') %></span>
+              <span class="d-none d-lg-inline"><%= raw t('tag.show.people') %></span>
               <span class="badge badge-primary"><%=@length %></span>
             </span>
           </a>

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -1,4 +1,4 @@
-<div class="node-types">
+<div class="node-types" style="margin-bottom:8px;">
   <ul class="nav nav-tabs" aria-labelledby="dropdownMenuButton">
 
     <% if params[:action] == "show" %>

--- a/app/views/tag/show/_nav_tabs.html.erb
+++ b/app/views/tag/show/_nav_tabs.html.erb
@@ -7,7 +7,7 @@
           <a class="nav-link <% if @node_type == "note" %> active<% end %>" href="/tag/<%= params[:id] %>">
             <i class="fa fa-file"></i> 
             <span class="d-lg-inline"> 
-              <span class="d-none d-sm-block"><%= t('tag.show.research_notes') %></span>
+              <span class="d-none d-md-inline"><%= t('tag.show.research_notes') %></span>
               <span class="badge badge-primary"><%= params[:counts][:posts] %></span>
             </span>
           </a>
@@ -17,7 +17,7 @@
         <a class="nav-link <% if @node_type == "questions" %> active<% end %>" href="/questions/tag/<%= params[:id] %>">
           <i class="fa fa-question-circle"></i> 
           <span class="d-lg-inline">
-            <span class="d-none d-sm-block"><%= t('tag.show.questions') %></span>
+            <span class="d-none d-md-inline"><%= t('tag.show.questions') %></span>
             <span class="badge badge-primary"><%= params[:counts][:questions] %></span>
           </span>
         </a>
@@ -26,7 +26,7 @@
         <a class="nav-link <% if @node_type=="wiki" %> active <% end %>" href="/wiki/tag/<%= params[:id] %>">
           <i class="fa fa-book"></i> 
           <span class="d-lg-inline">
-            <span class="d-none d-sm-block"><%= t('tag.show.wiki_pages') %></span>
+            <span class="d-none d-md-inline"><%= t('tag.show.wiki_pages') %></span>
             <span class="badge badge-primary"><%= params[:counts][:wiki] %></span>
           </span>
         </a>
@@ -44,7 +44,7 @@
           <a class="nav-link <% if @node_type == "contributors" %> active <% end %>" href="/contributors/<%= params[:id] %>">
             <i class="fa fa-user"></i> 
             <span class="d-lg-inline">
-              <span class="d-none d-sm-block"><%= raw t('tag.show.people') %></span>
+              <span class="d-none d-md-inline"><%= raw t('tag.show.people') %></span>
               <span class="badge badge-primary"><%=@length %></span>
             </span>
           </a>
@@ -52,7 +52,7 @@
       <% else %>
         <a class="disabled" class="dropdown-item<% if @node_type == "contributors" %> active <% end %>" href="#" rel="tooltip" title="Contributors cannot be listed for wildcard tag searches" >
           <i class="fa fa-user"></i> 
-          <span class="d-lg-inline d-none d-sm-block"><%= raw t('tag.show.contributors') %></span>
+          <span class="d-lg-inline d-none d-md-inline"><%= raw t('tag.show.contributors') %></span>
         </a>
       <% end %>
 

--- a/app/views/tag/show/_sort.html.erb
+++ b/app/views/tag/show/_sort.html.erb
@@ -1,0 +1,10 @@
+<div class="dropdown pull-right">
+  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Sort by</button>
+  <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
+  <% if params[:action] == "show" %>
+    <a class="dropdown-item <% if params[:order] == 'last_updated' %> active<% end %>" href="/tag/<%= params[:id] %>"><i class="fa fa-clock-o"></i> <span class="d-lg-inline">by last updated</span></a>
+    <a class="dropdown-item <% if params[:order] == 'views' %> active<% end %>" href="?order=views"><i class="fa fa-eye"></i> <span class="d-lg-inline">by views</span></a>
+    <a class="dropdown-item <% if params[:order] == 'likes' %> active<% end %>" href="?order=likes"><i class="fa fa-star"></i> <span class="d-lg-inline">by likes</span></a>
+  <% end %>
+  </div>
+</div>

--- a/app/views/tag/show/_sort.html.erb
+++ b/app/views/tag/show/_sort.html.erb
@@ -1,5 +1,5 @@
 <div class="dropdown pull-right">
-  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Sort by</button>
+  <button class="btn btn-outline-secondary dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="margin-left:14px;">Sort by</button>
   <div class="dropdown-menu dropdown-menu-right mt-1" aria-labelledby="dropdownMenuButton">
   <% if params[:action] == "show" %>
     <a class="dropdown-item <% if params[:order] == 'last_updated' %> active<% end %>" href="/tag/<%= params[:id] %>"><i class="fa fa-clock-o"></i> <span class="d-lg-inline">by last updated</span></a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,7 +392,7 @@ en:
       or_subscribe_to_answer: "<a style='margin-bottom:6px;' class='btn btn-primary
         requireLogin' target='_blank' href='%{url1}'>Subscribe to answer questions
         on this topic</a>"
-      research_notes: "Research Notes"
+      research_notes: "Research notes"
       questions: "Questions"
       wiki_pages: "Wiki pages"
       maps: "Maps"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,7 +392,7 @@ en:
       or_subscribe_to_answer: "<a style='margin-bottom:6px;' class='btn btn-primary
         requireLogin' target='_blank' href='%{url1}'>Subscribe to answer questions
         on this topic</a>"
-      research_notes: "Research </span>Notes"
+      research_notes: "Research Notes"
       questions: "Questions"
       wiki_pages: "Wiki pages"
       maps: "Maps"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,7 +162,7 @@ en:
       recent: "Recent"
       popular: "Popular"
       liked: "Liked"
-      wiki_pages: "Wiki<span class=\"hidden-sm\"> pages</span>"
+      wiki_pages: "Wiki pages"
     _notes:
       moderate_first_time_post: "Moderate first-time post:"
       approve: "Approve"
@@ -392,9 +392,9 @@ en:
       or_subscribe_to_answer: "<a style='margin-bottom:6px;' class='btn btn-primary
         requireLogin' target='_blank' href='%{url1}'>Subscribe to answer questions
         on this topic</a>"
-      research_notes: "<span class=\"hidden-sm\">Research </span>Notes"
+      research_notes: "Research </span>Notes"
       questions: "Questions"
-      wiki_pages: "Wiki<span class=\"hidden-sm\"> pages</span>"
+      wiki_pages: "Wiki pages"
       maps: "Maps"
       no_results_found: "No results found; try searching for '<b>%{tag}</b>'"
       try_advanced_search: "Or try an <a href='%{url1}'>advanced search</a>"
@@ -471,7 +471,7 @@ en:
       back_to_wiki: "Back to <a href='%{url1}'>%{title}"
       overview: "Overview"
       research: "Research"
-      wiki_pages: "Wiki<span class=\"hidden-sm\"> pages</span>"
+      wiki_pages: "Wiki pages"
       more_research: "More research on \"%{tag}\""
       more_tag_research: "More \"%{tag}\" research"
     _wikis:

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -433,7 +433,7 @@ class I18nTest < ActionDispatch::IntegrationTest
       follow_redirect!
 
       get '/tag/some-tag'
-      assert_select 'a', I18n.t('tag.show.wiki_pages')
+      assert_select 'a span.d-none', I18n.t('tag.show.wiki_pages')
     end
   end
 

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -433,7 +433,7 @@ class I18nTest < ActionDispatch::IntegrationTest
       follow_redirect!
 
       get '/tag/some-tag'
-      assert_select 'a', I19n.t('tag.show.wiki_pages')
+      assert_select 'a', I18n.t('tag.show.wiki_pages')
     end
   end
 

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -433,7 +433,7 @@ class I18nTest < ActionDispatch::IntegrationTest
       follow_redirect!
 
       get '/tag/some-tag'
-      assert_select 'a', I18n.t('tag.show.maps')
+      assert_select 'a', I19n.t('tag.show.wiki_pages')
     end
   end
 

--- a/test/system/tags_controller_test.rb
+++ b/test/system/tags_controller_test.rb
@@ -13,17 +13,6 @@ class TagTest < ApplicationSystemTestCase
     find(".login-modal-form #login-button").click()
   end
 
-  test 'viewing the dropdown menu' do
-    visit '/tag/test'
-
-    take_screenshot
-
-    click_on "by type"
-
-    take_screenshot
-
-  end
-
   test 'subscribing to a tag' do
     visit '/tag/nature'
 


### PR DESCRIPTION
Hi @Tlazypanda -- i'm making some changes from #6307 here, and it may need some aria fixes if you're able to help out? Thank you!!

More soon, this is just my first commit.

Compact view:

![image](https://user-images.githubusercontent.com/24359/84836397-ac47d280-b003-11ea-8ee2-9bad7e64a1a9.png)

Larger view:

![image](https://user-images.githubusercontent.com/24359/84844005-6268e780-b017-11ea-9629-a4cc6f798f73.png)

And largest layout:

![image](https://user-images.githubusercontent.com/24359/84851406-2722e480-b028-11ea-9aab-4c36c770317d.png)


Do we prefer that the text of the tabs is all black? I guess that makes sense, but it's an easy fix. 

UPDATE:

OK, i made all tab text black (dark grey) and adjusted the spacing below the main image. Tidier:

![image](https://user-images.githubusercontent.com/24359/84851701-04dd9680-b029-11ea-8d38-490c59da7a0a.png)
