### PR TITLE
improve accessibility of new note page

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -66,6 +66,7 @@
 
       <div class="ple-module-content col-lg-9">
         <input
+          aria-label="Enter Note Title"
           class="form-control input-lg"
           type="text"
           id="title-input"
@@ -100,6 +101,7 @@
           </div>
           <p>
             <input
+              aria-label="Upload image"
               type="file"
               accept=".png, .jpg, .jpeg"
               name="image[photo]"
@@ -145,7 +147,7 @@
 
             <div class="col-lg-6">
               <div class="form-group">
-                <label>By place name</label>
+                <label for="placenameInput">By place name</label>
                 <p>
                   <input id="placenameInput" type="text" class="form-control" />
                 </p>
@@ -156,7 +158,7 @@
 
                 <div id="coord_input" class="row">
                   <div class="col-sm-6">
-                    <label>Latitude</label>
+                    <label for="lat">Latitude</label>
                     <p>
                       <input
                         id="lat"
@@ -168,7 +170,7 @@
                   </div>
 
                   <div class="col-sm-6">
-                    <label>Longitude</label>
+                    <label for="lng">Longitude</label>
                     <p>
                       <input
                         id="lng"
@@ -221,7 +223,7 @@
       </div>
 
       <div class="ple-module-content col-lg-9">
-        <textarea id="text-input" class="ple-textarea form-control"><% if @node && @node.latest && @node.latest.body_rich %><%= @node.latest.body %><% else %><%= params[:body] %><% end %></textarea>
+        <textarea aria-label="Enter note description" id="text-input" class="ple-textarea form-control"><% if @node && @node.latest && @node.latest.body_rich %><%= @node.latest.body %><% else %><%= params[:body] %><% end %></textarea>
       </div>
 
     </div>
@@ -237,6 +239,7 @@
 
       <div class="ple-module-content col-lg-9">
         <input
+          aria-label="Enter related tags"
           class="form-control input-lg"
           type="text"
           placeholder="balloon-mapping, water-quality..."
@@ -424,7 +427,7 @@
       new L.LatLng(-90, 180)
     );
     editor.mapModule.blurredLocation.map.setMaxBounds(bounds);
-    
+
     <% if @lat and @lon %>
       <% if @zoom %>
         editor.mapModule.blurredLocation.setZoom(<%= @zoom %>);
@@ -440,7 +443,7 @@
       $('#coord_input').toggle();
     });
     $("#coord_input").hide();
-    
+
     $(function() {
       var target = document.querySelector('#map_content');
       var observer = new MutationObserver(function(mutations) {
@@ -459,7 +462,7 @@
       }
     }
     setLocationButtonText();
-    
+
     $("#obscureLocation").prop('checked', <%= @map_blurred %>);
     editor.mapModule.blurredLocation.setBlurred(<%= @map_blurred %>);
 
@@ -508,4 +511,3 @@
   }
 
 </script>
-


### PR DESCRIPTION
Fixes #8053 
Improved accessibility of new note route by adding form labels for missing form labels.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below  

## Screenshots 
Before  

![ss_new_note_before](https://user-images.githubusercontent.com/33183263/85115063-b1da2e00-b238-11ea-84ea-29d7bcb2dc2e.png)
After  

![ss_new_note](https://user-images.githubusercontent.com/33183263/85115081-b9013c00-b238-11ea-9e3d-da1039d2feeb.png)


Thanks!
