### PR TITLE
Spam2: Digest for Unmoderated posts with settings

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -395,4 +395,9 @@ class AdminController < ApplicationController
 
     s.close
   end
+
+  def test_digest_email_spam
+    DigestSpamJob.perform_async(0)
+    redirect_to "/spam"
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -401,7 +401,9 @@ class UsersController < ApplicationController
 
     digest_settings = [
       'digest:weekly',
-      'digest:daily'
+      'digest:daily',      
+      'digest:weekly:spam',
+      'digest:daily:spam'
     ]
     digest_settings.each do |setting|
       if params[setting] == "on"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -401,7 +401,7 @@ class UsersController < ApplicationController
 
     digest_settings = [
       'digest:weekly',
-      'digest:daily',      
+      'digest:daily',
       'digest:weekly:spam',
       'digest:daily:spam'
     ]

--- a/app/jobs/digest_spam_job.rb
+++ b/app/jobs/digest_spam_job.rb
@@ -1,15 +1,15 @@
 class DigestSpamJob
-    include Sidekiq::Worker
-    def perform(frequency_digest)
-      if frequency_digest.zero?
+  include Sidekiq::Worker
+  def perform(frequency_digest)
+    if frequency_digest.zero?
         tag_digest = 'digest:daily:spam'
-      elsif frequency_digest == 1
+    elsif frequency_digest == 1
         tag_digest = 'digest:weekly:spam'
-      end
-      users = User.where(role: %w(moderator admin))
+    end
+    users = User.where(role: %w(moderator admin))
               .includes(:user_tags)
               .where('user_tags.value=?', tag_digest)
               .references(:user_tags)
-      users.each(&:send_digest_email_spam)
-    end
+    users.each(&:send_digest_email_spam)
+  end
 end

--- a/app/jobs/digest_spam_job.rb
+++ b/app/jobs/digest_spam_job.rb
@@ -2,9 +2,9 @@ class DigestSpamJob
   include Sidekiq::Worker
   def perform(frequency_digest)
     if frequency_digest.zero?
-        tag_digest = 'digest:daily:spam'
+      tag_digest = 'digest:daily:spam'
     elsif frequency_digest == 1
-        tag_digest = 'digest:weekly:spam'
+      tag_digest = 'digest:weekly:spam'
     end
     users = User.where(role: %w(moderator admin))
               .includes(:user_tags)

--- a/app/jobs/digest_spam_job.rb
+++ b/app/jobs/digest_spam_job.rb
@@ -1,0 +1,15 @@
+class DigestSpamJob
+    include Sidekiq::Worker
+    def perform(frequency_digest)
+      if frequency_digest.zero?
+        tag_digest = 'digest:daily:spam'
+      elsif frequency_digest == 1
+        tag_digest = 'digest:weekly:spam'
+      end
+      users = User.where(role: %w(moderator admin))
+              .includes(:user_tags)
+              .where('user_tags.value=?', tag_digest)
+              .references(:user_tags)
+      users.each(&:send_digest_email_spam)
+    end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -120,4 +120,15 @@ class AdminMailer < ActionMailer::Base
       subject: subject
     )
   end
+
+  def send_digest_spam(nodes, frequency_digest)
+    if frequency_digest == User::Frequency::DAILY
+      @subject = 'Your daily digest for moderation'
+    elsif frequency_digest == User::Frequency::WEEKLY
+      @subject = 'Your weekly digest for moderation'
+    end
+    moderators = User.where(role: %w(moderator admin)).collect(&:email)
+    @nodes = nodes
+    mail(to: moderators, subject: @subject)
+  end
 end

--- a/app/views/admin_mailer/send_digest_spam.html.erb
+++ b/app/views/admin_mailer/send_digest_spam.html.erb
@@ -1,0 +1,39 @@
+<header style="margin:0 auto; text-align:center; width:100%;">
+  <img src="https://avatars2.githubusercontent.com/u/4621650?s=200&v=4">
+  <p style="font-size:1.5em; color:black;">[Public Lab] <i style="color:grey;"><%= @subject %></i></p>
+  <p style="font-size:1em; color:grey;"><%= Time.now.strftime("%B %-d %Y") %></p>
+  <p style="font-size:1em; font-family:sans-serif; margin-bottom:0; color:grey;">Unmoderated Notes at <a href="https://publiclab.org" style="color:black; text-decoration:none;">PublicLab.org</a></p>
+  <hr style="height:1px; background-color:black; width:50%;">
+</header>
+
+<ul style="list-style-type:none; height:auto; font-family:sans-serif;width:auto;">
+    <% @nodes.each do |n| %>
+        <li style="position:relative; height:auto; width:90vw;">
+            <div style="padding:3vh 0 0 5vw ;">
+                <a style="text-decoration:none; color:black; font-weight:500; font-size:1.5em; " href="<%= ActionMailer::Base.default_url_options[:host] + n.path %>"><%= n.title %></a>
+            </div> 
+            <table style="padding-left:5vw; font-size:1em;width:70vw">  
+                <tbody> <tr><td style="width:8vh;">
+                    <% if n.author.photo? %>
+                        <img style="width:7vh; height:7vh; border-radius:50%; padding-top:2vh" src="https://<%= ActionMailer::Base.default_url_options[:host] %><%= n.author.photo_path(:thumb) %>"/>
+                    <% else %>
+                        <img style="width:7vh; height:7vh;border-radius:50%;padding-top:2vh;" src="https://www.gravatar.com/avatar/1aedb8d9dc4751e229a335e371db8058"/>
+                    <% end %>
+                </td>
+                <td style= "font-size: 2vh;">
+                    <p style="font-weight:500;"><%= n.author.username.capitalize %> </p>
+                    <span style="color:#999;font-weight:500;">Created at <%= n.created_at.strftime("%B %-d %Y") %></span>
+                </td></tr>
+            </table>
+            <div style="padding-left:5vw;">
+                <p style="color:grey; font-size:1.0em; line-height: 1.6;"><i><%= n.body.truncate(300) %></i></p>
+            </div>
+            <a style="color:blue; text-decoration:none; padding-left:5vw" href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/publish/<%= n.id %>">Approve</a>      <a style="color:blue; text-decoration:none;"href="https://<%= ActionMailer::Base.default_url_options[:host] %>/moderate/spam/<%= n.id %>">Spam</a></div>
+            <hr style="border:none; height:1px; width: 45%; background-color:grey; margin-top:2%;">
+        </li>
+    <% end %>
+</ul>
+<div style="margin:5% 0 0 8vw; font-size:1em;">
+    <p style=" text-decoration:none;">Click <a style="color:blue; text-decoration:none;"href="https://<%= ActionMailer::Base.default_url_options[:host] %>/subscriptions">here</a> to choose your followed topics</p>
+    <p style=" text-decoration:none;">Click <a style="color:blue; text-decoration:none;"  href="https://<%= ActionMailer::Base.default_url_options[:host] %>/settings">here</a> to change your subscription settings</p>
+</div> 

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -209,6 +209,9 @@
         <%= form_tag "/users/test_digest_email", method: :post do %>
           <%= submit_tag "Test Digest Email", class: "btn btn-info", style: "width: 100%;" %>
         <% end %>
+        <%= form_tag "/admin/test_digest_email_spam", method: :post do %>
+          <%= submit_tag "Test Spam Digest Email", class: "btn btn-sm btn-primary mt-2", style: "width: 100%;" %>
+        <% end %>
       <% end %>
 
     <% end %>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -90,6 +90,35 @@
   <br />
   <br />
 
+  <% if current_user.can_moderate? %>
+    <div style="display: inline-flex; justify-content: space-between; width: 90%;">
+      <span>Do you want to receive weekly digest for unmoderated posts?</span>
+      <span>
+        <label style=" vertical-align: middle;" class="switch">
+          <p> Notification switch </p>
+          <input type="checkbox" name="digest:weekly:spam" <% if UserTag.exists?(current_user.id, 'digest:weekly:spam') %>checked<% end %>>
+          <span class="slider round"></span>
+        </label>
+      </span>
+    </div>
+
+    <br />
+    <br />
+
+    <div style="display: inline-flex; justify-content: space-between; width: 90%;">
+      <span>Do you want to receive daily digest for unmoderated posts?</span>
+      <span>
+        <label style=" vertical-align: middle;" class="switch">
+          <p> Notification switch </p>
+          <input type="checkbox" name="digest:daily:spam" <% if UserTag.exists?(current_user.id, 'digest:daily:spam') %>checked<% end %>>
+          <span class="slider round"></span>
+        </label>
+      </span>
+    </div>
+
+    <br />
+    <br />
+  <% end %>
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
     <span>Do you want to receive browser notification when you are mentioned?</span>
     <span>
@@ -266,6 +295,17 @@
         $(':input[name="digest:weekly"]').change(function () {
             if($(':input[name="digest:weekly"]').prop('checked') === true){
                 $(':input[name="digest:daily"]').prop('checked', false);
+            }
+        });
+        $(':input[name="digest:daily:spam"]').change(function () {
+            if($(':input[name="digest:daily:spam"]').prop('checked') === true){
+                $(':input[name="digest:weekly:spam"]').prop('checked', false);
+            }
+        });
+
+        $(':input[name="digest:weekly:spam"]').change(function () {
+            if($(':input[name="digest:weekly:spam"]').prop('checked') === true){
+                $(':input[name="digest:daily:spam"]').prop('checked', false);
             }
         });
     });

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -4,7 +4,7 @@
   <hr style="width: 35%;  margin-left: 0;" />
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to be notified by email for comments on your posts? </span>
+    <span>Do you want to be notified by a email for comments on your posts? </span>
     <span>
     <label class="switch">
       <p> Notification switch </p>
@@ -18,7 +18,7 @@
   <br />
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to be notified by email for likes on your posts? </span>
+    <span>Do you want to be notified by a email for likes on your posts? </span>
     <span>
     <label class="switch">
       <p> Notification switch </p>
@@ -32,7 +32,7 @@
   <br />
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to be notified by email for comments on all posts you've commented on? </span>
+    <span>Do you want to be notified by a email for comments on all posts you've commented on? </span>
     <span>
     <label class="switch">
       <p> Notification switch </p>
@@ -47,7 +47,7 @@
 
   <% if logged_in_as(['admin', 'moderator']) %>
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to be notified by email for moderation emails? </span>
+    <span>Do you want to be notified by a email for moderation emails? </span>
     <span>
     <label class="switch">
       <p> Notification switch </p>
@@ -63,7 +63,7 @@
 
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to receive customized digest weekly?</span>
+    <span>Do you want to receive a customized digest weekly?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
       <p> Notification switch </p>
@@ -77,7 +77,7 @@
   <br />
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to receive customized digest daily?</span>
+    <span>Do you want to receive a customized digest daily?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
       <p> Notification switch </p>
@@ -90,37 +90,8 @@
   <br />
   <br />
 
-  <% if current_user.can_moderate? %>
-    <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-      <span>Do you want to receive weekly digest for unmoderated posts?</span>
-      <span>
-        <label style=" vertical-align: middle;" class="switch">
-          <p> Notification switch </p>
-          <input type="checkbox" name="digest:weekly:spam" <% if UserTag.exists?(current_user.id, 'digest:weekly:spam') %>checked<% end %>>
-          <span class="slider round"></span>
-        </label>
-      </span>
-    </div>
-
-    <br />
-    <br />
-
-    <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-      <span>Do you want to receive daily digest for unmoderated posts?</span>
-      <span>
-        <label style=" vertical-align: middle;" class="switch">
-          <p> Notification switch </p>
-          <input type="checkbox" name="digest:daily:spam" <% if UserTag.exists?(current_user.id, 'digest:daily:spam') %>checked<% end %>>
-          <span class="slider round"></span>
-        </label>
-      </span>
-    </div>
-
-    <br />
-    <br />
-  <% end %>
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to receive browser notification when you are mentioned?</span>
+    <span>Do you want to receive a browser notification when you are mentioned?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
       <p> Notification switch </p>
@@ -134,7 +105,7 @@
   <br />
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to receive browser notification for all ?</span>
+    <span>Do you want to receive a browser notification for all ?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
       <p> Notification switch </p>
@@ -148,7 +119,7 @@
   <br />
 
   <div style="display: inline-flex; justify-content: space-between; width: 90%;">
-    <span>Do you want to receive browser notification when someone likes your work?</span>
+    <span>Do you want to receive a browser notification when someone likes your work?</span>
     <span>
     <label style=" vertical-align: middle;" class="switch">
       <p> Notification switch </p>
@@ -201,8 +172,40 @@
 <!--  <br />-->
 <!--  <br />-->
 
-</div>
 
+  <br>
+  <% if current_user.can_moderate? %>
+  <h4><b>Spam Digest Settings</b></h4>
+  <hr style="width: 35%;  margin-left: 0;" />
+    <div style="display: inline-flex; justify-content: space-between; width: 90%;">
+      <span>Do you want to receive a weekly digest for unmoderated posts?</span>
+      <span>
+        <label style=" vertical-align: middle;" class="switch">
+          <p> Notification switch </p>
+          <input type="checkbox" name="digest:weekly:spam" <% if UserTag.exists?(current_user.id, 'digest:weekly:spam') %>checked<% end %>>
+          <span class="slider round"></span>
+        </label>
+      </span>
+    </div>
+
+    <br />
+    <br />
+
+    <div style="display: inline-flex; justify-content: space-between; width: 90%;">
+      <span>Do you want to receive a daily digest for unmoderated posts?</span>
+      <span>
+        <label style=" vertical-align: middle;" class="switch">
+          <p> Notification switch </p>
+          <input type="checkbox" name="digest:daily:spam" <% if UserTag.exists?(current_user.id, 'digest:daily:spam') %>checked<% end %>>
+          <span class="slider round"></span>
+        </label>
+      </span>
+    </div>
+
+    <br />
+    <br />
+  <% end %>
+</div>
 
 <br />
 <br />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -344,6 +344,7 @@ Plots2::Application.routes.draw do
   get 'questions/liked(/:tagnames)' => 'questions#liked'
 
   post 'users/test_digest_email' => 'users#test_digest_email'
+  post 'admin/test_digest_email_spam' => 'admin#test_digest_email_spam'
 
   get 'comment/delete/:id' => 'comment#delete'
   get 'comment/update/:id' => 'comment#update'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -46,8 +46,10 @@ end
 
 every 1.day do
   runner "DigestMailJob.perform_async(0)"
+  runner "DigestSpamJob.perform_async(0)"
 end
 
 every 1.week do
   runner "DigestMailJob.perform_async(1)"
+  runner "DigestSpamJob.perform_async(1)"
 end

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -638,4 +638,10 @@ class AdminControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:users)
   end
+  
+  test "test digest emails to moderators" do
+    UserSession.create(users(:moderator))
+    post :test_digest_email_spam
+    assert_redirected_to '/spam'
+  end
 end


### PR DESCRIPTION
Here **digest for unmoderated posts** is added where I have used tag **digest:daily:spam** for daily digest and **digest:weekly:spam** for weekly digest. There is also a test button in the profile section which is used to generate the daily digest. Settings for this are only visible to moderators and admin. _**This PR is similar to https://github.com/publiclab/plots2/pull/7987 with some additional changes like tags and settings.**_

Please refer to following Screenshots:
![Screenshot from 2020-06-22 18-50-06](https://user-images.githubusercontent.com/36025262/85294961-e65e1c00-b4bc-11ea-9dff-0e8abe21535f.png)
![Screenshot from 2020-06-22 18-49-34](https://user-images.githubusercontent.com/36025262/85294966-e8c07600-b4bc-11ea-8c4f-a73e385a433a.png)
![Screenshot from 2020-06-22 18-49-51](https://user-images.githubusercontent.com/36025262/85294956-e3632b80-b4bc-11ea-8372-33b1c489c91c.png)
Please review @jywarren @cesswairimu @pydevsg @ananyaarun @ebarry @emilyashley @VladimirMikulic @Uzay-G 
Thanks!
