### PR TITLE
Reflect IP change in production docker service.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ redeploy-container:
 	docker-compose down --remove-orphans
 	rm -f ./tmp/pids/server.pid
 	docker-compose up -d
-	docker-compose exec -T web bash -c "echo 172.19.0.1 smtp >> /etc/hosts"
-	docker-compose exec -T mailman bash -c "echo 172.19.0.1 smtp >> /etc/hosts"
-	docker-compose exec -T sidekiq bash -c "echo 172.19.0.1 smtp >> /etc/hosts"
+	docker-compose exec -T web bash -c "echo 172.17.0.1 smtp >> /etc/hosts"
+	docker-compose exec -T mailman bash -c "echo 172.17.0.1 smtp >> /etc/hosts"
+	docker-compose exec -T sidekiq bash -c "echo 172.17.0.1 smtp >> /etc/hosts"
 	docker-compose exec -T web bundle exec whenever --update-crontab
 	docker-compose exec -T web service cron start
 
@@ -22,9 +22,9 @@ deploy-container:
 	docker-compose run --rm web bash -c "sleep 5 && rake db:migrate && rake assets:precompile"
 	rm -f ./tmp/pids/server.pid
 	docker-compose up -d
-	docker-compose exec -T web bash -c "echo 172.19.0.1 smtp >> /etc/hosts"
-	docker-compose exec -T mailman bash -c "echo 172.19.0.1 smtp >> /etc/hosts"
-	docker-compose exec -T sidekiq bash -c "echo 172.19.0.1 smtp >> /etc/hosts"
+	docker-compose exec -T web bash -c "echo 172.17.0.1 smtp >> /etc/hosts"
+	docker-compose exec -T mailman bash -c "echo 172.17.0.1 smtp >> /etc/hosts"
+	docker-compose exec -T sidekiq bash -c "echo 172.17.0.1 smtp >> /etc/hosts"
 	docker-compose exec -T web bundle exec whenever --update-crontab
 	docker-compose exec -T web service cron start
 


### PR DESCRIPTION
Sometimes updating docker the host changes IP. We depend on this IP for using the smtp service.
A better solution is wanted. For now please accept this PR for the latest IP in production.