### PR TITLE
Optimise performance of notes_controller#recent

### DIFF
--- a/app/views/notes/_card.html.erb
+++ b/app/views/notes/_card.html.erb
@@ -50,7 +50,7 @@
           <li><a><%= distance_of_time_in_words(Time.at(node.latest.timestamp), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></a></li>
         <% end %>
         <li><a>Total Views: </i> <%= number_with_delimiter(node.views) %> <span class="d-none d-lg-inline"><%= t('notes._notes.views') %></span></a></li>
-        <li><a>Total Likes: <%= node.likers.length %></a></li>
+        <li><a>Total Likes: <%= node.likers.size %></a></li>
         <div class="content" style="width: 100%" >
           <% if @compact.nil? %>
 


### PR DESCRIPTION
Fixes #8070 

optimised performance of notes_controller#recent by replacing the .length method with .size to reduce response time

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

## Screenshots  

Before  
![recent_before](https://user-images.githubusercontent.com/33183263/85560569-6664bd00-b648-11ea-99c8-cd1da86734a6.png)
After  
![recent_after](https://user-images.githubusercontent.com/33183263/85560584-6a90da80-b648-11ea-88c2-8da2d02d511b.png)


Thanks!
