### PR TITLE
optimise performance of tag_controller show

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -123,7 +123,7 @@ class TagController < ApplicationController
       nodes = nodes.where(created: @start.to_i..@end.to_i)
     else
       @pinned_nodes = NodeShared.pinned_nodes(params[:id])
-      if @pinned_nodes.length > 0 && params[:page].nil? # i.e. first page
+      if @pinned_nodes.size.positive? && params[:page].nil? # i.e. first page
         nodes = nodes.where.not(nid: @pinned_nodes.collect(&:id))
       end
     end


### PR DESCRIPTION
Fixes #8072 

optimised performance of tag_controller show by replacing .length>0 with size.positive? so that sql queries are not repeated and response time is reduced.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below  

## Screenshots 

Before  

![tagshow_before](https://user-images.githubusercontent.com/33183263/85570704-34a42400-b651-11ea-97c1-1517ecd02724.png)
After  

![tagshow_after](https://user-images.githubusercontent.com/33183263/85570746-3d94f580-b651-11ea-9495-5a4540548926.png)





Thanks!
