### PR TITLE
replace leaflet css/js files in editor rich

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -3,10 +3,8 @@
 <link href="/lib/bootstrap-tokenfield/dist/css/bootstrap-tokenfield.min.css" rel="stylesheet">
 
 <!-- required for MapModule -->
-<link href="/lib/leaflet/dist/leaflet.css" rel="stylesheet">
-<script src="/lib/leaflet/dist/leaflet.js"></script>
-<link href="/lib/leaflet-blurred-location/dist/Leaflet.BlurredLocation.css" rel="stylesheet">
-<script src="/lib/leaflet-blurred-location/dist/Leaflet.BlurredLocation.js"></script>
+<%= stylesheet_link_tag "leaflet-blurred-location/dist/Leaflet.BlurredLocation.css" %>
+<%= javascript_include_tag('leaflet-blurred-location/dist/Leaflet.BlurredLocation.js') %>
 
 <!-- required for TagsModule -->
 <script src="/lib/typeahead.js/dist/bloodhound.js"></script>
@@ -424,7 +422,7 @@
       new L.LatLng(-90, 180)
     );
     editor.mapModule.blurredLocation.map.setMaxBounds(bounds);
-    
+
     <% if @lat and @lon %>
       <% if @zoom %>
         editor.mapModule.blurredLocation.setZoom(<%= @zoom %>);
@@ -440,7 +438,7 @@
       $('#coord_input').toggle();
     });
     $("#coord_input").hide();
-    
+
     $(function() {
       var target = document.querySelector('#map_content');
       var observer = new MutationObserver(function(mutations) {
@@ -459,7 +457,7 @@
       }
     }
     setLocationButtonText();
-    
+
     $("#obscureLocation").prop('checked', <%= @map_blurred %>);
     editor.mapModule.blurredLocation.setBlurred(<%= @map_blurred %>);
 
@@ -508,4 +506,3 @@
   }
 
 </script>
-

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,7 @@
 Rails.application.config.assets.precompile += [
   'leaflet-blurred-location/dist/Leaflet.BlurredLocation.js',
-
+  'leaflet-blurred-location/dist/Leaflet.BlurredLocation.css',
+  
   'advanced_search.js',
   'submit_form_ajax.js',
   'application.js',
@@ -54,4 +55,5 @@ Rails.application.config.assets.precompile += [
   'async_tag_subscriptions.js',
   'cable.js',
   'spam2.css',
+  'spam2.js',
 ]


### PR DESCRIPTION
Fixes #7923 

Replaced leaflet css/js files in editor rich which are otherwise available from the asset pipeline.  

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
