### PR TITLE
Removed "legacy" link from new question form issue#8146

### DIFF
--- a/app/views/editor/questionRich.html.erb
+++ b/app/views/editor/questionRich.html.erb
@@ -22,8 +22,6 @@
 
 <script src="/lib/publiclab-editor/dist/PublicLab.Editor.js"></script>
 
-<div class="alert alert-success" style="width: 100%;" >This is the new rich Questions form. <a href="/questions/new?legacy=true">Click here for the legacy form</a>.</div>
-
 <div class="pl-editor" style="width:100%;">
 
   <div class="ple-content">


### PR DESCRIPTION
This was a first-timers-only issue (#8146) on the repository. I have not contributed to publiclab before, hence I would like to start with this. 
Removed "legacy" link from new question form
https://github.com/publiclab/plots2/issues/8146
Fixes #0000 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
