### PR TITLE
externalise jquery using jquery-rails-cdn and jquery-rails fallback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,8 @@ gem 'lemmatizer', '~> 0.2.2'
 gem 'mailman', require: false
 # To implement fontawesome v4.7.0
 gem "font-awesome-rails"
- gem "lazyload-rails"
+gem "lazyload-rails"
+gem 'jquery-rails-cdn'
 
 # To convert html to markdown
 gem 'reverse_markdown'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,8 +14,6 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
-//= require jquery
-//= require jquery_ujs
 //= require jquery-lazyload/jquery.lazyload.js
 //= require debounce/index.js
 //= require bootstrap/dist/js/bootstrap.bundle.min.js

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
+    <%= jquery_include_tag :google, force: true %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <meta name="google-translate-customization" content="4ce4c7c384354172-5179499fc244f592-g2b333d0d29f59663-d" />

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,15 +54,15 @@ module Plots2
 
     # Enable the asset pipeline
     config.assets.enabled = true
-    
+
     I18n.available_locales = [:en, :de, "zh-CN", :ar, :es, "hi-IN", :it, :ko, "pt-BR", :ru]
-    config.i18n.default_locale = :en 
-    
+    config.i18n.default_locale = :en
+
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
     # rails will fallback to config.i18n.default_locale translation
     config.i18n.fallbacks = true
-    
+
     # rails will fallback to en, no matter what is set as config.i18n.default_locale
     config.i18n.fallbacks = [:en]
 
@@ -73,6 +73,8 @@ module Plots2
     # Auto-load API and its subdirectories
     config.paths.add File.join('app/api'), glob: File.join('**', '*.rb')
     config.autoload_paths += Dir[Rails.root.join('app','api', '**', '*.rb')]
+
+    config.assets.precompile += ['jquery3.js']
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'

--- a/config/initializers/jquery_cdn.rb
+++ b/config/initializers/jquery_cdn.rb
@@ -1,0 +1,1 @@
+Jquery::Rails::Cdn.major_version = 3


### PR DESCRIPTION
Fixes #7920 

Externalise jquery using jquery-rails-cdn and jquery-rails fallback to improve performance in terms of - 
Automatically fallback to jquery-rails' bundled jQuery when:

On top of that, if you're using asset pipeline, you may have noticed that the major chunks of the code in combined application.js is jQuery. Implications of externalizing jQuery from application.js are:

- Updating your JS code won't evict the entire cache in browsers.
- Cached jQuery in the client browsers will survive deployments.
- rake assets:precompile will run faster and use less memory.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below


Thanks!
