### PR TITLE
replace esri cdn link with minified cdn

### DIFF
--- a/app/views/map/_mapDependencies.html.erb
+++ b/app/views/map/_mapDependencies.html.erb
@@ -10,7 +10,7 @@
 <%= javascript_include_tag('/lib/leaflet-environmental-layers/src/windRoseLayer.js') %>
 <%= javascript_include_tag('/lib/leaflet-fullhash/leaflet-fullHash.js') %>
 <%= javascript_include_tag('https://unpkg.com/esri-leaflet@2.2.3/dist/esri-leaflet.js') %>
-<%= javascript_include_tag('https://unpkg.com/esri-leaflet-renderers@2.0.6') %>
+<%= javascript_include_tag('https://cdn.jsdelivr.net/npm/esri-leaflet-renderers@2.0.6/dist/esri-leaflet-renderers-debug.min.js') %>
 
 <%= javascript_include_tag('/lib/leaflet-spin/example/spin/dist/spin.min.js') %>
 <%= javascript_include_tag('/lib/leaflet-spin/example/leaflet.spin.min.js') %>


### PR DESCRIPTION
Fixes #8163 

replaced esri-leaflet-renderers cdn link with minified cdn

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
