### PR TITLE
Upgrade Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile # Plots2
 # https://github.com/publiclab/plots2
 
-FROM ruby:2.4.4-stretch
+FROM ruby:2.6.6-stretch
 
 LABEL description="This image deploys Plots2."
 


### PR DESCRIPTION
Fixes #8160 (<=== Add issue number here)

Wanted to deploy main to production, found the stable build broken.

We really should build the container in Travis and confirm it builds.