### PR TITLE
fix tag_selection_test using timecop

### DIFF
--- a/test/unit/tag_selection_test.rb
+++ b/test/unit/tag_selection_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class TagSelectionTest < ActiveSupport::TestCase
 
   test 'graph' do
+    Timecop.freeze
     ts_count = TagSelection.select(:following, :created_at)
       .where(following: true, created_at: (Time.now - 1.year..Time.now))
       .count
@@ -11,5 +12,6 @@ class TagSelectionTest < ActiveSupport::TestCase
 
     assert_equal ts_count, graph.values.sum
     assert_equal Hash, graph.class
+    Timecop.return
   end
 end


### PR DESCRIPTION
Fixes #7718 
Fixed tag_selection_test using Timecop. 
Tested locally by assertion of Time.now such that time is frozen in the entire test thus making sure the db queries select the right tags. Reference (https://github.com/travisjeffery/timecop) (https://www.greyblake.com/blog/2018-02-19-how-to-fix-intermittent-test-failures/)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
