### PR TITLE
wip: improve performance of comments#create

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -641,7 +641,7 @@ class Node < ActiveRecord::Base
     comment_via_status = params[:comment_via].nil? ? 0 : params[:comment_via].to_i
     user = User.find(params[:uid])
     status = user.first_time_poster && user.first_time_commenter ? 4 : 1
-    c = Comment.new(pid: 0,
+    c = Comment.includes(:node).new(pid: 0,
                     nid: nid,
                     uid: params[:uid],
                     subject: '',

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -4,7 +4,7 @@
     <h3><span id="comment-count"><%= comments.length %></span> <%= translation('notes._comments.comments') %></h3>
 
     <div style="margin-bottom: 50px;" id="comments-list">
-      <% comments.includes(:replied_comments).order('timestamp ASC').each do |comment| %>
+      <% comments.includes([:replied_comments, :node]).order('timestamp ASC').each do |comment| %>
         <% if comment.cid == @node.comments&.first&.cid %><a id="last" name="last"></a><% end %>
 
         <% if comment.reply_to.nil? %>


### PR DESCRIPTION
Fixes #8170 

DO NOT MERGE WORK IN PROGRESS
Improving performance of comments#create endpoint by removing repeated sql calls to find user based on uid

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
