### PR TITLE
eliminate n+1 queries of tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -62,7 +62,7 @@ class Tag < ApplicationRecord
   end
 
   def self.contributors(tagname)
-    tag = Tag.includes(:node).where(name: tagname).first
+    tag = Tag.where(name: tagname).first
     return [] if tag.nil?
 
     nodes = tag.node.includes(:revision, :comments, :answers).where(status: 1)

--- a/app/views/tag/_advanced_tagging.html.erb
+++ b/app/views/tag/_advanced_tagging.html.erb
@@ -4,7 +4,7 @@
 <div class="dropdown-menu dropdown-menu-right float-right" style="margin-top:5px;" id="pt-list">
   <% if current_user %>
     <p class="dropdown-header"><b>Recently used tags</b></p>
-    <% NodeTag.where(uid: current_user.id).order('date DESC').limit(5).each do |tag| %>
+    <% NodeTag.includes(:tag).where(uid: current_user.id).order('date DESC').limit(5).each do |tag| %>
       <a class="dropdown-item" onClick="addTag('<%= tag.name %>')"><span style="cursor:pointer;" class="badge badge-primary"><%= tag.name %></span></a>
     <% end %>
   <% end %>

--- a/app/views/tag/_tagging.html.erb
+++ b/app/views/tag/_tagging.html.erb
@@ -10,8 +10,8 @@
     <% end %>
   </p>
   <div id="tags" class="node-tags">
-    <%= render partial: 'tag/tags', locals: { power_tag: false, badge_name: 'badge-secondary', tags: @node.normal_tags(:followers) } %>
-    <%= render partial: 'tag/tags', locals: { power_tag: true, badge_name: 'badge-primary', tags: @node.power_tag_objects } %>
+    <%= render partial: 'tag/tags', locals: { power_tag: false, badge_name: 'badge-secondary', tags: @node.normal_tags(:followers).includes(:tag) } %>
+    <%= render partial: 'tag/tags', locals: { power_tag: true, badge_name: 'badge-primary', tags: @node.power_tag_objects.includes(:tag) } %>
   </div>
 <% else %>
   <div id="tags" class="profile-tags">

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -48,7 +48,7 @@
         <% end %>
       </a>
       <% if logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid) %>
-      <a aria-label="Delete tag" data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>     
+      <a aria-label="Delete tag" data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
       <% end %>
     </span>
     </li>


### PR DESCRIPTION
Fixes #8182

Added include statements to eliminate n+1 queries of tags to improve server response timing as flagged by 'bullet' gem.
- NodeTag includes Tag because in sidebar tag/_advanced_tagging file name method is called which makes use of tag
- NodeTag includes Tag because in sidebar tag/_miniCard file name method is called which makes use of tag
- Eager loading removed from contributors method since not required anywhere

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
