### PR TITLE
wip: remove n+1 query from revision#path method

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -111,6 +111,7 @@ class HomeController < ApplicationController
       .order('nid DESC')
       .limit(10)
     revisions = Revision.joins(:node)
+      .includes(:node)
       .order('timestamp DESC')
       .where('type = (?)', 'page')
       .where('node.status = 1')


### PR DESCRIPTION
Fixes #8188 

Removed n+1 query prob from revision#path method

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
