### PR TITLE
try fixing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 
 addons:
   mariadb: '10.2'
+  chrome: stable
 
 cache:
   directories:
@@ -28,7 +29,9 @@ env:
     - RAILS_SYSTEM_TESTING_SCREENSHOT=simple
 
 before_install:
-  - sudo wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
+  - CHROME_MAIN_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
+  - CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
+  - sudo wget https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
   - sudo unzip chromedriver_linux64.zip -d /usr/local/bin/
   - sudo chmod +x /usr/local/bin/chromedriver
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  chromeOptions = %w(--headless --disable-gpu --no-sandbox --remote-debugging-port=9222)
-  caps = Selenium::WebDriver::Remote::Capabilities.chrome("chromeOptions" => {"args" => chromeOptions})
+  chromeOptions = %w(no-sandbox disable-dev-shm-usage headless disable-gpu remote-debugging-port=9222)
+  caps = Selenium::WebDriver::Remote::Capabilities.chrome("goog:chromeOptions" => {"args" => chromeOptions})
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: { desired_capabilities: caps }
 
   # https://web.archive.org/web/20170730200309/http://blog.paulrugelhiatt.com/rails/testing/capybara/dropzonejs/2014/12/29/test-dropzonejs-file-uploads-with-capybara.html


### PR DESCRIPTION
Fixes #0000 (<=== Add issue number here)

Travis error fixed by matching the level of chrome stable and chromedriver by checking for the version of chrome and then installing the chrome driver of the same version. Also corrected the syntax for the Selenium Capybara testing in ruby.

Referred docs: - https://chromedriver.chromium.org/capabilities
https://docs.travis-ci.com/user/gui-and-headless-browsers/

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
