### PR TITLE
Fixes to tag counting logic

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -37,7 +37,7 @@ class Tag < ApplicationRecord
   end
 
   def run_count
-    self.count = NodeTag.where(tid: tid).count
+    self.count = NodeTag.joins(:node).where(tid: tid).where('node.status = 1').count
     save
   end
 

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -24,7 +24,7 @@ class TagTest < ActiveSupport::TestCase
     assert_nil tag.count
     assert_not_nil tag.run_count
     assert_not_nil tag.count
-    assert_equal 1, tag.count
+    assert_equal 3, tag.count
 
     tag = tags(:awesome)
     assert_nil tag.count

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -19,6 +19,20 @@ class TagTest < ActiveSupport::TestCase
     assert_not_nil tag.nodes
   end
 
+  test 'tag counting' do
+    tag = tags(:awesome)
+    assert_nil tag.count
+    assert_not_nil tag.run_count
+    assert_not_nil tag.count
+    assert_equal 1, tag.count
+
+    tag = tags(:awesome)
+    assert_nil tag.count
+    assert_not_nil tag.run_count
+    assert_not_nil tag.count
+    assert_equal 0, tag.count # even if used, it should not count spam tags
+  end
+
   test 'tag followers' do
     followers = Tag.followers(node_tags(:awesome).name)
     assert !followers.empty?

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -26,7 +26,7 @@ class TagTest < ActiveSupport::TestCase
     assert_not_nil tag.count
     assert_equal 3, tag.count
 
-    tag = tags(:awesome)
+    tag = tags(:spam)
     assert_nil tag.count
     assert_not_nil tag.run_count
     assert_not_nil tag.count


### PR DESCRIPTION
Fixes #8244 

If this fails properly, we should then add this to line 40 of tag.rb:


```ruby
    self.count = NodeTag.joins(:node).where(tid: tid).where('node.status = 1').count
```