### PR TITLE
Added alerts-container class

### DIFF
--- a/app/views/tag/show.html.erb
+++ b/app/views/tag/show.html.erb
@@ -8,6 +8,13 @@
 .tag-header {
   margin-top: -21px;
 }
+.alerts-container {
+  position: absolute;
+  z-index: 999;
+  width: 100%;
+  left: 0;
+  padding: 0 20px;
+}
 @media screen and (max-width: 340px) {
   .tag-header {
     margin-top: -30px;


### PR DESCRIPTION
This adds `.alerts-container` to `<style>` inline to float the alert boxes instead of pushing down the page image headings.

Fixes #8167

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
