### PR TITLE
eliminate n+1 query of comment parent method

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -81,6 +81,7 @@ class HomeController < ApplicationController
     notes = notes.where('nid != (?)', blog.nid) if blog
 
     comments = Comment.joins(:node, :user)
+                   .includes(:node)
                    .order('timestamp DESC')
                    .where('timestamp - node.created > ?', 86_400) # don't report edits within 1 day of page creation
                    .where('node.status = ?', 1)


### PR DESCRIPTION
Fixes #8266 

eliminates n+1 query of comment parent method by eagerly loading `:node` for activity comments.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below



Thanks!
