### PR TITLE
eliminate n+1 query in questions comments parent method

### DIFF
--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -55,7 +55,7 @@
   <% comments = @node.comments_viewable_by(current_user) %>
   <h3><span id="comment-count"><%= comments.length %></span> Comments</h3>
     <div id="comments-list">
-      <% comments.includes(:replied_comments).order("timestamp ASC").each do |comment| %>
+      <% comments.includes([:node, :replied_comments]).order("timestamp ASC").each do |comment| %>
         <% if comment.reply_to.nil? %>
           <%= render :partial => "notes/comment", :locals => {:comment => comment} %>
         <% end %>


### PR DESCRIPTION
Fixes #8271

Eliminates n+1 query in questions comments parent method by eagerly loading the node model for accessing the parent method in comments.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
