### PR TITLE
bcc on moderator spam digest email

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -129,6 +129,10 @@ class AdminMailer < ActionMailer::Base
     end
     moderators = User.where(role: %w(moderator admin)).collect(&:email)
     @nodes = nodes
-    mail(to: moderators, subject: @subject)
+    mail(
+      to: "moderators@#{ActionMailer::Base.default_url_options[:host]}",
+      bcc: moderators,
+      subject: @subject
+    )
   end
 end


### PR DESCRIPTION
Hi @keshavsethi - noted that the spam digest email showed all moderator emails, which is not that big a deal as they are all approved and managed by PL staff, but I felt it was probably better to put them in bcc, unless @ebarry feels differently!

![Screen Shot 2020-08-08 at 3 36 13 PM](https://user-images.githubusercontent.com/24359/89718475-ea6ecc00-d98c-11ea-8356-8765d136a681.png)

But, the email is definitely working! Great job!