### PR TITLE
Fix comment page wrapping for non-logged in users

### DIFF
--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -85,6 +85,7 @@
                 <img alt="React to post" class="emoji" height="20" width="20" src="<%= emoji_image_map[e] %>">
               <% end %>
               <% end %>
+            </div>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Fixes #8287

Testable on any notes page when not logged in, in full width display; 

![image](https://user-images.githubusercontent.com/24359/89938666-cf969480-dbe4-11ea-8214-2075178477a7.png)
