### PR TITLE
remove n+1 queries in rss builder

### DIFF
--- a/app/views/notes/rss.rss.builder
+++ b/app/views/notes/rss.rss.builder
@@ -5,7 +5,7 @@ xml.rss :version => '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom' do
     xml.link "https://#{request.host}/feed.rss"
     xml.tag! 'atom:link', rel: 'self', type: 'application/rss+xml', href: "https://#{request.host}/feed.rss"
 
-    @notes.each do |node|
+    @notes.includes(user: [:user_tags]).each do |node|
       author = node.author.username
       if node.author.has_power_tag('twitter')
         author = "@#{node.author.get_value_of_power_tag('twitter')}"

--- a/app/views/tag/rss.rss.builder
+++ b/app/views/tag/rss.rss.builder
@@ -5,7 +5,7 @@ xml.rss :version => '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom' do
     xml.link "https://#{request.host}/feed/tag/" + params[:tagname] + ".rss"
     xml.rel "self"
 
-    @notes.each do |node|
+    @notes.includes(user: [:user_tags]).each do |node|
       body = node.body
       author = node.author.username
       if node.author.has_power_tag('twitter')

--- a/app/views/users/rss.rss.builder
+++ b/app/views/users/rss.rss.builder
@@ -5,7 +5,7 @@ xml.rss :version => "2.0" do
     xml.description "Open source environmental science research at Public Lab"
     xml.link "https://#{request.host}/feed/" + params[:author] + ".rss"
 
-    @notes.each do |node|
+    @notes.includes(:user).each do |node|
       newline = '&#13;&#10;'
 
       body = node.body


### PR DESCRIPTION
Fixes #8308 

Eliminate n+1 queries for rss by using .includes to preload user and user_tags models.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
