### PR TITLE
add more lazyload optimisations

### DIFF
--- a/app/views/dashboard/_node_event.html.erb
+++ b/app/views/dashboard/_node_event.html.erb
@@ -4,19 +4,19 @@
   <div class="header-icon"><i class="fa fa-calendar"></i> <a aria-label="Link to event" href="/n/<%= node.id %>"><i class="fa fa-link"></i></a></div>
 
     <div style="overflow: hidden;">
-      
+
       <%= render partial: 'dashboard/node_moderate', locals: { node: node } %>
-     
+
       <% if node.main_image %>
-        <a class="img" href="<%= node.path %>"><img src="<%= node.main_image.path(:default) %>" style="width:100%;" /></a>
+          <a class="img" href="<%= node.path %>"><%= image_tag(node.main_image.path(:default), style:'width:100%;') %></a>
       <% elsif node.scraped_image %>
-        <a class="img" href="<%= node.path %>"><img src="<%= node.scraped_image %>" style="width:100%;" /></a>
+          <a class="img" href="<%= node.path %>"><%= image_tag(node.scraped_image, style:'width:100%;') %></a>
       <% end %>
-     
+
       <h4><a href="<%= node.path %>"><%= node.title %></a></h4>
-     
+
       <a class="btn btn-outline-secondary btn-sm float-right respond rsvp">RSVP</a>
-     
+
       <p class="meta">Event <%= render partial: "dashboard/node_meta", locals: { node: node } %></p>
 
     </div>

--- a/app/views/dashboard/_node_wiki.html.erb
+++ b/app/views/dashboard/_node_wiki.html.erb
@@ -8,14 +8,14 @@
       <div class="header-icon"><i class="fa fa-pencil"></i></div>
       <p class="meta"><%= translation('dashboard._node_wiki.new_edit_by') %> <a href="/profile/<%= node.author.try(:name) %>"><%= node.author.try(:name) %></a></p>
     <% end %>
- 
-    <!-- TODO: could be resolved with `node.node.main_image` but applying quick fix here --> 
+
+    <!-- TODO: could be resolved with `node.node.main_image` but applying quick fix here -->
     <% if false && node.main_image %>
-      <a class="img" href="<%= node.path %>"><img src="<%= node.main_image.path(:default) %>" style="width:100%;" /></a>
+        <a class="img" href="<%= node.path %>"><%= image_tag(node.main_image.path(:default), style:'width:100%;') %></a>
     <% elsif false && node.scraped_image %>
-      <a class="img" href="<%= node.path %>"><img src="<%= node.scraped_image %>" style="width:100%;" /></a>
+        <a class="img" href="<%= node.path %>"><%= image_tag(node.scraped_image, style:'width:100%;') %></a>
     <% end %>
- 
+
     <h4>
       <a href="<%= node.path %>">
         <% if node.is_a?(Node) %>
@@ -23,17 +23,17 @@
         <% else %>
           <%= node.parent.latest.title %>
         <% end %>
-      </a> 
+      </a>
     </h4>
 
     <% if node.is_a?(Revision) && node.previous %>
       <a class="btn btn-outline-secondary btn-sm float-right btn-diff btn-diff-<%= index %>"><%= translation('dashboard._node_wiki.changes') %> &raquo;</a>
     <% end %>
- 
+
     <p class="meta"><%= render partial: "dashboard/node_meta", locals: { node: node } %></p>
 
     <% if node.is_a?(Revision) && node.previous %>
-      
+
       <div class="card bg-light">
         <div data-diff-a="<%= node.previous.vid %>" data-diff-b="<%= node.vid %>" class="card-body wiki-diff wiki-diff-<%= index %>" style="display:none;"><i class="fa fa-circle-o-notch fa-spin"></i></div>
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -109,7 +109,7 @@
                   <% if current_user.profile_image == "https://www.gravatar.com/avatar/eb721d116a28f4a4da4ea67340c8ce75" %>
                     <i class="fa fa-user-circle fa-lg" style="color:white;"></i>
                   <% else %>
-                    <img class="rounded-circle" id="profile-photo" alt="profile-photo" style="width:20px; height:20px; margin-right:8px;" src="<%= current_user.profile_image %>" />
+                    <%= image_tag(current_user.profile_image, class:'rounded-circle', style:'width:20px; height:20px; margin-right:8px;', alt:'profile-photo', id:'profile-photo') %>
                   <% end %>
                 </div>
               </a>

--- a/app/views/tag/blog.html.erb
+++ b/app/views/tag/blog.html.erb
@@ -46,7 +46,7 @@
       <% @notes.each_with_index do |node,i| %>
         <div class="clearfix blog-entry">
           <% if node.main_image %>
-            <a class="img" href="<%= node.path %>"><img src="<%= node.main_image.path(:default) %>" /></a>
+              <a class="img" href="<%= node.path %>"><%= image_tag(node.main_image.path(:default)) %></a>
           <% end %>
           <h1><a href="<%= node.path %>"><%= node.title %></a></h1>
           <p class="meta" style="color:#888;"><small>


### PR DESCRIPTION
Follow up pr to #8043 

Added more lazyload optimisations that were flagged by Lighthouse  
On /dashboard route lazyload added to events and wikis which was not previously lazyloaded. Also added for the user profile pic in header navbar. Since the parent file didn't have script for img.lazyload they were not lazyloaded before, adding the image_tag will solve this problem.

![image](https://user-images.githubusercontent.com/33183263/90962888-1f246c80-e4d1-11ea-8041-050c4d690855.png)


* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

Thanks!
