### PR TITLE
fix timecop freeze by ignoring nanosecond precision for ci

### DIFF
--- a/test/unit/tag_selection_test.rb
+++ b/test/unit/tag_selection_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class TagSelectionTest < ActiveSupport::TestCase
 
   test 'graph' do
+    Time.zone.now.change(nsec: 0)
     Timecop.freeze
     ts_count = TagSelection.select(:following, :created_at)
       .where(following: true, created_at: (Time.now - 1.year..Time.now))


### PR DESCRIPTION
Fixes #8401 

fixed timecop freeze by ignoring nanosecond precision for ci since the test was failing on Travis because of nanoseconds drift. Check https://github.com/travisjeffery/timecop/issues/97#issuecomment-41294684

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
