### PR TITLE
Add pagy for blogs

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -253,9 +253,7 @@ class TagController < ApplicationController
 
   def blog
     nids = Tag.find_nodes_by_type(params[:id], 'note', nil).collect(&:nid)
-    @notes = Node.paginate(page: params[:page], per_page: 6)
-      .where('status = 1 AND nid in (?)', nids)
-      .order('created DESC')
+    @pagy, @notes = pagy(Node.where('status = 1 AND nid in (?)', nids).order('created DESC'), items: 6)
     @tags = Tag.where(name: params[:id])
     @tagnames = @tags.collect(&:name).uniq! || []
     @title = @tagnames.join(',') + ' Blog' if @tagnames

--- a/app/views/tag/blog.html.erb
+++ b/app/views/tag/blog.html.erb
@@ -79,7 +79,11 @@
       <% end %>
 
     <div class="text-center">
+      <% if @pagy %>
+        <%== pagy_bootstrap_nav @pagy %>
+      <% else %>
         <%= will_paginate @notes, renderer: WillPaginate::ActionView::BootstrapLinkRenderer unless @unpaginated %>
+      <% end %>
     </div>
 
   <% end %>


### PR DESCRIPTION
Fixes #8443

Adds pagy pagination for the blogs route. As stated in the issue, the `/blog` endpoint directs to the `tags#blog` action 👍 

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

## Before
![image](https://user-images.githubusercontent.com/49186122/94770010-6bc36780-03ee-11eb-975f-1dbd4084de78.png)


## After
![image](https://user-images.githubusercontent.com/49186122/94769953-3d458c80-03ee-11eb-82ee-f2f29a224a03.png)



> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
