### PR TITLE
test 'incomplete spamaway test does not create new user record', and fix users controller to prevent user creation in this scenario

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     recaptcha = verify_recaptcha(model: @user) if using_recaptcha
     @spamaway = Spamaway.new(spamaway_params) unless using_recaptcha
 
-    if ((@spamaway&.valid?) || recaptcha) && saved_user = @user.save # pass spamaway validation FIRST then try saving the user; https://github.com/publiclab/plots2/issues/8463
+    if ((@spamaway&.valid?) || recaptcha) && @user.save # pass spamaway validation FIRST then try saving the user; https://github.com/publiclab/plots2/issues/8463
       if current_user.crypted_password.nil? # the user has not created a pwd in the new site
         flash[:warning] = I18n.t('users_controller.account_migrated_create_new_password')
         redirect_to "/profile/edit"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,8 +15,7 @@ class UsersController < ApplicationController
     recaptcha = verify_recaptcha(model: @user) if using_recaptcha
     @spamaway = Spamaway.new(spamaway_params) unless using_recaptcha
 
-    saved_user = @user.save
-    if ((@spamaway&.valid?) || recaptcha) && saved_user
+    if ((@spamaway&.valid?) || recaptcha) && saved_user = @user.save # pass spamaway validation FIRST then try saving the user; https://github.com/publiclab/plots2/issues/8463
       if current_user.crypted_password.nil? # the user has not created a pwd in the new site
         flash[:warning] = I18n.t('users_controller.account_migrated_create_new_password')
         redirect_to "/profile/edit"

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -96,7 +96,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
        } 
     end
     assert response.body.include? '1 error prohibited this user from being saved'
-    assert response.body.include? "Spam detection Spam detection -- It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
+    assert response.body.include? "Spam detection -- It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
   end
   
   test 'spamaway text area not blank error message' do

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -81,6 +81,24 @@ class SignUpTest < ActionDispatch::IntegrationTest
     assert response.body.include? 'Email should look like an email address.'
   end
   
+  test 'incomplete spamaway test does not create new user record, returns useful validation' do
+    assert_difference 'User.count', 0 do
+      post '/register', params: {
+        user: {
+           username: "newuser",
+           email: @new_user[:email],
+           password: @new_user[:password],
+           password_confirmation: @new_user[:password]
+        },
+        spamaway: {
+          follow_instructions: "Not_Blank"
+         }
+       } 
+    end
+    assert response.body.include? '1 error prohibited this user from being saved'
+    assert response.body.include? "Spam detection Spam detection -- It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
+  end
+  
   test 'spamaway text area not blank error message' do
     post '/register', params: {
       user: {

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -91,7 +91,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
            password_confirmation: @new_user[:password]
         },
         spamaway: {
-          follow_instructions: "Not_Blank"
+          follow_instructions: ""
          }
        } 
     end

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -96,7 +96,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
        } 
     end
     assert response.body.include? '1 error prohibited this user from being saved'
-    assert response.body.include? "Spam detection -- It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
+    assert response.body.include? "Spam detection It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
   end
   
   test 'spamaway text area not blank error message' do

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -96,7 +96,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
        } 
     end
     assert response.body.include? '1 error prohibited this user from being saved'
-    assert response.body.include? "Spam detection It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
+    assert response.body.include? "It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
   end
   
   test 'spamaway text area not blank error message' do

--- a/test/integration/signup_flow_test.rb
+++ b/test/integration/signup_flow_test.rb
@@ -96,7 +96,7 @@ class SignUpTest < ActionDispatch::IntegrationTest
        } 
     end
     assert response.body.include? '1 error prohibited this user from being saved'
-    assert response.body.include? "It doesn't seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
+    assert response.body.include? "It doesn&#39;t seem like you are a real person! If you disagree or are having trouble, please see https://publiclab.org/registration-test."
   end
   
   test 'spamaway text area not blank error message' do


### PR DESCRIPTION
Re: #8463 and related to https://github.com/publiclab/plots2/blob/8c9c39da0152d5a965e7eb77697c056ca3d45111/test/system/signup_form_test.rb