### PR TITLE
[WIP] Temporarily fixes double pagination on /questions/tag/

### DIFF
--- a/app/views/questions/_questions.html.erb
+++ b/app/views/questions/_questions.html.erb
@@ -19,6 +19,7 @@
     <% end %>
   <% end %>
 </div>
+
 <div class="text-center mt-3">
   <% if @pagy %>
     <%== pagy_bootstrap_nav @pagy %>

--- a/app/views/tag/show/_tab_content.html.erb
+++ b/app/views/tag/show/_tab_content.html.erb
@@ -26,7 +26,7 @@
           </div>
 
           <div class="tab-pane" id="answered-tab">
-            <% if @answered_questions %>
+            <% if @answered_questions.present? %>
               <%= render partial: "users/answered" %>
             <% end %>
           </div>

--- a/app/views/users/_answered.html.erb
+++ b/app/views/users/_answered.html.erb
@@ -37,10 +37,12 @@
   </div>
 </div>
 
-<div class="text-center">
-<% if @pagy %>
-  <%== pagy_bootstrap_nav @pagy %>
-<% else %>
-  <%= will_paginate @questions, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer unless @unpaginated || @questions.empty? %>
+<% if @answered_questions.present? %>
+  <div class="text-center">
+  <% if @pagy %>
+    <%== pagy_bootstrap_nav @pagy %>
+  <% else %>
+    <%= will_paginate @answered_questions, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer unless @unpaginated || @answered_questions.empty? %>
+  <% end %>
+  </div>
 <% end %>
-</div>


### PR DESCRIPTION
Fixes #7530 

## Checks
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

## Description
Changes the `_answered` html fragment to check the existence of `@answered_questions` before rendering the pagy pagination.

Note, that this was not actually tested with answered questions because it seems that the Asked/Answered tabs are broken under the `questions/tag` screen. Clicking either tab does not change anything. @jywarren 

### Before
![image](https://user-images.githubusercontent.com/49186122/95407414-e4c73f80-0957-11eb-80da-926d44c51957.png)

### After



> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
