### PR TITLE
Bypass GitPod SQL .group() error by grouping only in production

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -19,44 +19,44 @@ class TagController < ApplicationController
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where("name LIKE :keyword", keyword: "%#{keyword}%")
         .where(powertag_clause)
-        .group(:name)
         .order(order_string)
         .paginate(page: params[:page], per_page: 24)
+      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
     elsif @toggle == "uses"
       @tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
         .where('node.status = ?', 1)
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
-        .group(:name)
         .order(order_string)
         .paginate(page: params[:page], per_page: 24)
+      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
     elsif @toggle == "name"
       @tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
         .where('node.status = ?', 1)
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
-        .group(:name)
         .order(order_string)
         .paginate(page: params[:page], per_page: 24)
+      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
     elsif @toggle == "followers"
       raw_tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
         .where('node.status = ?', 1)
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
-        .group(:name)
       raw_tags = Tag.sort_according_to_followers(raw_tags, params[:order])
       @tags = raw_tags.paginate(page: params[:page], per_page: 24)
+      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
     else
       tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
         .where('node.status = ?', 1)
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
-        .group(:name)
         .order(order_string)
+      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
 
       followed = []
       not_followed = []

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -20,8 +20,8 @@ class TagController < ApplicationController
         .where("name LIKE :keyword", keyword: "%#{keyword}%")
         .where(powertag_clause)
         .order(order_string)
-        .paginate(page: params[:page], per_page: 24)
       @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
+      @tags.paginate(page: params[:page], per_page: 24)
     elsif @toggle == "uses"
       @tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
@@ -29,8 +29,8 @@ class TagController < ApplicationController
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
         .order(order_string)
-        .paginate(page: params[:page], per_page: 24)
       @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
+      @tags.paginate(page: params[:page], per_page: 24)
     elsif @toggle == "name"
       @tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
@@ -38,8 +38,8 @@ class TagController < ApplicationController
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
         .order(order_string)
-        .paginate(page: params[:page], per_page: 24)
       @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
+      @tags.paginate(page: params[:page], per_page: 24)
     elsif @toggle == "followers"
       raw_tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
@@ -47,8 +47,8 @@ class TagController < ApplicationController
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
       raw_tags = Tag.sort_according_to_followers(raw_tags, params[:order])
+      raw_tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
       @tags = raw_tags.paginate(page: params[:page], per_page: 24)
-      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
     else
       tags = Tag.joins(:node_tag, :node)
         .select('node.nid, node.status, term_data.*, community_tags.*')
@@ -56,7 +56,7 @@ class TagController < ApplicationController
         .where('community_tags.date > ?', (DateTime.now - 1.month).to_i)
         .where(powertag_clause)
         .order(order_string)
-      @tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
+      tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
 
       followed = []
       not_followed = []

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -136,8 +136,8 @@ class UsersController < ApplicationController
                    .joins(:revisions)
                    .where("node_revisions.status = 1")
                    .order(order_string)
-                   .page(params[:page])
       @users.group('rusers.id') unless Rails.env.development? # for GitPod compatibility; #8117
+      @users.page(params[:page])
     end
 
     @users = @users.where('rusers.status = 1') unless current_user&.can_moderate?


### PR DESCRIPTION
Re: #8177 as temp solution:

```
@tags.group(:name) unless Rails.env.development? # for GitPod compatibility; #8117
```
