### PR TITLE
Remove Redundant Time Text

### DIFF
--- a/app/views/notes/_card.html.erb
+++ b/app/views/notes/_card.html.erb
@@ -51,12 +51,6 @@
       <a class="ellipsis bottom-right" data-toggle="dropdown"><i class="fa fa-ellipsis-h" style="color : #666; font-size:15px; float:right; cursor:pointer;"></i></a>
 
       <ul class="dropdown-menu" style = "width: 150px; font-size:10px;">
-        <% if node.type == 'note' %>
-          <li><a> Made: <%= distance_of_time_in_words(node.created_at, Time.current, { include_seconds: false, scope:'datetime.time_ago_in_words' }) %> </a></li>
-        <% else %>
-          <li><a>Last Edited: <%= t('notes._notes.last_edit_by') %> <a <% if @widget %>target="_blank"<% end %> href="/profile/<%= node.latest.author.name %>"><%= node.latest.author.name %></a></a></li>
-          <li><a><%= distance_of_time_in_words(Time.at(node.latest.timestamp), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %></a></li>
-        <% end %>
         <li><a>Total Views: </i> <%= number_with_delimiter(node.views) %> <span class="d-none d-lg-inline"><%= t('notes._notes.views') %></span></a></li>
         <li><a>Total Likes: <%= node.likers.size %></a></li>
         <div class="content" style="width: 100%" >


### PR DESCRIPTION
Fixes #6685 

-Removed the redundant time "Made" in the notes view dropdown.

**Before**
<img width="411" alt="Screenshot 2020-10-08 at 23 06 49" src="https://user-images.githubusercontent.com/7622875/95547425-a7bc8500-0a0b-11eb-85fc-4fd3dfae4d07.png">
**After**
<img width="563" alt="Screenshot 2020-10-09 at 08 42 19" src="https://user-images.githubusercontent.com/7622875/95547444-b30fb080-0a0b-11eb-9e8d-367c7636af2e.png">

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
