### PR TITLE
Validate sign up form elements on page reload

### DIFF
--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -46,12 +46,25 @@ $(document).ready(function() {
   if (signUpForms[1]) {
     signUpForms[1].classList.add("signup-register-form");
     var signUpRegisterForm = new SignUpFormValidator(".signup-register-form");
-    signUpRegisterForm.validateForm()
 
-    if (signUpErrorMessages.innerHTML.includes("Email")) {
-      signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, false, "Email already exists");
+    if (signUpErrorMessages.innerHTML.includes("error")) {
+      if (signUpErrorMessages.innerHTML.includes("Email") && signUpErrorMessages.innerHTML.includes("Username")) {
+        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, false, "Email already exists");
+        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, false, "Username already exists");
+      }
+      else if (signUpErrorMessages.innerHTML.includes("Email") && !(signUpErrorMessages.innerHTML.includes("Username"))) {
+        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, false, "Email already exists");
+        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, true);
+      }
+      else if (!(signUpErrorMessages.innerHTML.includes("Email")) && signUpErrorMessages.innerHTML.includes("Username")) {
+        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, true);
+        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, false, "Username already exists");
+      }
+      else {
+        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, true);
+        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, true);
+      }
     }
-    signUpRegisterForm.isFormValid()
   }
 
   // The same goes for login forms

--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -48,21 +48,13 @@ $(document).ready(function() {
     var signUpRegisterForm = new SignUpFormValidator(".signup-register-form");
 
     if (signUpErrorMessages.innerHTML.includes("error")) {
-      if (signUpErrorMessages.innerHTML.includes("Email") && signUpErrorMessages.innerHTML.includes("Username")) {
+      signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, true);
+      signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, true);
+      if (signUpErrorMessages.innerHTML.includes("Email")) {
         signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, false, "Email already exists");
+      }
+      if (signUpErrorMessages.innerHTML.includes("Username")) {
         signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, false, "Username already exists");
-      }
-      else if (signUpErrorMessages.innerHTML.includes("Email") && !(signUpErrorMessages.innerHTML.includes("Username"))) {
-        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, false, "Email already exists");
-        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, true);
-      }
-      else if (!(signUpErrorMessages.innerHTML.includes("Email")) && signUpErrorMessages.innerHTML.includes("Username")) {
-        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, true);
-        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, false, "Username already exists");
-      }
-      else {
-        signUpRegisterForm.updateUI(signUpRegisterForm.emailElement, true);
-        signUpRegisterForm.updateUI(signUpRegisterForm.usernameElement, true);
       }
     }
   }


### PR DESCRIPTION
Fixes #8463 (<=== Add issue number here)
Reinstates the changes of #7768 
Validates the email and username elements of signup form on page reload when an error is faced during sign up. The error could be :
1. Invalid spam check
2. Duplicate username or email

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
