### PR TITLE
Change t to translation in dashboard/_comment_moderate

### DIFF
--- a/app/views/dashboard/_comment_moderate.html.erb
+++ b/app/views/dashboard/_comment_moderate.html.erb
@@ -1,11 +1,11 @@
 <% if comment.status == 4 %>
   <p class="alert alert-warning moderated">
     <% if logged_in_as(['admin','moderator']) %>
-      <%= t('dashboard._comment_moderate.first_time_post') %>
-      <a class="btn btn-outline-secondary btn-sm" href="/admin/publish_comment/<%= comment.id %>"><%= t('dashboard.moderate.approve') %></a>
-      <a class="btn btn-outline-secondary btn-sm" href="/admin/mark_comment_spam/<%= comment.id %>"><%= t('dashboard.moderate.spam') %></a>
+      <%= translation('dashboard._comment_moderate.first_time_post') %>
+      <a class="btn btn-outline-secondary btn-sm" href="/admin/publish_comment/<%= comment.id %>"><%= translation('dashboard.moderate.approve') %></a>
+      <a class="btn btn-outline-secondary btn-sm" href="/admin/mark_comment_spam/<%= comment.id %>"><%= translation('dashboard.moderate.spam') %></a>
     <% else %>
-      <%= raw t('dashboard.moderate.pending_approval', :url => '/wiki/moderation') %>
+      <%= raw translation('dashboard.moderate.pending_approval', :url => '/wiki/moderation') %>
     <% end %>
   </p>
 <% end %>


### PR DESCRIPTION
Fixes #[6598 ](https://github.com/publiclab/plots2/issues/6598)

Changed the function named t(....) to be named as translation(...) on lines 4, 5, 6, and 8.

* [ ✅] PR is descriptively titled 📑 and links the original issue above 🔗
* [✅ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [✅ ] code is in uniquely-named feature branch and has no merge conflicts 📁

