### PR TITLE
Fixed Social media sharing pills misaligned in sidebar and aligned social buttons in a row

### DIFF
--- a/app/views/home/_social.html.erb
+++ b/app/views/home/_social.html.erb
@@ -1,6 +1,6 @@
-<div id="social" style="clear:both;margin-top:10px;">
+<div id="social" style="clear:both;margin-top:10px;display:flex;">
   <% if Rails.env == "production" %>
-    <div class="fb-like" data-send="false" data-layout="button_count" data-width="50" data-show-faces="false" style="vertical-align: middle; bottom: 6px;margin-right:10px" ></div>
+    <div class="fb-like" data-send="false" data-layout="button_count" data-width="50" data-show-faces="false" style="display:flex;margin-right:10px;" ></div>
 
     <script>(function(d, s, id) {
        var js, fjs = d.getElementsByTagName(s)[0];
@@ -10,7 +10,7 @@
     fjs.parentNode.insertBefore(js, fjs);
   }(document, 'script', 'facebook-jssdk'));</script>
 
-    <div class="fb-share-button" style="vertical-align: middle; bottom: 6px;margin-right:10px"
+    <div class="fb-share-button" style="display:flex;margin-right:10px;"
     data-layout="button"
     data-size="small" data-mobile-iframe="true"><a target="_blank"
     href="https://www.facebook.com/sharer"
@@ -25,6 +25,5 @@
 <style>
 .tweet{
   position: relative;
-  vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
Fixes #8431 Social media sharing pills misaligned in sidebar

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [X] ask `@publiclab/reviewers` for help, in a comment below

The styles in the social buttons have been updated. The button misalignment has been fixed. Buttons are in a single row as per the discussion on the issue thread. I am attaching the screens for the same (on firefox - 78.0.2). Tested on chrome - 85.0.4183.121, firefox and Chromium
![Screenshot from 2020-10-10 12-02-41](https://user-images.githubusercontent.com/38653376/95648133-8d110b80-0af2-11eb-8c97-b24d3fe986e3.png)

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
