### PR TITLE
Avoid  error msg double-render

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,7 @@ class ApplicationController < ActionController::Base
       flash.now[:warning] = "This is a draft note. Once you're ready, click <a class='btn btn-success btn-xs' href='/notes/publish_draft/#{@node.id}'>Publish Draft</a> to make it public. You can share it with collaborators using this private link <a href='#{@node.draft_url(request.base_url)}'>#{@node.draft_url(request.base_url)}</a>"
     elsif @node.status == 3 && (params[:token].nil? || (params[:token].present? && @node.slug.split('token:').last != params[:token]))
       page_not_found
-    elsif @node.status != 1 && @node.status != 3 && !(logged_in_as(['admin', 'moderator']))
+    elsif @node.status != 1 && @node.status != 3 && current_user&.id != @node.author.id && !(logged_in_as(['admin', 'moderator']))
       # if it's spam or a draft
       # no notification; don't let people easily fish for existing draft titles; we should try to 404 it
       redirect_to '/'

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -128,6 +128,7 @@ class NotesController < ApplicationController
         flash[:notice] = thanks_for_question
 
       elsif not_draft_and_user_is_first_time_poster?
+        flash[:first_time_post] = true
         thanks_for_contribution = I18n.t('notes_controller.thank_you_for_contribution').html_safe
         flash[:notice] = thanks_for_contribution
 


### PR DESCRIPTION
Fixes #8595   (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
