### PR TITLE
Update application_controller.rb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,7 @@ class ApplicationController < ActionController::Base
       flash.now[:warning] = "This is a draft note. Once you're ready, click <a class='btn btn-success btn-xs' href='/notes/publish_draft/#{@node.id}'>Publish Draft</a> to make it public. You can share it with collaborators using this private link <a href='#{@node.draft_url(request.base_url)}'>#{@node.draft_url(request.base_url)}</a>"
     elsif @node.status == 3 && (params[:token].nil? || (params[:token].present? && @node.slug.split('token:').last != params[:token]))
       page_not_found
-    elsif @node.status != 1 && @node.status != 3 && !(logged_in_as(['admin', 'moderator']))
+    elsif @node.status != 1 && @node.status != 3 && current_user&.id != @node.author.id && !(logged_in_as(['admin', 'moderator']))
       # if it's spam or a draft
       # no notification; don't let people easily fish for existing draft titles; we should try to 404 it
       redirect_to '/'


### PR DESCRIPTION
Fix #8595

removed 
```
elsif @node.status != 1 && @node.status != 3 && !(logged_in_as(['admin', 'moderator']))
```
replaced with
```
elsif @node.status != 1 && @node.status != 3 && current_user&.id != @node.author.id && !(logged_in_as(['admin', 'moderator']))
```