### PR TITLE
Fixes #6173. Powertag pages for activity () can use the "value" of their key:value pair

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -77,8 +77,7 @@ class TagController < ApplicationController
     if params[:id].is_a? Integer
       @wiki = Node.find(params[:id])&.first
     elsif params[:id].match?(":")
-      tagname = params[:id].match('[^:]*$')
-      @wiki = Node.where(slug: tagname.to_s).try(:first)
+      @wiki = Node.where(slug: params[:id].match('[^:]*$').to_s).try(:first)
     else
       @wiki = Node.where(path: "/wiki/#{params[:id]}").try(:first) || Node.where(path: "/#{params[:id]}").try(:first)
       @wiki = Node.where(slug: @wiki.power_tag('redirect'))&.first if @wiki&.has_power_tag('redirect') # use a redirected wiki page if it exists

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -76,9 +76,9 @@ class TagController < ApplicationController
   def show
     if params[:id].is_a? Integer
       @wiki = Node.find(params[:id])&.first
-    elsif params[:id].match(':')
+    elsif params[:id] =~ /:/
       tagname = params[:id].match('[^:]*$')
-      @wiki = Node.where(slug: "#{tagname}").try(:first)
+      @wiki = Node.where(slug: tagname.to_s).try(:first)
     else
       @wiki = Node.where(path: "/wiki/#{params[:id]}").try(:first) || Node.where(path: "/#{params[:id]}").try(:first)
       @wiki = Node.where(slug: @wiki.power_tag('redirect'))&.first if @wiki&.has_power_tag('redirect') # use a redirected wiki page if it exists

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -76,7 +76,7 @@ class TagController < ApplicationController
   def show
     if params[:id].is_a? Integer
       @wiki = Node.find(params[:id])&.first
-    elsif params[:id] =~ /:/
+    elsif params[:id].match?(":")
       tagname = params[:id].match('[^:]*$')
       @wiki = Node.where(slug: tagname.to_s).try(:first)
     else

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -76,6 +76,9 @@ class TagController < ApplicationController
   def show
     if params[:id].is_a? Integer
       @wiki = Node.find(params[:id])&.first
+    elsif params[:id].match(':')
+      tagname = params[:id].match('[^:]*$')
+      @wiki = Node.where(slug: "#{tagname}").try(:first)
     else
       @wiki = Node.where(path: "/wiki/#{params[:id]}").try(:first) || Node.where(path: "/#{params[:id]}").try(:first)
       @wiki = Node.where(slug: @wiki.power_tag('redirect'))&.first if @wiki&.has_power_tag('redirect') # use a redirected wiki page if it exists


### PR DESCRIPTION
Fixes #6173

From the issue:
> This situation is where there's a power tag in the form `key:value` where `value` already has a dedicated wiki page.
> 
> In your example, you are showing the tag page for the powertag `activity:translation`. There is a page publiclab.org/wiki/translation, so the `activity:translation` card should:
> 
> 1. pull the preview text from publiclab.org/wiki/translation, same as publiclab.org/tag/translation does.
> 2. display a "Learn more" button that links to /wiki/translation instead of "Add a description" button that leads to an editor for creating a new wiki page.
> 3. pull the lead image from /wiki/translation same as /tag/translation does
> 4. Remain labelled on the card as `activity:translation`



For now, 1 and 2 works.
![Screen Shot 2020-10-19 at 11 16 05 PM](https://user-images.githubusercontent.com/4979096/96547523-19dd6700-1261-11eb-9f90-581f7462b71d.png)
