### PR TITLE
Update notify_node_creation, checks for empty tag

### DIFF
--- a/app/views/subscription_mailer/notify_node_creation.html.erb
+++ b/app/views/subscription_mailer/notify_node_creation.html.erb
@@ -16,9 +16,10 @@
 
 <div style="color:#aaa;">
 
-<p>You received this email because you are subscribed to some or all of the following tags: <%= @tags %>.</p>
-
-<p>Subscribe to all the tags for this post by visiting https://<%= ActionMailer::Base.default_url_options[:host] %>/subscribe/multiple/tag/<%= @tags %>.</p>
+<% unless @tags.empty? %>
+  <p>You received this email because you are subscribed to some or all of the following tags: <%= @tags %>.</p>
+  <p>Subscribe to all the tags for this post by visiting https://<%= ActionMailer::Base.default_url_options[:host] %>/subscribe/multiple/tag/<%= @tags %>.</p>
+<% end %>
 
 <p>To change your preferences, please visit https://<%= ActionMailer::Base.default_url_options[:host] %>/subscriptions.</p>
 


### PR DESCRIPTION
The update lets us check for empty tags with `@tag.empty?`

Fixes #8682 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
