### PR TITLE
Return helpful error message when attempting to login/signup w Twitter oauth with no email

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -89,9 +89,17 @@ class UserSessionsController < ApplicationController
           elsif params[:return_to] && params[:return_to].split('/')[0..3] == ["", "subscribe", "multiple", "tag"]
             flash[:notice] = "You are now following '#{params[:return_to].split('/')[4]}'."
             subscribe_multiple_tag(params[:return_to].split('/')[4])
-            redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            if user.email
+              redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            else
+              redirect_to '/dashboard', notice: "You have successfully signed in. Please add an email address and change your password from the Edit Profile menu item."
+            end
           else
-            redirect_to "/dashboard", notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            if user.email
+              redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            else
+              redirect_to '/dashboard', notice: "You have successfully signed in. Please add an email address and change your password from the Edit Profile menu item."
+            end
           end
         else # email exists so link the identity with existing user and log in the user
           user = User.where(email: auth["info"]["email"])

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -50,7 +50,7 @@ class UserSessionsController < ApplicationController
         redirect_to return_to + hash_params, notice: "Already linked to another account!"
       end
     else # not signed in
-      if auth["info"]["email"].empty?
+      if auth["info"]["email"].nil?
         flash[:error] = "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!"
         redirect_to return_to
       else

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -50,73 +50,70 @@ class UserSessionsController < ApplicationController
         redirect_to return_to + hash_params, notice: "Already linked to another account!"
       end
     else # not signed in
-      # User U has Provider P linked to U. U has email E1 while P has email E2. So, User table can't find E2 provided
-      # from auth hash, hence U is found by the user of identity having E2 as email
-      @user = User.where(email: auth["info"]["email"]) ? User.find_by(email: auth["info"]["email"]) : @identity.user
-      if @user&.status&.zero?
-        flash[:error] = I18n.t('user_sessions_controller.user_has_been_banned', username: @user.username).html_safe
-        redirect_to return_to + hash_params
-      elsif @user&.status == 5
-        flash[:error] = I18n.t('user_sessions_controller.user_has_been_moderated', username: @user.username).html_safe
-        redirect_to return_to + hash_params
-      elsif @identity&.user.present?
-        # The identity we found had a user associated with it so let's
-        # just log them in here
-        @user = @identity.user
-        @user_session = UserSession.create(@identity.user)
-        if session[:openid_return_to] # for openid login, redirects back to openid auth process
-          return_to = session[:openid_return_to]
-          session[:openid_return_to] = nil
+      if auth["info"]["email"].empty?
+        flash[:error] = "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!"
+        redirect_to return_to
+      else
+        # User U has Provider P linked to U. U has email E1 while P has email E2. So, User table can't find E2 provided
+        # from auth hash, hence U is found by the user of identity having E2 as email
+        @user = User.where(email: auth["info"]["email"]) ? User.find_by(email: auth["info"]["email"]) : @identity.user
+        if @user&.status&.zero?
+          flash[:error] = I18n.t('user_sessions_controller.user_has_been_banned', username: @user.username).html_safe
           redirect_to return_to + hash_params
-        else
-          redirect_to return_to + hash_params, notice: I18n.t('user_sessions_controller.logged_in')
-        end
-      else # identity does not exist so we need to either create a user with identity OR link identity to existing user
-        if User.where(email: auth["info"]["email"]).empty?
-          # Create a new user as email provided is not present in PL database
-          user = User.create_with_omniauth(auth)
-          WelcomeMailer.notify_newcomer(user).deliver_now
-          @identity = UserTag.create_with_omniauth(auth, user.id)
-          key = user.generate_reset_key
+        elsif @user&.status == 5
+          flash[:error] = I18n.t('user_sessions_controller.user_has_been_moderated', username: @user.username).html_safe
+          redirect_to return_to + hash_params
+        elsif @identity&.user.present?
+          # The identity we found had a user associated with it so let's
+          # just log them in here
+          @user = @identity.user
           @user_session = UserSession.create(@identity.user)
-          @user = user
-          # send key to user email
-          PasswordResetMailer.reset_notify(user, key).deliver_now unless user.nil? # respond the same to both successes and failures; security
           if session[:openid_return_to] # for openid login, redirects back to openid auth process
             return_to = session[:openid_return_to]
             session[:openid_return_to] = nil
             redirect_to return_to + hash_params
-          elsif params[:return_to] && params[:return_to].split('/')[0..3] == ["", "subscribe", "multiple", "tag"]
-            flash[:notice] = "You are now following '#{params[:return_to].split('/')[4]}'."
-            subscribe_multiple_tag(params[:return_to].split('/')[4])
-            if user.email
-              redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
-            else
-              redirect_to '/dashboard', notice: "You have successfully signed in. Please add an email address and change your password from the Edit Profile menu item."
-            end
           else
-            if user.email
-              redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
-            else
-              redirect_to '/dashboard', notice: "You have successfully signed in. Please add an email address and change your password from the Edit Profile menu item."
-            end
+            redirect_to return_to + hash_params, notice: I18n.t('user_sessions_controller.logged_in')
           end
-        else # email exists so link the identity with existing user and log in the user
-          user = User.where(email: auth["info"]["email"])
-          # If no identity was found, create a brand new one here
-          @identity = UserTag.create_with_omniauth(auth, user.ids.first)
-          # The identity is not associated with the current_user so lets
-          # associate the identity
-          @identity.save
-          @user = user
-          # log in them
-          @user_session = UserSession.create(@identity.user)
-          if session[:openid_return_to] # for openid login, redirects back to openid auth process
-            return_to = session[:openid_return_to]
-            session[:openid_return_to] = nil
-            redirect_to return_to + hash_params
-          else
-            redirect_to return_to + hash_params, notice: "Successfully linked to your account!"
+        else # identity does not exist so we need to either create a user with identity OR link identity to existing user
+          if User.where(email: auth["info"]["email"]).empty?
+            # Create a new user as email provided is not present in PL database
+            user = User.create_with_omniauth(auth)
+            WelcomeMailer.notify_newcomer(user).deliver_now
+            @identity = UserTag.create_with_omniauth(auth, user.id)
+            key = user.generate_reset_key
+            @user_session = UserSession.create(@identity.user)
+            @user = user
+            # send key to user email
+            PasswordResetMailer.reset_notify(user, key).deliver_now unless user.nil? # respond the same to both successes and failures; security
+            if session[:openid_return_to] # for openid login, redirects back to openid auth process
+              return_to = session[:openid_return_to]
+              session[:openid_return_to] = nil
+              redirect_to return_to + hash_params
+            elsif params[:return_to] && params[:return_to].split('/')[0..3] == ["", "subscribe", "multiple", "tag"]
+              flash[:notice] = "You are now following '#{params[:return_to].split('/')[4]}'."
+              subscribe_multiple_tag(params[:return_to].split('/')[4])
+              redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            else
+              redirect_to '/dashboard', notice: "You have successfully signed in. Please change your password using the link sent to you via e-mail."
+            end
+          else # email exists in user db so link the identity with existing user and log in the user
+            user = User.where(email: auth["info"]["email"])
+            # If no identity was found, create a brand new one here
+            @identity = UserTag.create_with_omniauth(auth, user.ids.first)
+            # The identity is not associated with the current_user so lets
+            # associate the identity
+            @identity.save
+            @user = user
+            # log in them
+            @user_session = UserSession.create(@identity.user)
+            if session[:openid_return_to] # for openid login, redirects back to openid auth process
+              return_to = session[:openid_return_to]
+              session[:openid_return_to] = nil
+              redirect_to return_to + hash_params
+            else
+              redirect_to return_to + hash_params, notice: "Successfully linked to your account!"
+            end
           end
         end
       end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -194,7 +194,7 @@ Rails.application.configure do
   
   
   # Twitter Provider with no email provided
-  OmniAuth.config.mock_auth[:twitter1] = OmniAuth::AuthHash.new({
+  OmniAuth.config.mock_auth[:twitter_no_email] = OmniAuth::AuthHash.new({
       'provider' => 'twitter',
       'uid' => '135798079602',
       'info' => {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -191,4 +191,14 @@ Rails.application.configure do
         'email' => 'bob@publiclab.org'
       }
     }) 
+  
+  
+  # Twitter Provider with no email provided
+  OmniAuth.config.mock_auth[:twitter1] = OmniAuth::AuthHash.new({
+      'provider' => 'twitter',
+      'uid' => '135798079602',
+      'info' => {
+        'name' => 'jeff with no email',
+      }
+    })
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,7 +1,7 @@
 bob:
   username: Bob
   status: 1
-  email: bob@publiclab.org
+  email: ''
   id: 1
   password_salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,7 +1,7 @@
 bob:
   username: Bob
   status: 1
-  email: ''
+  email: 'bob@publiclab.org'
   id: 1
   password_salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -178,7 +178,9 @@ class UserSessionsControllerTest < ActionController::TestCase
       assert_not_nil request.env['omniauth.auth']
       #Sign Up for a new user
       assert_difference 'User.count', 0 do
-        post :create
+        assert_difference 'UserSession.count', 0 do
+          post :create
+        end
       end
       assert_equal "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!",  flash[:error]
     end

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -154,75 +154,74 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_equal "Successfully logged out.",  flash[:notice]
   end
 
+  test 'sign up and login via provider basic flow for twitter' do
+    assert_not_nil OmniAuth.config.mock_auth[:twitter1]
+    #Omniauth hash is present
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter1]
+    assert_not_nil request.env['omniauth.auth']
+    #Sign Up for a new user
+    post :create
+    assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
+    #Log Out
+    post :destroy
+    assert_equal "Successfully logged out.",  flash[:notice]
+    #auth hash is present so login via a provider
+    post :create
+    assert_equal "Successfully logged in.",  flash[:notice]
+  end
 
-    test 'sign up and login via provider basic flow for twitter' do
-      assert_not_nil OmniAuth.config.mock_auth[:twitter1]
-      #Omniauth hash is present
-      request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter1]
-      assert_not_nil request.env['omniauth.auth']
-      #Sign Up for a new user
+  test 'sign up and login via provider basic flow for twitter user with no email' do
+    assert_not_nil OmniAuth.config.mock_auth[:twitter_no_email]
+    #Omniauth hash is present
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter_no_email]
+    assert_not_nil request.env['omniauth.auth']
+    #Sign Up for a new user
+    session[:user_session].should be_nil
+    assert_difference 'User.count', 0 do
       post :create
-      assert_equal "You have successfully signed in. Please change your password using the link sent to you via e-mail.",  flash[:notice]
-      #Log Out
-      post :destroy
-      assert_equal "Successfully logged out.",  flash[:notice]
-      #auth hash is present so login via a provider
-      post :create
-      assert_equal "Successfully logged in.",  flash[:notice]
     end
-  
-    test 'sign up and login via provider basic flow for twitter user with no email' do
-      assert_not_nil OmniAuth.config.mock_auth[:twitter_no_email]
-      #Omniauth hash is present
-      request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter_no_email]
-      assert_not_nil request.env['omniauth.auth']
-      #Sign Up for a new user
-      assert_difference 'User.count', 0 do
-        assert_difference 'UserSession.count', 0 do
-          post :create
-        end
-      end
-      assert_equal "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!",  flash[:error]
-    end
+    session[:user_session].should be_nil
+    assert_equal "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!",  flash[:error]
+  end
 
-    test 'sign up and login via provider alternative flow for twitter' do
-      assert_not_nil OmniAuth.config.mock_auth[:twitter2]
-      #Omniauth hash is present
-      request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter2]
-      assert_not_nil request.env['omniauth.auth']
-      #Sign Up for an existing user as email exists in the db
-      post :create
-      assert_equal "Successfully linked to your account!",  flash[:notice]
-      #Log Out
-      post :destroy
-      assert_equal "Successfully logged out.",  flash[:notice]
-      #auth hash is present so login via a provider
-      post :create
-      assert_equal "Successfully logged in.",  flash[:notice]
-    end
+  test 'sign up and login via provider alternative flow for twitter' do
+    assert_not_nil OmniAuth.config.mock_auth[:twitter2]
+    #Omniauth hash is present
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter2]
+    assert_not_nil request.env['omniauth.auth']
+    #Sign Up for an existing user as email exists in the db
+    post :create
+    assert_equal "Successfully linked to your account!",  flash[:notice]
+    #Log Out
+    post :destroy
+    assert_equal "Successfully logged out.",  flash[:notice]
+    #auth hash is present so login via a provider
+    post :create
+    assert_equal "Successfully logged in.",  flash[:notice]
+  end
 
-    test 'login user with an email and then contwitter provider' do
-      post :create,
-         params: {
-          user_session: {
-          username: users(:jeff).email,
-          password: 'secretive'
-          }
-         }
-      assert_redirected_to '/dashboard'
-      assert_not_nil OmniAuth.config.mock_auth[:twitter2]
-      #Omniauth hash is present
-      request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter2]
-      assert_not_nil request.env['omniauth.auth']
-      #Link a twitter account to an existing user
-      post :create
-      assert_equal "Successfully linked to your account!",  flash[:notice]
-      #Link same twitter account to an existing user again
-      post :create
-      assert_equal "Already linked to your account!",  flash[:notice]
-      #Log Out
-      post :destroy
-      assert_equal "Successfully logged out.",  flash[:notice]
+  test 'login user with an email and then contwitter provider' do
+    post :create,
+       params: {
+        user_session: {
+        username: users(:jeff).email,
+        password: 'secretive'
+        }
+       }
+    assert_redirected_to '/dashboard'
+    assert_not_nil OmniAuth.config.mock_auth[:twitter2]
+    #Omniauth hash is present
+    request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter2]
+    assert_not_nil request.env['omniauth.auth']
+    #Link a twitter account to an existing user
+    post :create
+    assert_equal "Successfully linked to your account!",  flash[:notice]
+    #Link same twitter account to an existing user again
+    post :create
+    assert_equal "Already linked to your account!",  flash[:notice]
+    #Log Out
+    post :destroy
+    assert_equal "Successfully logged out.",  flash[:notice]
   end
 
   test 'sign up and login via provider basic flow for facebook' do

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -176,11 +176,11 @@ class UserSessionsControllerTest < ActionController::TestCase
     request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter_no_email]
     assert_not_nil request.env['omniauth.auth']
     #Sign Up for a new user
-    session[:user_session].should be_nil
+    assert_nil session[:user_session]
     assert_difference 'User.count', 0 do
       post :create
     end
-    session[:user_session].should be_nil
+    assert_nil session[:user_session]
     assert_equal "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!",  flash[:error]
   end
 

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -177,14 +177,10 @@ class UserSessionsControllerTest < ActionController::TestCase
       request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter_no_email]
       assert_not_nil request.env['omniauth.auth']
       #Sign Up for a new user
-      post :create
-      assert_equal "You have successfully signed in. Please change your password by editing your profile in the upper right menu.",  flash[:notice]
-      #Log Out
-      post :destroy
-      assert_equal "Successfully logged out.",  flash[:notice]
-      #auth hash is present so login via a provider
-      post :create
-      assert_equal "Successfully logged in.",  flash[:notice]
+      assert_difference 'User.count', 0 do
+        post :create
+      end
+      assert_equal "You have tried using a Twitter account with no associated email address. Unfortunately we need an email address; please add one and try again, or sign up a different way. Thank you!",  flash[:error]
     end
 
     test 'sign up and login via provider alternative flow for twitter' do

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -170,6 +170,22 @@ class UserSessionsControllerTest < ActionController::TestCase
       post :create
       assert_equal "Successfully logged in.",  flash[:notice]
     end
+  
+    test 'sign up and login via provider basic flow for twitter user with no email' do
+      assert_not_nil OmniAuth.config.mock_auth[:twitter_no_email]
+      #Omniauth hash is present
+      request.env['omniauth.auth'] =  OmniAuth.config.mock_auth[:twitter_no_email]
+      assert_not_nil request.env['omniauth.auth']
+      #Sign Up for a new user
+      post :create
+      assert_equal "You have successfully signed in. Please change your password by editing your profile in the upper right menu.",  flash[:notice]
+      #Log Out
+      post :destroy
+      assert_equal "Successfully logged out.",  flash[:notice]
+      #auth hash is present so login via a provider
+      post :create
+      assert_equal "Successfully logged in.",  flash[:notice]
+    end
 
     test 'sign up and login via provider alternative flow for twitter' do
       assert_not_nil OmniAuth.config.mock_auth[:twitter2]


### PR DESCRIPTION
Fixes #8325 with a test - we may need to remove `uid` as well!

## Part 1

We need to modify this logic to account for not having a Twitter email:

Both of these pathways could lead to this same error: 

https://github.com/publiclab/plots2/blob/c60aaabb56c018962c76abf3f5f2d114f8492d15/app/controllers/user_sessions_controller.rb#L75-L99

And if there's no email provided, perhaps we should divert away here too:

https://github.com/publiclab/plots2/blob/c60aaabb56c018962c76abf3f5f2d114f8492d15/app/controllers/user_sessions_controller.rb#L52-L56

I think this section should divert to the final `else` if there is no email in the provided Twitter response.

## Part 2

We then should try solving for the scenario with the allocator undefined for Proc error from #8325:

> if `create(value: "oauth:" + auth['provider'] + ":" + auth['uid'], uid: uid, data: auth.to_hash)` fails, maybe it's the non-existence of auth['uid'] OR it could be the .to_hash and it's failing to hash something that is too complex to hash? That might be a more subtle one.

https://github.com/publiclab/plots2/blob/4b2e5321de6cc0c2341535b722722c1bfa1804f0/app/models/user_tag.rb#L25-L28