### PR TITLE
8765: Move flag-node button outside the admin-only zone in menu.

### DIFF
--- a/app/views/like/_like.html.erb
+++ b/app/views/like/_like.html.erb
@@ -74,14 +74,15 @@
           </a></p>
         <% end %>
 
+        <a rel='tooltip' title='Flag as spam' class='btn btn-sm btn-outline-secondary btn-flag-spam-<%= node.id %>' href='/moderate/flag_node/<%= node.id %>'>
+          <i class='fa fa-flag'></i>
+        </a>
+
         <% if logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == node.uid) %>
 
             <hr />
 
             <div class='btn-group'>
-                <a rel='tooltip' title='Flag as spam' class='btn btn-sm btn-outline-secondary btn-flag-spam-<%= node.id %>' href='/moderate/flag_node/<%= node.id %>'>
-                    <i class='fa fa-flag'></i>
-                </a>
                 <li data-toggle='tooltip' data-placement='top' title='Follow by tag or author' id='menu-follow-btn' class='btn btn-outline-secondary btn-sm requireLogin nestedPopover' data-html='true' rel='popover' data-placement='left' data-content=&quot;    <%= "No tags" if tagnames.nil? || tagnames.size == 0 %>    <% if tagnames %><% tagnames.each do |tagname| %><p style='margin-bottom:3px; overflow: hidden; text-overflow: ellipsis;'><a href='/subscribe/tag/<%= tagname %>' class='btn btn-outline-secondary btn-sm'><%= tagname %></a></p><% end %><% end %><hr /><i class='fa fa-user'></i><% if current_user && !current_user.following?(node.author) && node.author != current_user %>&nbsp;<a class='btn btn-sm' href='/relationships?followed_id=<%= node.author.id %>' data-method='post' > <%= node.author.name %></a><% else %>  &nbsp;<%= node.author.name %><% end %>&quot;>
                     <i class='fa fa-user-plus' aria-hidden='true'></i>
                 </li>


### PR DESCRIPTION
This commit moves the flag-node button outside of the
admin-only zone in menu per the diff on the request

Fixes #8765  (<=== Add issue number here)
[Issue #8765 ](https://github.com/publiclab/plots2/issues/8765)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
