### PR TITLE
Remove TimeCop from the tag_selection_test

### DIFF
--- a/test/unit/tag_selection_test.rb
+++ b/test/unit/tag_selection_test.rb
@@ -3,16 +3,15 @@ require 'test_helper'
 class TagSelectionTest < ActiveSupport::TestCase
 
   test 'graph' do
-    Time.zone.now.change(nsec: 0)
-    Timecop.freeze
+    end_time = Time.now
+    start_time = end_time - 1.year
     ts_count = TagSelection.select(:following, :created_at)
-      .where(following: true, created_at: (Time.now - 1.year..Time.now))
+      .where(following: true, created_at: (start_time..end_time))
       .count
 
-    graph = TagSelection.graph(Time.now - 1.year, Time.now)
+    graph = TagSelection.graph(start_time, end_time)
 
     assert_equal ts_count, graph.values.sum
     assert_equal Hash, graph.class
-    Timecop.return
   end
 end


### PR DESCRIPTION
By setting the date with Time.now just once we remove the need for
freezing time within the spec. Now the dates used are always consistent
with each other.

Fixes #8401 
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in a uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation N/A
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
