### PR TITLE
[Comment Editor #8775] System Test: Synchronous Comment from Question Page via JS + URL

### DIFF
--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -261,3 +261,10 @@ organizers-chapter:
   nid: 5
   date: <%= DateTime.now.to_i %>
 
+# this tags node 37 as a question
+# ultimately, this is for testing comments on that node.
+question4:
+  tid: 35
+  uid: 2
+  nid: 37
+  date: <%= DateTime.now.to_i %>

--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -445,3 +445,15 @@ sun_question:
   type: "note"
   cached_likes: 0
   slug: "note-tagged-with-question-sun"
+
+question4: # fresh question fixture for testing comments on question pages
+  nid: 37
+  uid: 2
+  title: "Can I post comments here"
+  path: "/notes/jeff/12-07-2020/can-i-post-comments-here"
+  created: <%= DateTime.new(2020,12,7).to_i %>
+  changed: <%= DateTime.new(2020,12,7).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: jeff-12-07-2020-can-i-post-comments-here

--- a/test/fixtures/revisions.yml
+++ b/test/fixtures/revisions.yml
@@ -402,3 +402,11 @@ sun_question:
   body: "This is the body"
   timestamp: <%= DateTime.new(2020,2,12).to_i %>
   status: 1
+
+question4: # fresh question fixture for testing comments on question pages
+  nid: 37
+  uid: 2
+  title: "Can I post comments here"
+  body: "I'm gonna do it"
+  timestamp: <%= DateTime.new(2020,12,7).to_i %>
+  status: 1

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -136,3 +136,9 @@ sunny_day:
 sun_question:
   tid: 34
   name: question:sun
+
+# this tags node 37 as a question
+# ultimately, this is for testing comments on that node.
+question4: 
+  tid: 35
+  name: question:general

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -71,6 +71,13 @@ class CommentTest < ApplicationSystemTestCase
     find("p", text: "Awesome Reply")
   end
 
+  test 'question page: add synchronous comment via javascript with URL only' do
+    # questions: the comment form points toward /comment/create/{node ID}?type=question.
+    visit "/wiki/wiki-page-path/comments"
+    page.evaluate_script("addComment('superhero', '/comment/create/11?type=question')")
+    assert_selector('#comments-list .comment-body p', text: 'superhero')
+  end
+
   test 'comment preview button' do
     visit "/wiki/wiki-page-path/comments"
 

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -72,10 +72,9 @@ class CommentTest < ApplicationSystemTestCase
   end
 
   test 'question page: add synchronous comment via javascript with URL only' do
-    # questions: the comment form points toward /comment/create/{node ID}?type=question.
-    visit "/wiki/wiki-page-path/comments"
-    page.evaluate_script("addComment('superhero', '/comment/create/11?type=question')")
-    assert_selector('#comments-list .comment-body p', text: 'superhero')
+    visit "/questions/jeff/12-07-2020/can-i-post-comments-here"
+    page.evaluate_script("addComment('yes you can', '/comment/create/37')")
+    assert_selector('#comments-list .comment-body p', text: 'yes you can')
   end
 
   test 'comment preview button' do

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -359,7 +359,7 @@ class NodeTest < ActiveSupport::TestCase
 
   test 'should find all questions' do
     questions = Node.questions
-    expected = [nodes(:question), nodes(:question2), nodes(:first_timer_question), nodes(:question3), nodes(:sun_question)]
+    expected = [nodes(:question), nodes(:question2), nodes(:first_timer_question), nodes(:question3), nodes(:sun_question), nodes(:question4)]
     assert_equal expected, questions
   end
 


### PR DESCRIPTION
This is a draft PR, I'm not there yet. Feedback very welcome as I'm learning a lot about `plots2`, and a lot else.

This adds a single new system test, testing for "User adds comment to a question page." In particular, this tests for commenting via `addComment(URL)` (a JS method that seemingly comes with comment forms). 

In my understanding, question pages seem to reuse the same form partial (below) that other nodes (wikis, notes) use. A crucial difference for question comments is that a `?type=question` parameter is added to the AJAX request URL. So that's the difference in this test:
https://github.com/publiclab/plots2/blob/cbb807ba8e2302f09dafc0060475aa118e34c2c6/app/views/comments/_form.html.erb#L3

**Point of Concern**
The other comment tests in `comment_test.rb` are testing comments on the page `/wiki/wiki-page-path/comments`. `wiki-page-path` seems to be a dummy article that exists only in the testing environment. It doesn't exist in development locally, nor in production at publiclab.org (navigating to `https://site + /wiki/wiki-page-path` 404s at both).

![failures_test_add_comment_to_question_page_via_javascript_with_url_only](https://user-images.githubusercontent.com/4361605/101311087-7858a780-3805-11eb-8232-589234de55e4.png)

**My concern is that this test should probably be testing on an actual question page** (`/question/{id-as-string}/comments`, or the equivalent). However, I don't know what the testing convention is. 

- How is `wiki-page-path` generated? Is it seeded into the development database somehow? 
- Is there a way to make a similar question page for testing purposes? (Or for that matter, a note, which we also need tests for)
- There are tests for posting a new question from scratch in `post_question_test.rb`, it seems a little bit involved though:
https://github.com/publiclab/plots2/blob/cbb807ba8e2302f09dafc0060475aa118e34c2c6/test/system/post_question_test.rb#L23-L71 What's more preferable: generating something like `wiki-page-path` or creating a new question from scratch in the test, and posting the comment to it?

(This PR is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context)