### PR TITLE
[Comment Editor] New Test: Comment on Notes with addComment Script

### DIFF
--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -445,3 +445,15 @@ sun_question:
   type: "note"
   cached_likes: 0
   slug: "note-tagged-with-question-sun"
+
+comment_note: # for testing comments on notes
+  nid: 38
+  uid: 2
+  title: "Please don't comment here"
+  path: "/notes/jeff/12-08-2020/please-don-t-comment-here"
+  created: <%= DateTime.new(2020,12,8).to_i %>
+  changed: <%= DateTime.new(2020,12,8).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: "note-please-don-t-comment-here"

--- a/test/fixtures/revisions.yml
+++ b/test/fixtures/revisions.yml
@@ -402,3 +402,11 @@ sun_question:
   body: "This is the body"
   timestamp: <%= DateTime.new(2020,2,12).to_i %>
   status: 1
+
+comment_note: # for testing comments on notes
+  nid: 38
+  uid: 2
+  title: "Please don't comment here"
+  body: "I beg you, please"
+  timestamp: <%= DateTime.new(2020,12,8).to_i %>
+  status: 1

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -368,7 +368,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal 27, selector.size
+    assert_equal 28, selector.size
     assert_select "div p", 'Pending approval by community moderators. Please be patient!'
   end
 
@@ -397,7 +397,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal 27, selector.size
+    assert_equal 28, selector.size
     assert_select 'a[data-test="spam"]','Spam'
   end
 

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -15,7 +15,7 @@ class CommentTest < ApplicationSystemTestCase
     find(".login-modal-form #login-button").click()
   end
 
-  test 'adding a comment via javascript' do
+  test 'wiki: comment via JavaScript, with comment body ONLY' do
     visit "/wiki/wiki-page-path/comments"
 
     # run the javascript function
@@ -25,7 +25,7 @@ class CommentTest < ApplicationSystemTestCase
     assert_selector('#comments-list .comment-body p', text: 'fantastic four')
   end
 
-  test 'adding a comment via javascript with url only' do
+  test 'wiki: comment via JavaScript, with comment body + URL' do
     visit "/wiki/wiki-page-path/comments"
 
     # run the javascript function
@@ -35,7 +35,7 @@ class CommentTest < ApplicationSystemTestCase
     assert_selector('#comments-list .comment-body p', text: 'superhero')
   end
 
-  test 'adding a reply comment via javascript with url only' do
+  test 'wiki: reply to comment via JavaScript with comment body + URL' do
     visit "/wiki/wiki-page-path/comments"
 
     # run the javascript function
@@ -47,7 +47,13 @@ class CommentTest < ApplicationSystemTestCase
     assert_selector("#{parentid} .comment .comment-body p", text: 'batman')
   end
 
-  test "add a comment manually" do
+  test 'note: comment via JavaScript, with comment body + URL' do
+    visit nodes(:comment_note).path
+    page.evaluate_script("addComment('hahaha', '/comment/create/38')")
+    assert_selector('#comments-list .comment-body p', text: 'hahaha')
+  end
+
+  test "note: comment manually" do
     visit nodes(:one).path
 
     fill_in("body", with: "Awesome comment! :)")

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -349,7 +349,7 @@ class NodeTest < ActiveSupport::TestCase
                 nodes(:draft), nodes(:post_test1), nodes(:post_test2),
                 nodes(:post_test3), nodes(:post_test4), nodes(:scraped_image), nodes(:search_trawling),
                 nodes(:purple_air_without_hyphen), nodes(:purple_air_with_hyphen),
-                nodes(:sun_note), nodes(:sunny_day_note)]
+                nodes(:sun_note), nodes(:sunny_day_note), nodes(:comment_note)]
     assert_equal expected, notes
   end
 


### PR DESCRIPTION
Not to be confused with my other current PR, #8801, which adds a new test for Question pages. Please review that one first, it has more extensive write-up!

This test was fairly straightforward to write compared to questions.

I renamed some of the tests to distinguish between notes, questions, and the old tests for commenting on wiki pages.

I simulated a new note in the fixtures for testing comments:

**nodes.yml**
```
comment_note: # for testing comments on notes
  nid: 38
  uid: 2
  title: "Please don't comment here"
  path: "/notes/jeff/12-08-2020/please-don-t-comment-here"
  created: <%= DateTime.new(2020,12,8).to_i %>
  changed: <%= DateTime.new(2020,12,8).to_i %>
  status: 1
  type: "note"
  cached_likes: 0
  slug: "note-please-don-t-comment-here"
```

**revisions.yml**
```
comment_note: # for testing comments on notes
  nid: 38
  uid: 2
  title: "Please don't comment here"
  body: "I beg you, please"
  timestamp: <%= DateTime.new(2020,12,8).to_i %>
  status: 1
```

The test:
```
test 'note: comment via JavaScript, with comment body + URL' do
  visit nodes(:comment_note).path
  page.evaluate_script("addComment('hahaha', '/comment/create/38')")
  assert_selector('#comments-list .comment-body p', text: 'hahaha')
end
```

(This PR is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context)