### PR TITLE
Hotfix for email sending in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,10 +69,10 @@ Plots2::Application.configure do
   config.action_mailer.smtp_settings = {
   :address => ENV["SMTP_HOST"] || "smtp",
   :port => ENV["SMTP_PORT"] || 25,
-  :user_name => ENV["SMTP_USER"] || '',
-  :password => ENV["SMTP_PASS"] || '',
-  :authentication => ENV["SMTP_AUTH"] || '',
-  :enable_starttls_auto =>  ENV["SMTP_STLS"] || false
+  #:user_name => ENV["SMTP_USER"] || '',
+  #:password => ENV["SMTP_PASS"] || '',
+  #:authentication => ENV["SMTP_AUTH"] || '',
+  #:enable_starttls_auto =>  ENV["SMTP_STLS"] || false
   }
 
   # Enable threaded mode


### PR DESCRIPTION
Fixes #8811 

This fix is not ideal it only comments out the other action mailer parameters because leaving them empty didn't work and caused mails to not be sent. This was tested as a hotfix in production, and I will merge it in order to sync with production.