### PR TITLE
Resolve Intermittent Test Failure

### DIFF
--- a/test/unit/node_shared_test.rb
+++ b/test/unit/node_shared_test.rb
@@ -23,7 +23,7 @@ class NodeSharedTest < ActiveSupport::TestCase
     assert_equal 1, html.scan('<table').length
     assert_equal 5, html.scan('nodes-grid-test').length
     assert_equal 2, html.scan('<td class="author">').length # but not 3 because it shouldn't appear twice
-    assert_equal 1, html.scan(nodes(:one).title).length
+    assert_equal 1, html.scan(nodes(:question).title).length
   end
 
   test 'that NodeShared can be used to convert short codes like [nodes:grid:foo] into tables which list nodes with image thumbnails' do


### PR DESCRIPTION
Fixes #8859

The test failing `test/unit/node_shared_test.rb:26` keeps on failing on my end. I've somehow found out what is happening. Let me know what you think.

So far:

The title in the node.yml file for `node(:one)` is `"Canon A1200 IR conversion at PLOTS Barnraising at LUMCON"`
But, this same node, has a revision in the `revision.yml,` and the title shows `Should render a checked checkbox`

<img width="1147" alt="Screenshot 2020-12-16 at 17 46 47" src="https://user-images.githubusercontent.com/7622875/102364921-0e3fbf80-3fc8-11eb-89e6-5c60be51d788.png">

When I ran the test locally and checked the title displayed for `node(:one)` it was `Should render a checked checkbox`
<img width="1110" alt="Screenshot 2020-12-16 at 17 45 39" src="https://user-images.githubusercontent.com/7622875/102365027-2fa0ab80-3fc8-11eb-9ee9-1f80e4cc90fe.png">

So that means when we run this test `assert_equal 1, html.scan(nodes(:question).title).length` it checks for `"Canon A1200 IR conversion at PLOTS Barnraising at LUMCON"` which is not present because of the revision title.

I have altered the test to find the title of `node(:question)` which is displayed in the HTML during the test..
<img width="1135" alt="Screenshot 2020-12-16 at 17 49 06" src="https://user-images.githubusercontent.com/7622875/102365274-6aa2df00-3fc8-11eb-9d18-8b517d5502c5.png">


It is now passing as expected. 

* [X ] PR is descriptively titled 📑 and links the original issue above 🔗
* [X ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

