### PR TITLE
Filter Banned Users from User Reactions (Fixes #8618)

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -150,7 +150,7 @@ class CommentController < ApplicationController
       comment.likes.create(user_id: @user_id, emoji_type: @emoji_type)
     end
     # select likes from users that aren't banned (status = 0)
-    @likes = comment.likes.joins(:user).select(:emoji_type, :status).where("emoji_type IS NOT NULL").where("status IS NOT 0").group(:emoji_type).size
+    @likes = comment.likes.joins(:user).select(:emoji_type, :status).where("emoji_type IS NOT NULL").where("status != 0").group(:emoji_type).size
     @user_reactions_map = comment.user_reactions_map
     respond_with do |format|
       format.js do

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -149,8 +149,8 @@ class CommentController < ApplicationController
     else
       comment.likes.create(user_id: @user_id, emoji_type: @emoji_type)
     end
-
-    @likes = comment.likes.group(:emoji_type).size
+    # select likes from users that aren't banned (status = 0)
+    @likes = comment.likes.joins(:user).select(:emoji_type, :status).where("emoji_type IS NOT NULL").where("status IS NOT 0").group(:emoji_type).size
     @user_reactions_map = comment.user_reactions_map
     respond_with do |format|
       format.js do

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -213,22 +213,21 @@ class Comment < ApplicationRecord
     User.where(id: likes.pluck(:user_id))
   end
 
-  def emoji_likes
-    likes.group(:emoji_type).size
-  end
-
   def user_reactions_map
-    likes_map = likes.where.not(emoji_type: nil).includes(:user).group_by(&:emoji_type)
+    # select likes from users that aren't banned (status = 0)
+    likes_map = likes.joins(:user).select(:emoji_type, :username, :status).where("emoji_type IS NOT NULL").where("status IS NOT 0").group_by(&:emoji_type)
     user_like_map = {}
     likes_map.each do |reaction, likes|
       users = []
       likes.each do |like|
-        users << like.user.name
+        users << like.username
       end
-
       emoji_type = reaction.underscore.humanize.downcase
       users_string = (users.size > 1 ? users[0..-2].join(", ") + " and " + users[-1] : users[0]) + " reacted with " + emoji_type + " emoji"
-      user_like_map[reaction] = users_string
+      like_data = {}
+      like_data[:users_string] = users_string
+      like_data[:likes_num] = users.size
+      user_like_map[reaction] = like_data
     end
     user_like_map
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -215,7 +215,7 @@ class Comment < ApplicationRecord
 
   def user_reactions_map
     # select likes from users that aren't banned (status = 0)
-    likes_map = likes.joins(:user).select(:emoji_type, :username, :status).where("emoji_type IS NOT NULL").where("status IS NOT 0").group_by(&:emoji_type)
+    likes_map = likes.joins(:user).select(:emoji_type, :username, :status).where("emoji_type IS NOT NULL").where("status != 0").group_by(&:emoji_type)
     user_like_map = {}
     likes_map.each do |reaction, likes|
       users = []

--- a/app/views/comments/like_comment.js.erb
+++ b/app/views/comments/like_comment.js.erb
@@ -11,6 +11,6 @@ $("<%= str %>").css("display","none");
     $("<%= str %> div").first().html("<%= @likes[capitalized_emoji_name] %>");
   <% end %>
   <% if @user_reactions_map.has_key? capitalized_emoji_name %>
-    $("<%= str %>").attr("data-original-title", "<%= @user_reactions_map[capitalized_emoji_name] %>");
+    $("<%= str %>").attr("data-original-title", "<%= @user_reactions_map[capitalized_emoji_name][:users_string] %>");
   <% end %>
 <% end %>

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -179,15 +179,17 @@
   <% str = "#{comment.id}-like-emojis" %>
   <div id="<%= str %>" class="navbar-text float-right" style="margin: 0;width: 100%;display: flex;border: 1px solid #e7e7e7;border-top: 0;">
     <% emoji_names, emoji_image_map = emoji_info %>
-    <% emoji_like_map = comment.emoji_likes %>
     <% user_reactions_map = comment.user_reactions_map %>
     <% emoji_names.each do |e| %>
       <% capitalized_emoji_name = e.split("-").map(&:capitalize).join %>
       <% str = "#{comment.id}-emoji-button-#{e}" %>
-      <% display = (emoji_like_map.has_key? capitalized_emoji_name) ? "display: flex;" : "display: none;" %>
-      <button aria-label="Reaction" id="<%= str %>" style="border: 0;background: #f1f8ff;border-radius: 0;border-right: 1px solid #e7e7e7;<%= display %>" type="button" class="btn btn-outline-secondary btn-sm" data-toggle="tooltip" data-placement="bottom" title="<%= user_reactions_map[capitalized_emoji_name] %>">
+      <% user_reactions_exist = user_reactions_map.has_key? capitalized_emoji_name %>
+      <% display = user_reactions_exist ? "display: flex;" : "display: none;" %>
+      <% title = user_reactions_exist ? user_reactions_map[capitalized_emoji_name][:users_string] : "" %>
+      <% likes_num = user_reactions_exist ? user_reactions_map[capitalized_emoji_name][:likes_num] : "" %>
+      <button aria-label="Reaction" id="<%= str %>" style="border: 0;background: #f1f8ff;border-radius: 0;border-right: 1px solid #e7e7e7;<%= display %>" type="button" class="btn btn-outline-secondary btn-sm" data-toggle="tooltip" data-placement="bottom" title="<%= title %>">
         <img alt="<%= str %>" height="20" width="20" src="<%= emoji_image_map[e] %>">
-        <div style="margin-left: 6px;font-size: 14px;"><%= emoji_like_map[capitalized_emoji_name] %></div>
+        <div style="margin-left: 6px;font-size: 14px;"><%= likes_num %></div>
       </button>
     <% end %>
   </div>

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -231,12 +231,23 @@ class CommentTest < ActiveSupport::TestCase
     user = users(:bob)
     like = Like.create(likeable_id: comment.id, user_id: user.id, likeable_type: "Comment", emoji_type: "Heart")
     map = comment.user_reactions_map
-    assert_equal map["Heart"], "Bob reacted with heart emoji"
+    assert_equal map["Heart"][:users_string], "Bob reacted with heart emoji"
     like = Like.create(likeable_id: comment.id, user_id: users(:jeff).id, likeable_type: "Comment", emoji_type: "Heart")
     map = comment.user_reactions_map
-    assert_equal map["Heart"], "Bob and jeff reacted with heart emoji"
+    assert_equal map["Heart"][:users_string], "Bob and jeff reacted with heart emoji"
   end
 
+  test "should return reactions ONLY from users that aren't banned" do
+    comment = comments(:first)
+    # normal user
+    user = users(:bob)
+    new_like = Like.create(likeable_id: comment.id, user_id: user.id, likeable_type: "Comment", emoji_type: "Heart")
+    # banned user
+    spammer = users(:spammer)
+    new_like = Like.create(likeable_id: comment.id, user_id: spammer.id, likeable_type: "Comment", emoji_type: "Heart")
+    map = comment.user_reactions_map
+    assert_equal map["Heart"][:users_string], "Bob reacted with heart emoji"
+  end
 
   test 'should parse incoming mail from gmail service correctly and add comment' do
     require 'mail'


### PR DESCRIPTION
(Fixes #8618). 
- Changes the Rails ActiveRecord query when looking up user_reactions_map for displaying comment reactions.
  - Now, it filters out users with status = 0.
  - Please take a look at the query, I'm still learning how to write these properly.
- Writes a new unit test for comments showing that banned users are filtered from user reactions.
- I had to make additional changes to the `like` method in comment_controller.rb.
  - When a user likes a comment, the server sends an updated version of the comment's likes
  - So I had to make sure these likes were also filtered for banned users.

This was fun to figure out! It taught me a lot about queries and comments in general. 