### PR TITLE
Testing: Post Replies with Multiple Comment Boxes Open

### DIFF
--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -162,16 +162,79 @@ comment_by_first_time_user:
   timestamp: <%= Time.now.to_i + 10 %>
   thread: /01
 
-reply_to_this_comment:
+reply_to_this_comment: # comment on question, for comment system tests
   uid: 1
   nid: 37
   status: 1
   comment: Uhh...
   timestamp: <%= Time.now.to_i + 10 %>
 
-note_comment_for_responses:
+note_comment_for_responses: # comment on note, for comment system tests
   uid: 1
   nid: 38
   status: 1
   comment: I do what I want!
   timestamp: <%= Time.now.to_i + 10 %>
+
+ketchup_comment: # question fixture for testing multiple comments
+  uid: 1
+  nid: 40
+  status: 1
+  comment: I like ketchup
+  timestamp: <%= Time.now.to_i + 10 %>
+
+mustard_comment:
+  uid: 5
+  nid: 40
+  status: 1
+  comment: I like mustard
+  timestamp: <%= Time.now.to_i + 20 %>
+
+mayo_comment:
+  uid: 6
+  nid: 40
+  status: 1
+  comment: I like mayo
+  timestamp: <%= Time.now.to_i + 30 %>
+
+ouija_comment_1: # note fixture for testing multiple comments
+  uid: 1
+  nid: 41
+  status: 1
+  comment: P
+  timestamp: <%= Time.now.to_i + 10 %>
+
+ouija_comment_2:
+  uid: 5
+  nid: 41
+  status: 1
+  comment: O
+  timestamp: <%= Time.now.to_i + 20 %>
+
+ouija_comment_3:
+  uid: 6
+  nid: 41
+  status: 1
+  comment: O
+  timestamp: <%= Time.now.to_i + 30 %>
+
+wiki_comment_1: # wiki fixture for testing multiple comments
+  uid: 1
+  nid: 42
+  status: 1
+  comment: Squirtle
+  timestamp: <%= Time.now.to_i + 10 %>
+
+wiki_comment_2:
+  uid: 5
+  nid: 42
+  status: 1
+  comment: Charmander
+  timestamp: <%= Time.now.to_i + 20 %>
+
+wiki_comment_3:
+  uid: 6
+  nid: 42
+  status: 1
+  comment: Bulbasaur
+  timestamp: <%= Time.now.to_i + 30 %>

--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -274,3 +274,8 @@ hidden_response_node_tag:
   uid: 2
   nid: 39
   date: <%= DateTime.now.to_i %>
+
+question_with_multiple_comments: # another question for testing comments
+  tid: 35
+  uid: 2
+  nid: 40

--- a/test/fixtures/nodes.yml
+++ b/test/fixtures/nodes.yml
@@ -481,3 +481,39 @@ hidden_response_note:
   type: "note"
   cached_likes: 0
   slug: "note-tagged-with-hidden-response"
+
+question_with_multiple_comments: # for testing multiple comment forms
+  nid: 40
+  uid: 2
+  title: "Which condiments do you like"
+  path: "/notes/jeff/12-20-2020/which-condiments-do-you-like"
+  created: <%= DateTime.new(2020,12,20).to_i %>
+  changed: <%= DateTime.new(2020,12,20).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: "jeff-12-20-2020-which-condiments-do-you-like"
+
+note_with_multiple_comments:
+  nid: 41
+  uid: 2
+  title: "Ouija Board"
+  path: "/notes/jeff/12-20-2020/ouija-board"
+  created: <%= DateTime.new(2020,12,20).to_i %>
+  changed: <%= DateTime.new(2020,12,20).to_i %>
+  status: 1
+  type: "note"
+  cached_likes: 0
+  slug: "jeff-12-20-2020-ouija-board"
+
+wiki_with_multiple_comments: 
+  nid: 42
+  uid: 2
+  title: "List of pokemon"
+  path: "/wiki/list-of-pokemon"
+  created: <%= DateTime.new(2020,12,21).to_i %>
+  changed: <%= DateTime.new(2020,12,21).to_i %>
+  status: 1
+  type: "page"
+  cached_likes: 0
+  slug: "wiki-list-of-pokemon"

--- a/test/fixtures/revisions.yml
+++ b/test/fixtures/revisions.yml
@@ -419,10 +419,34 @@ comment_note: # for testing comments on notes
   timestamp: <%= DateTime.new(2020,12,8).to_i %>
   status: 1
 
-hidden_response_note_revision: # for testing comments on notes
+hidden_response_note_revision:
   nid: 39
   uid: 2
   title: "Note tagged with hidden:response"
   body: "This is a hidden note"
   timestamp: <%= DateTime.new(2020,12,8).to_i %>
+  status: 1
+
+question_with_multiple_comments:
+  nid: 40
+  uid: 2
+  title: "Which condiments do you like"
+  body: "I want to know"
+  timestamp: <%= DateTime.new(2020,12,20).to_i %>
+  status: 1
+
+note_with_multiple_comments:
+  nid: 41
+  uid: 2
+  title: "Ouija Board"
+  body: "Don't be scurred"
+  timestamp: <%= DateTime.new(2020,12,20).to_i %>
+  status: 1
+
+wiki_with_multiple_comments:
+  nid: 42
+  uid: 2
+  title: "List of pokemon"
+  body: "Gotta catch em all"
+  timestamp: <%= DateTime.new(2020,12,21).to_i %>
   status: 1

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -59,7 +59,7 @@ class HomeControllerTest < ActionController::TestCase
     @wikis.each do |obj|
       if obj.class == Revision && obj.status == 1
         selections = css_select '.wiki'
-        assert_equal 9, selections.length
+        assert_equal 10, selections.length
       elsif obj.class == Revision && obj.status != 1
         selections = css_select '.wiki'
         assert_equal 0, selections.length

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -367,7 +367,7 @@ class NotesControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal 16, selector.size
+    assert_equal 17, selector.size
   end
 
   test 'first-timer moderated note (status=4) shown to moderator with notice and approval prompt in full view' do
@@ -395,7 +395,7 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_response :success
     selector = css_select 'div.note'
-    assert_equal 16, selector.size
+    assert_equal 17, selector.size
   end
 
   test 'post_note_error_no_title' do

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -256,5 +256,44 @@ class CommentTest < ApplicationSystemTestCase
       first("img[src='https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png']").click()
       page.assert_no_selector("button[data-original-title='jeff reacted with thumbs up emoji'")
     end
+
+    test "#{page_type}: multiple comment boxes, post comments" do
+      if page_type == :note
+        visit nodes(:note_with_multiple_comments).path
+      elsif page_type == :question
+        visit nodes(:question_with_multiple_comments).path
+      elsif page_type == :wiki
+        visit nodes(:wiki_with_multiple_comments).path + '/comments'
+      end
+      # there should be exactly three "Reply to comment..."s on this fixture
+      reply_toggles = page.all('p', text: 'Reply to this comment...')
+      # extract the comment IDs from each
+      comment_ids = []
+      reply_toggles.each do |reply_toggle|
+        id_string = reply_toggle[:id]
+        comment_id = /comment-(\d+)-reply-toggle/.match(id_string)[1]
+        comment_ids << comment_id
+      end
+      # work with just the 2nd comment
+      reply_toggles[1].click 
+      # open the comment form by toggling, and fill in some text
+      find("div#comment-#{comment_ids[1]}-reply-section textarea#text-input").click.fill_in with: 'H'
+      # open the other two comment forms
+      reply_toggles[0].click
+      reply_toggles[2].click
+      # fill them in with text
+      find("div#comment-#{comment_ids[0]}-reply-section textarea#text-input").click.fill_in with: 'A'
+      find("div#comment-#{comment_ids[2]}-reply-section textarea#text-input").click.fill_in with: 'Y'
+      # click the publish buttons for each in a random sequence
+      [1, 2, 0].each do |number|
+        find("div#comment-#{comment_ids[number]}-reply-section button", text: 'Publish').click
+        wait_for_ajax
+      end
+      take_screenshot
+      # assert that the replies went to the right comments
+      assert_selector("#c" + comment_ids[0] + "show div div div p", text: 'A')
+      assert_selector("#c" + comment_ids[1] + "show div div div p", text: 'H')
+      assert_selector("#c" + comment_ids[2] + "show div div div p", text: 'Y')
+    end
   end
 end

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -289,7 +289,6 @@ class CommentTest < ApplicationSystemTestCase
         find("div#comment-#{comment_ids[number]}-reply-section button", text: 'Publish').click
         wait_for_ajax
       end
-      take_screenshot
       # assert that the replies went to the right comments
       assert_selector("#c" + comment_ids[0] + "show div div div p", text: 'A')
       assert_selector("#c" + comment_ids[1] + "show div div div p", text: 'H')

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -344,12 +344,7 @@ class NodeTest < ActiveSupport::TestCase
 
   test 'should find all research notes' do
     notes = Node.research_notes
-    expected = [nodes(:one), nodes(:spam), nodes(:first_timer_note), nodes(:blog),
-                nodes(:moderated_user_note), nodes(:activity), nodes(:upgrade),
-                nodes(:draft), nodes(:post_test1), nodes(:post_test2),
-                nodes(:post_test3), nodes(:post_test4), nodes(:scraped_image), nodes(:search_trawling),
-                nodes(:purple_air_without_hyphen), nodes(:purple_air_with_hyphen),
-                nodes(:sun_note), nodes(:sunny_day_note), nodes(:comment_note), nodes(:hidden_response_note)]
+    expected = [nodes(:one), nodes(:spam), nodes(:first_timer_note), nodes(:blog), nodes(:moderated_user_note), nodes(:activity), nodes(:upgrade), nodes(:draft), nodes(:post_test1), nodes(:post_test2), nodes(:post_test3), nodes(:post_test4), nodes(:scraped_image), nodes(:search_trawling), nodes(:purple_air_without_hyphen), nodes(:purple_air_with_hyphen), nodes(:sun_note), nodes(:sunny_day_note), nodes(:comment_note), nodes(:hidden_response_note), nodes(:note_with_multiple_comments)]
     assert_equal expected, notes
   end
 
@@ -359,7 +354,7 @@ class NodeTest < ActiveSupport::TestCase
 
   test 'should find all questions' do
     questions = Node.questions
-    expected = [nodes(:question), nodes(:question2), nodes(:first_timer_question), nodes(:question3), nodes(:sun_question), nodes(:comment_question)]
+    expected = [nodes(:question), nodes(:question2), nodes(:first_timer_question), nodes(:question3), nodes(:sun_question), nodes(:comment_question), nodes(:question_with_multiple_comments)]
     assert_equal expected, questions
   end
 


### PR DESCRIPTION
I have another PR open at #8879, merge that one first!

- Made new fixtures for question, wiki, note -- each with multiple comments on them.
  - I tried adding comments to the existing fixtures, but the assertions for earlier tests throw errors because Capybara expects to find just one element, but finds several.
  - It seemed a lot easier to just make new fixtures, rather than rewrite the old tests... For now.
- Because of the new fixtures, I also had to alter the assertions in unit tests that count questions, wikis, notes. We ran into this problem before (I'll rewrite these someday!)

(This PR is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context)