### PR TITLE
Update Mapbox API to fix map base layers

### DIFF
--- a/app/views/home/nearby.html.erb
+++ b/app/views/home/nearby.html.erb
@@ -12,7 +12,7 @@
 
   <script>
     var map = L.map('map').setView([<%= current_user.lat %>,<%= current_user.lon %>], 8);
-    L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/light-v10/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+    L.tileLayer('https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
       tileSize: 512,
       zoomOffset: -1,
       attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'

--- a/app/views/home/nearby.html.erb
+++ b/app/views/home/nearby.html.erb
@@ -12,7 +12,12 @@
 
   <script>
     var map = L.map('map').setView([<%= current_user.lat %>,<%= current_user.lon %>], 8);
-    L.tileLayer("https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png").addTo(map)
+    L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/light-v10/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+      tileSize: 512,
+      zoomOffset: -1,
+      attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+    }).addTo(map);
+
 
     <% if @users %>
     <% @users.each do |user| %>

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -28,8 +28,10 @@
       maxBounds: bounds , 
       maxBoundsViscosity: 0.75
     }).setView([15,0], 2);
-  var baselayer = L.tileLayer('https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  var baselayer = L.tileLayer('https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+        tileSize: 512,
+        zoomOffset: -1,
+        attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
     }).addTo(map) ; 
   map.options.minZoom = 1.5 ;
 

--- a/app/views/notes/tools_places.html.erb
+++ b/app/views/notes/tools_places.html.erb
@@ -5,9 +5,11 @@
 
 <script>
   var map = L.map('map').setView([22,0], 2);
-  L.tileLayer("https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png",{
-    attribution: "<a href='https://openstreetmap.org'>OSM</a> tiles by <a href='http://mapbox.com'>MapBox</a>",
-  }).addTo(map)
+  L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/light-v10/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+    tileSize: 512,
+    zoomOffset: -1,
+    attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+  }).addTo(map);
 
   <% @notes.each do |place| %>
     <% if place.lat && place.lon %>L.marker([<%= place.lat %>, <%= place.lon %>]).addTo(map).bindPopup("<a href='<%= place.path %>'><%= place.latest.title %></a>");<% end %>

--- a/app/views/notes/tools_places.html.erb
+++ b/app/views/notes/tools_places.html.erb
@@ -5,7 +5,7 @@
 
 <script>
   var map = L.map('map').setView([22,0], 2);
-  L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/light-v10/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+  L.tileLayer('https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
     tileSize: 512,
     zoomOffset: -1,
     attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'

--- a/app/views/users/map.html.erb
+++ b/app/views/users/map.html.erb
@@ -49,9 +49,11 @@
       $("#users_map").html("<div id='map' class='col-lg-12' style='height:500px;'></div>");
 
       var user_map = L.map('map').setView([15,0], 2);
-      L.tileLayer("https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png",{
-          attribution: "<a href='https://openstreetmap.org'>OSM</a> tiles by <a href='https://mapbox.com'>MapBox</a>"
-        }).addTo(user_map);
+      L.tileLayer('https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+        tileSize: 512,
+        zoomOffset: -1,
+        attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+      }).addTo(user_map);
 
       <% @location_tags.each do |location_tag, user_tag| %>
 
@@ -75,9 +77,11 @@
         var user_map = L.map('map').setView([15,0], 2);
       <% end %>
       
-      L.tileLayer("https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/{z}/{x}/{y}.png",{
-          attribution: "<a href='https://openstreetmap.org'>OSM</a> tiles by <a href='https://mapbox.com'>MapBox</a>"
-        }).addTo(user_map);
+      L.tileLayer('https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
+        tileSize: 512,
+        zoomOffset: -1,
+        attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+      }).addTo(user_map);
 
       <% @users.each do |user| %>
         <% location_privacy = user.user.location_privacy %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -5,9 +5,9 @@
     <%= render :partial => "map/leaflet" , locals: { lat: @map_lat, lon: @map_lon, zoom: @map_zoom, blurred: @map_blurred, topmap: true, user: @profile_user } %>
   <% elsif !current_user.nil? && current_user.id == @profile_user.id %>
     <div id="map_template" style="position: relative; width: 100%; display: inline-block;">
-      <img src="https://a.tiles.mapbox.com/v3/jywarren.map-lmrwb2em/0/0/0.png" style="height:300px; width: 100%; margin: 0; position: relative; margin-right: -10px;">
+      <img src="https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/0/0/0?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig" style="height:300px; width: 100%; margin: 0; position: relative; margin-right: -10px;">
       <button type='button' class='blurred-location-input btn btn-default btn-lg' style="position:absolute;position:absolute;top:41%;left:15%;"> <strong> Share your Location </strong> </button>
-      <p><i><small>Learn about <a href='https://publiclab.org/wiki/location-privacy'>privacy</a> </small></i></p>
+      <p><i><small>Learn about <a href='https://publiclab.org/location-privacy'>privacy</a> </small></i></p>
     </div>
   <% end %>
 


### PR DESCRIPTION
Noting we have more places to do this too:

https://github.com/publiclab/plots2/search?q=https%3A%2F%2Fa.tiles.mapbox.com%2Fv3%2Fjywarren

Following: https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4

I wonder if we could also instead use static tiles, not sure if what i selected are among them? OK, confirmed these are static tiles api: https://docs.mapbox.com/api/maps/static-tiles/

@Sagarpreet i wonder if we need to make this update to LEL as well? 

```js
var baseLayer = L.tileLayer('https://api.mapbox.com/styles/v1/jywarren/ckj06ujnc1nmi19nuelh46pr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1Ijoianl3YXJyZW4iLCJhIjoiVzVZcGg3NCJ9.BJ6ArUPuTs1JT9Ssu3K8ig', {
        tileSize: 512,
        zoomOffset: -1,
        attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
    }).addTo(map);
```