### PR TITLE
Feature: Add $D.selected Comment Documentation, Change .bind eventHandlers to .on

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -2,7 +2,7 @@
 
   $('.comment-form').each(function() {
     if(!$(this).hasClass('bound-success')) {
-      $(this).addClass('bound-success').bind('ajax:success', function(e, data, status, xhr){
+      $(this).addClass('bound-success').on('ajax:success', function(e, data, status, xhr){
         $(this).find('.text-input').prop('disabled',false);
         $(this).find('.text-input').val('');
         $('#comments-container').append(xhr.responseText);
@@ -14,7 +14,7 @@
     }
 
     if(!$(this).hasClass('bound-beforeSend')) {
-      $(this).addClass('bound-beforeSend').bind('ajax:beforeSend', function(event){
+      $(this).addClass('bound-beforeSend').on('ajax:beforeSend', function(event){
         $(this).find(".text-input").prop('disabled',true)
         $(this).find('.text-input').val('');
         $(this).find(".btn-primary").button('loading',true);
@@ -22,7 +22,7 @@
     }
 
     if(!$(this).hasClass('bound-error')) {
-      $(this).addClass('bound-error').bind('ajax:error', function(e,response){
+      $(this).addClass('bound-error').on('ajax:error', function(e,response){
         notyNotification('mint', 3000, 'error', 'topRight', 'Some error occured while adding comment');
         $(this).find('.text-input').prop('disabled',false);
         $(this).find('.control-group').addClass('has-error')

--- a/app/assets/javascripts/dragdrop.js
+++ b/app/assets/javascripts/dragdrop.js
@@ -32,13 +32,19 @@ jQuery(function() {
     $('#side-dropzone').removeClass('hover');
   });
   $('.dropzone').on('drop',function(e) {
+    // this 'drop' listener is also reused for pages with just one form, ie. /wiki/new
     $D.selected = $(e.target).closest('div.comment-form-wrapper').eq(0);
     e.preventDefault();
     let params = {};
-    if ($D.selected.hasOwnProperty(0)) {
-      params['textarea'] = $D.selected[0].querySelector('textarea').id
+    // $D.selected will look different for multi vs. single form pages, because of what $.closest returns:
+    //   multiple comments: { 0: the_closest_element }
+    //   /wiki/new: .comment-form-wrapper doesn't exist!
+    if ($D.selected.hasOwnProperty(0)) { // eg. jQuery finds a .comment-form-wrapper somewhere on the page.
+      params['textarea'] = $D.selected[0].querySelector('textarea').id // assign the ID of the textarea within the closest comment-form-wrapper
     } else {
-      params['textarea'] = 'text-input'
+      // default to #text-input
+      // ideally there should only be one per page
+      params['textarea'] = 'text-input' 
     }
     $E.initialize(params);
   });

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -51,16 +51,16 @@
           $E.initialize(args);
         }
 
-        $('#c<%= comment.id%>div').bind('dragover',function(e) {
+        $('#c<%= comment.id%>div').on('dragover',function(e) {
           e.preventDefault();
           $('#c<%= comment.id%>div').addClass('hover');
         });
 
-        $('#c<%= comment.id%>div').bind('dragout',function(e) {
+        $('#c<%= comment.id%>div').on('dragout',function(e) {
           $('#c<%= comment.id%>div').removeClass('hover');
         });
 
-        $('#c<%= comment.id%>div').bind('drop',function(e) {
+        $('#c<%= comment.id%>div').on('drop',function(e) {
           e.preventDefault();
           $D.selected = $(e.target).closest('div.comment-form-wrapper').eq(0);
           setInit(<%= comment.id %>);


### PR DESCRIPTION
This is followup for PR #8897, which fixed #8670 (edit/main image drag&drop cross-wiring).

- changes some jQuery .bind eventHandlers to .on
  - in comments/_edit.html.erb, which Sagarpreet noticed [here](https://github.com/publiclab/plots2/pull/8897#discussion_r553121375)
  - also in comment.js
- leave some comments explaining [this commit](https://github.com/publiclab/plots2/pull/8897#discussion_r554225757): initialize $E with params in dragdrop.js
---
_This PR is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context_