### PR TITLE
Fix failure for short timeout on passenger start

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -10,4 +10,5 @@ if [ -f $pidfile ] ; then
   rm $pidfile;
 fi
 
+bundle exec passenger-config compile-nginx-engine
 bundle exec passenger start --max-pool-size 9 --min-instances 9 -p 4000


### PR DESCRIPTION
Following tip on https://github.com/phusion/passenger/issues/1394#issuecomment-76899201
This is to fix stable branch in staging server

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
