### PR TITLE
Bug: Fix Rich-Text Cross-Wiring in Comment Forms

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -1,3 +1,28 @@
+// jQuery (document).ready function:
+$(function() {
+  // this click eventHandler assigns $D.selected to the appropriate comment form
+  // on pages with multiple comments, $D.selected needs to be accurate so that rich-text changes (bold, italic, etc.) go into the right comment form
+  // however, the editor is also used on pages with JUST ONE form, and no other comments, eg. /wiki/new & /wiki/edit, so this code needs to be reusable for that context
+  $('.rich-text-button').on('click', function(e) {
+    const closestCommentFormWrapper = e.target.closest('div.comment-form-wrapper'); // this returns null if there is no match
+    let params = {};
+    // there are no .comment-form-wrappers on /wiki/edit or /wiki/new
+    // these pages just have a single text-input form.
+    if (closestCommentFormWrapper) {
+      $D.selected = $(closestCommentFormWrapper);
+      // assign the ID of the textarea within the closest comment-form-wrapper
+      params['textarea'] = closestCommentFormWrapper.querySelector('textarea').id;
+    } else {
+      // default to #text-input
+      // ideally there should only be one per page
+      params['textarea'] = 'text-input';
+    }
+    $E.initialize(params);
+    const action = e.currentTarget.dataset.action // 'bold', 'italic', etc.
+    $E[action](); // call the appropriate editor function
+  });
+});
+
 $E = {
   initialize: function(args) {
     args = args || {}
@@ -65,9 +90,10 @@ $E = {
   italic: function() {
     $E.wrap('_','_')
   },
-  link: function(uri) {
-    uri = uri || prompt('Enter a URL')
-    $E.wrap('[',']('+uri+')')
+  link: function() {
+    uri = prompt('Enter a URL');
+    if (uri == null) { uri = ""; }
+    $E.wrap('[', '](' + uri + ')');
   },
   image: function(src) {
     $E.wrap('\n![',']('+src+')\n')

--- a/app/views/editor/_toolbar.html.erb
+++ b/app/views/editor/_toolbar.html.erb
@@ -14,34 +14,34 @@
   </div>
   <!-- defined in application_helper.rb -->
   <% toolbar_element_id = get_toolbar_element_id(location, local_assigns[:reply_to], local_assigns[:comment_id]) %>
-  <div class="btn-group mr-2 ">
+  <div class="btn-group mr-2">
     <a
       id="bold-button-<%= toolbar_element_id %>"
-      data-toggle="tooltip" 
       title="Bold" 
+      data-action="bold"
       data-placement="bottom" 
-      class="bold-button btn btn-outline-secondary btn-sm" 
-      onClick="$E.bold()"
+      data-toggle="tooltip" 
+      class="bold-button btn btn-outline-secondary btn-sm rich-text-button" 
     >
       <i class="fa fa-bold" ></i>
     </a>
     <a
       id="italic-button-<%= toolbar_element_id %>"
-      data-toggle="tooltip" 
       title="Italic" 
+      data-action="italic"
       data-placement="bottom" 
-      class="italic-button btn btn-outline-secondary btn-sm" 
-      onClick="$E.italic()"
+      data-toggle="tooltip" 
+      class="italic-button btn btn-outline-secondary btn-sm rich-text-button" 
     >
       <i class="fa fa-italic" ></i>
     </a>
     <a
       id="header-button-<%= toolbar_element_id %>"
-      data-toggle="tooltip" 
       title="Header" 
+      data-action="h2"
       data-placement="bottom" 
-      class="header-button btn btn-outline-secondary btn-sm" 
-      onClick="$E.h2()"
+      data-toggle="tooltip" 
+      class="header-button btn btn-outline-secondary btn-sm rich-text-button" 
     >
       <b>
         <span class="d-md-none d-lg-inline">
@@ -52,11 +52,11 @@
     <a
       id="link-button-<%= toolbar_element_id %>"
       aria-label="Make a link" 
-      data-toggle="tooltip" 
       title="Make a link" 
+      data-action="link"
       data-placement="bottom" 
-      class="link-button btn btn-outline-secondary btn-sm" href="javascript:void(0)" 
-      onClick="$E.link()"
+      data-toggle="tooltip" 
+      class="link-button btn btn-outline-secondary btn-sm rich-text-button" href="javascript:void(0)" 
     >
       <i class="fa fa-link"></i>
     </a>

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -72,27 +72,26 @@
         </a>
       <% end %>
       <% if current_user %>
-            <button style="border: 1px solid;padding: 4px 6px;" class="btn btn-outline-secondary dropdown" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class='icon fa fa-smile-o'></i>
-              <sup style="font-size: 12px;">+</sup>
-            </button>
-            
-            <div id="emoji-dropdown" style="background:#f8f8f8;padding:0;" class=" dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-              <p id="emoji-title" style="text-align: center;color: #586069; font-size:14px;margin:6px;">Pick your reaction</p>
-              <div id= "dropdown-divider" style="display: block;height: 0;border-top: 1px solid #e1e4e8;"></div>         
-                          
-              <div id="emoji-list" class="emoji-container">              
-                <% emoji_names, emoji_image_map = emoji_info %>                           
-                <% emoji_names.each do |e| %>
-                <% capitalized_emoji_name = e.split("-").map(&:capitalize).join %>
-                <% str = "/comment/like?comment_id=#{comment.cid}&user_id=#{current_user.uid}&emoji_type=#{capitalized_emoji_name}" %>               
-                <%= link_to str, data: { method: "post", remote: true }, style: "margin: 6px;" do %>                     
-                  <img alt="React to post" class="emoji grow" height="20" width="20" src="<%= emoji_image_map[e] %>">                         
-                <% end %>
-                <% end %>
-              </div>
-            </div>  
-        <% end %>      
+        <button style="border: 1px solid;padding: 4px 6px;" class="btn btn-outline-secondary dropdown" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <i class='icon fa fa-smile-o'></i>
+          <sup style="font-size: 12px;">+</sup>
+        </button>    
+        <div id="emoji-dropdown" style="background:#f8f8f8;padding:0;" class=" dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+          <p id="emoji-title" style="text-align: center;color: #586069; font-size:14px;margin:6px;">Pick your reaction</p>
+          <div id= "dropdown-divider" style="display: block;height: 0;border-top: 1px solid #e1e4e8;">
+          </div>         
+          <div id="emoji-list" class="emoji-container">              
+            <% emoji_names, emoji_image_map = emoji_info %>                           
+            <% emoji_names.each do |e| %>
+              <% capitalized_emoji_name = e.split("-").map(&:capitalize).join %>
+              <% str = "/comment/like?comment_id=#{comment.cid}&user_id=#{current_user.uid}&emoji_type=#{capitalized_emoji_name}" %>               
+              <%= link_to str, data: { method: "post", remote: true }, style: "margin: 6px;" do %>                     
+                <img alt="React to post" class="emoji grow" height="20" width="20" src="<%= emoji_image_map[e] %>">                         
+              <% end %>
+            <% end %>
+          </div>
+        </div>  
+      <% end %>      
     </div>  
   </div>
 
@@ -152,7 +151,6 @@
     <% if comment.parent.has_power_tag('activity') && current_user && current_user.id == comment.uid %>
       <div class="alert alert-info">Have you attempted or completed this activity? Consider <a href="/post?n=15798&tags=replication:<%= comment.nid %>,<%= comment.parent.tagnames.join(',') %>">sharing how it went</a> to help refine and improve it.</div>
     <% end %>
-
 
     <% if comment.reply_to.nil? %>
       <% comment.replied_comments.order("timestamp ASC").each do |replied_comment| %>

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -447,6 +447,37 @@ class CommentTest < ApplicationSystemTestCase
       assert_selector('.btn[data-original-title="Help"]', count: 1)
     end
 
+    test "#{page_type_string}: IMMEDIATE rich-text input works in MAIN form" do
+      visit get_path(page_type, nodes(node_name).path)
+      main_comment_form =  page.find('h4', text: /Post comment|Post Comment/).find(:xpath, '..') # title text on wikis is 'Post comment'
+      main_comment_form.find("[data-original-title='Bold']").click
+      text_input_value = main_comment_form.find('#text-input').value
+      assert_equal(text_input_value, '****')
+    end
+
+    test "#{page_type_string}: rich-text input into REPLY form isn't CROSS-WIRED with EDIT form" do
+      nodes(node_name).add_comment({
+        uid: 5,
+        body: comment_text
+      })
+      nodes(node_name).add_comment({
+        uid: 2,
+        body: comment_text
+      })
+      visit get_path(page_type, nodes(node_name).path)
+      # open up the edit comment form
+      page.find("#edit-comment-btn").click
+      # find the EDIT id
+      edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
+      # open up the reply comment form
+      page.all('p', text: 'Reply to this comment...')[1].click
+      page.all("[data-original-title='Bold']")[0].click
+      reply_input_value = page.find('[id^=text-input-reply-]').value
+      edit_input_value = page.find('#' + edit_comment_form_id + ' textarea').value
+      assert_equal(comment_text, edit_input_value)
+      assert_equal('****', reply_input_value)
+    end
+
     test "#{page_type_string}: edit comment" do
       nodes(node_name).add_comment({
         uid: 2,


### PR DESCRIPTION
Fixes #8478

The review comments explain most everything. I think this fix covers most bases, since `$D.selected` is now assigned any time a button is clicked.

Interestingly, even before I merged unique button IDs, I saw that `e.target` was pretty accurate. That makes me think that these cross-wiring fixes maybe have less to do with unique IDs for every single element, and more to do with how the jQuery eventListeners are attached? Still not sure.

The most important thing here is code architecture, which codeclimate caught. `dragdrop.js` and `editor.js` now have duplicated code... Not sure where to put their common code. Also, not sure if the `click` eventHandler truly belongs in `editor.js`. Pointers definitely welcome!!! 🙏 

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context)