### PR TITLE
Feature: Add setState Method in editor.js

### DIFF
--- a/app/assets/javascripts/dragdrop.js
+++ b/app/assets/javascripts/dragdrop.js
@@ -29,12 +29,10 @@ jQuery(function() {
     });
 
     $(this).on('drop',function(e) {
-      const params = getEditorParams(e.target); // defined in editorHelper.js
+      const { textArea, preview, dSelected } = getEditorParams(e.target); // defined in editorHelper.js
       e.preventDefault();
-      if (params.hasOwnProperty('dSelected')) {
-        $D.selected = params['dSelected'];
-      }
-      $E.initialize(params);
+      if (dSelected) { $D.selected = dSelected; }
+      $E.setState(textArea, preview);
     });
 
     $(this).fileupload({

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -71,7 +71,7 @@ $E = {
     var end = $E.textarea[0].selectionEnd;
     const fallbackParameterExists = args && args['fallback'];
     const newlineParameterExists = args && args['newline'];
-    var sel = fallbackParameterExists ? $E.textarea.val().substring(start, end) : args['fallback']; // // fallback if nothing has been selected, and we're simply dealing with an insertion point
+    var sel = fallbackParameterExists ? args['fallback'] : $E.textarea.val().substring(start, end); // // fallback if nothing has been selected, and we're simply dealing with an insertion point
     var replace = a + sel + b;
     if (newlineParameterExists) {
       replace = replace + "\n\n";

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -4,29 +4,22 @@ $(function() {
   // on pages with multiple comments, $D.selected needs to be accurate so that rich-text changes (bold, italic, etc.) go into the right comment form
   // however, the editor is also used on pages with JUST ONE form, and no other comments, eg. /wiki/new & /wiki/edit, so this code needs to be reusable for that context
   $('.rich-text-button').on('click', function(e) {
-    const params = getEditorParams(e.target); // defined in editorHelper.js
+    const { textArea, preview, dSelected } = getEditorParams(e.target); // defined in editorHelper.js
     // assign dSelected
-    if (params.hasOwnProperty('dSelected')) {
-      $D.selected = params['dSelected'];
-    }
-    $E.initialize(params);
+    if (dSelected) { $D.selected = dSelected; }
+    $E.setState(textArea, preview);
     const action = e.currentTarget.dataset.action // 'bold', 'italic', etc.
     $E[action](); // call the appropriate editor function
   });
 });
 
 $E = {
-  initialize: function(args) {
-    args = args || {}
-    // title
-    $E.title = $('#title')
-    // textarea
-    args['textarea'] = args['textarea'] || 'text-input'
-    $E.textarea = $('#'+args['textarea'])
-    $E.textarea.bind('input propertychange',$E.save)
-    // preview
-    args['preview'] = args['preview'] || 'preview-main'
-    $E.preview = $('#'+args['preview'])
+  initialize: function() {
+    // call setState with no parameters, aka. default parameters.
+    // default parameters point toward either:
+    //   1. the comment form at the bottom of multi-comment wikis/questions/research notes
+    //   2. the only editor form on /wiki/new and /wiki/edit
+    $E.setState();
     
     marked.setOptions({
       gfm: true,
@@ -43,6 +36,12 @@ $E = {
         return code;
       }
     });
+  },
+  setState: function(textarea = 'text-input', preview = 'preview-main', title = 'title') {
+    $E.title = $('#' + title + 'title'); // not sure why this exists? seems like $E.title is always #title
+    $E.textarea = $('#' + textarea);
+    $E.textarea.bind('input propertychange', $E.save);
+    $E.preview = $('#' + preview);
   },
   is_editing: function() {
     return ($E.textarea[0].selectionStart == 0 && $E.textarea[0].selectionEnd == 0)

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -69,11 +69,15 @@ $E = {
     var len = $E.textarea.val().length;
     var start = $E.textarea[0].selectionStart;
     var end = $E.textarea[0].selectionEnd;
-    var sel = (args && args['fallback']) ? $E.textarea.val().substring(start, end) : args['fallback']; // // fallback if nothing has been selected, and we're simply dealing with an insertion point
+    const fallbackParameterExists = args && args['fallback'];
+    const newlineParameterExists = args && args['newline'];
+    var sel = fallbackParameterExists ? $E.textarea.val().substring(start, end) : args['fallback']; // // fallback if nothing has been selected, and we're simply dealing with an insertion point
     var replace = a + sel + b;
-    if (args && args['newline']) {
-      if ($E.textarea[0].selectionStart > 0) replace = "\n"+replace
-      replace = replace+"\n\n"
+    if (newlineParameterExists) {
+      replace = replace + "\n\n";
+    }
+    if (newlineParameterExists && $E.textarea[0].selectionStart > 0) { 
+      replace = "\n" + replace; 
     }
     $E.textarea.val($E.textarea.val().substring(0,start) + replace + $E.textarea.val().substring(end,len));
   },

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -53,20 +53,19 @@ $E = {
     // preview
     $E.preview = ($D.selected).find('.comment-preview').eq(0);
   },
-  // wraps currently selected text in textarea with strings a and b
-  wrap: function(a,b,args) {
+  isRichTextEditor: function(url) {
     // this RegEx matches three different cases where the legacy editor is still used:
     //   1. /wiki/new
     //   2. /wiki/{wiki name}/edit
     //   3. /features/new
-    const url = window.location.pathname;
     const legacyEditorPath = RegExp(/\/(wiki|features)(\/[^\/]+\/edit|\/new)/);
-    const isRichTextEditor = !legacyEditorPath.test(url);
-    // we only refresh $E's values if with the rich-text editor (most pages).
+    return !legacyEditorPath.test(url); // if we're not on one of these pages, we are using the rich-text editor.
+  },
+  // wraps currently selected text in textarea with strings a and b
+  wrap: function(a, b, args) {
+    // we only refresh $E's values if we are on a page using the rich-text editor (most pages).
     // the legacy editor pages only have one editor form, unlike pages with multiple comments.
-    if (isRichTextEditor && $D.selected) {
-      this.refresh();
-    }
+    this.isRichTextEditor(window.location.pathname) && this.refresh();
     var len = $E.textarea.val().length;
     var start = $E.textarea[0].selectionStart;
     var end = $E.textarea[0].selectionEnd;

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -65,7 +65,7 @@ $E = {
   wrap: function(a, b, args) {
     // we only refresh $E's values if we are on a page using the rich-text editor (most pages).
     // the legacy editor pages only have one editor form, unlike pages with multiple comments.
-    this.isRichTextEditor(window.location.pathname) && this.refresh();
+    if (this.isRichTextEditor(window.location.pathname)) { this.refresh(); }
     var len = $E.textarea.val().length;
     var start = $E.textarea[0].selectionStart;
     var end = $E.textarea[0].selectionEnd;

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -69,10 +69,7 @@ $E = {
     var len = $E.textarea.val().length;
     var start = $E.textarea[0].selectionStart;
     var end = $E.textarea[0].selectionEnd;
-    var sel = $E.textarea.val().substring(start, end);
-    if (args && args['fallback']) { // an alternative if nothing has been selected, but we're simply dealing with an insertion point
-      sel = args['fallback']
-    }
+    var sel = (args && args['fallback']) ? $E.textarea.val().substring(start, end) : args['fallback']; // // fallback if nothing has been selected, and we're simply dealing with an insertion point
     var replace = a + sel + b;
     if (args && args['newline']) {
       if ($E.textarea[0].selectionStart > 0) replace = "\n"+replace

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -59,11 +59,12 @@ $E = {
     //   1. /wiki/new
     //   2. /wiki/{wiki name}/edit
     //   3. /features/new
-    const isLegacyEditorPath = RegExp(/\/(wiki|features)(\/[^\/]+\/edit|\/new)/);
-    const isLegacyEditorPage = isLegacyEditorPath.test(window.location.pathname);
-    // we don't need to refresh $E's values if we're on a page where the legacy editor is still used.
-    // this is because these pages only have one editor form, unlike pages with multiple comments.
-    if (!isLegacyEditorPage && $D.selected) {
+    const url = window.location.pathname;
+    const legacyEditorPath = RegExp(/\/(wiki|features)(\/[^\/]+\/edit|\/new)/);
+    const isRichTextEditor = !legacyEditorPath.test(url);
+    // we only refresh $E's values if with the rich-text editor (most pages).
+    // the legacy editor pages only have one editor form, unlike pages with multiple comments.
+    if (isRichTextEditor && $D.selected) {
       this.refresh();
     }
     var len = $E.textarea.val().length;

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -55,10 +55,15 @@ $E = {
   },
   // wraps currently selected text in textarea with strings a and b
   wrap: function(a,b,args) {
-    // this RegEx is: /wiki/ + any char not "/" + /edit
-    const isWikiCommentPage = (/\/wiki\/[^\/]+\/edit/).test(window.location.pathname);
-    // we don't need to refresh $E's values if we're on a page with a single comment form, ie. /wiki/new or /wiki/edit
-    if (window.location.pathname !== "/wiki/new" && !isWikiCommentPage && $D.selected) {
+    // this RegEx matches three different cases where the legacy editor is still used:
+    //   1. /wiki/new
+    //   2. /wiki/{wiki name}/edit
+    //   3. /features/new
+    const isLegacyEditorPath = RegExp(/\/(wiki|features)(\/[^\/]+\/edit|\/new)/);
+    const isLegacyEditorPage = isLegacyEditorPath.test(window.location.pathname);
+    // we don't need to refresh $E's values if we're on a page where the legacy editor is still used.
+    // this is because these pages only have one editor form, unlike pages with multiple comments.
+    if (!isLegacyEditorPage && $D.selected) {
       this.refresh();
     }
     var len = $E.textarea.val().length;

--- a/app/assets/javascripts/editorHelper.js
+++ b/app/assets/javascripts/editorHelper.js
@@ -8,10 +8,13 @@ const getEditorParams = (targetDiv) => {
     params['dSelected'] = $(closestCommentFormWrapper);
     // assign the ID of the textarea within the closest comment-form-wrapper
     params['textarea'] = closestCommentFormWrapper.querySelector('textarea').id;
+    params['preview'] = closestCommentFormWrapper.querySelector('.comment-preview').id;
   } else {
     // default to #text-input
     // #text-input ID should be unique, and the only comment form on /wiki/new & /wiki/edit
     params['textarea'] = 'text-input';
+    // #preview-main should be unique as well
+    params['preview'] = 'preview-main';
   }
   return params;
 };

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -40,11 +40,9 @@
     </div>
       <script type="application/javascript">
         function setInit(id) {
-          var args = {
-            'textarea': 'c'+id+'text',
-            'preview': 'c'+id+'preview'
-          }
-          $E.initialize(args);
+          const textArea = 'c'+id+'text';
+          const preview = 'c'+id+'preview';
+          $E.setState(textArea, preview);
         }
 
         $('#c<%= comment.id%>div').on('dragover',function(e) {
@@ -115,7 +113,7 @@
         });
       </script>
 
-      <div class="well col-md-11" id="c<%= comment.id %>preview" style="background:white;display: none">
+      <div class="comment-preview well col-md-11" id="c<%= comment.id %>preview" style="background:white;display: none">
       </div>
 
       <div class="control-group">

--- a/app/views/editor/_editor.html.erb
+++ b/app/views/editor/_editor.html.erb
@@ -21,6 +21,6 @@
 
 <script>
   jQuery(document).ready(function() {
-    $E.initialize({})
+    $E.initialize();
   })
 </script>

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -365,7 +365,7 @@ class CommentTest < ApplicationSystemTestCase
       page.find('#c' + edit_id_num + 'edit a', text: 'Preview').click
       page.first('a', text: 'Preview').click
       assert_selector('#c' + edit_id_num + 'preview img', count: 1)
-      assert_selector('.comment-preview img', count: 1)
+      assert_selector('#preview-reply-' + reply_id_num, count: 1)
     end
 
     test "#{page_type_string}: ctrl/cmd + enter comment publishing keyboard shortcut" do


### PR DESCRIPTION
This is a small part of a larger object-oriented refactoring for `editor.js`, see #9004 for details.

Basically the major change here is that I am creating a setState method for use in cases like this:
https://github.com/publiclab/plots2/blob/f0be879e5e0fb57590f4207a6ca059d92b203bdf/app/views/comments/_edit.html.erb#L42-L48

I think `$E.initialize` is used for two different cases, and I'm trying to make a greater distinction between the two:
1. `$E.initialize` when the document loads, and the editor **must** point toward the main comment form (or the only editor form on the page, in the case of `/wiki/new`, `/wiki/edit`, and `/features/new`
2. `$E.initialize` when we want the editor `textarea` to change on a multi-comment page, as in the above example. For this case, we can use the new `setState` method instead.

I have confidence this is going to help!!!

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context)