### PR TITLE
Feature: Reorganize comment.js & dragdrop.js Script-Loading

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,5 +1,4 @@
-(function() {
-
+$(function() {
   $('.comment-form').each(function() {
     if(!$(this).hasClass('bound-success')) {
       $(this).addClass('bound-success').on('ajax:success', function(e, data, status, xhr){
@@ -46,7 +45,7 @@
     }
 
   });
-}());
+});
 
 function insertTitleSuggestionTemplate() {
   var element = $('#text-input');

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -103,11 +103,8 @@
           $E.refresh();
         }
       </script>
-
-      <%= javascript_include_tag "dragdrop" %>
       <script src="/emoji.js" type="text/javascript"></script>
       <script src="/assets/atwho_autocomplete.js" type="text/javascript"></script>
-      <%= javascript_include_tag "comment.js" %>
 
       <div class="control-group">
         <button type="submit" class="btn btn-primary"><%= translation('comments._form.publish') %></button>

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -2,7 +2,8 @@
   <div id="comments" class="col-lg-10 comments">
     <% comments = @node.comments_viewable_by(current_user) %>
     <h3><span id="comment-count"><%= comments.size %></span> <%= translation('notes._comments.comments') %></h3>
-
+    <%= javascript_include_tag "dragdrop" %>
+    <%= javascript_include_tag "comment" %>
     <div style="margin-bottom: 50px;" id="comments-list">
       <% comments.includes([:replied_comments, :node]).order('timestamp ASC').each do |comment| %>
         <% if comment.cid == @node.comments&.first&.cid %><a id="last" name="last"></a><% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -117,8 +117,6 @@
       <hr />
     <% end %>
     <% if !@preview %>
-        <%= javascript_include_tag "dragdrop" %>
-        <%= javascript_include_tag "comment" %>
         <%= render partial: "notes/responses" %>
         <div><%= render partial: "notes/comments" %></div>
     <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -117,6 +117,8 @@
       <hr />
     <% end %>
     <% if !@preview %>
+        <%= javascript_include_tag "dragdrop" %>
+        <%= javascript_include_tag "comment" %>
         <%= render partial: "notes/responses" %>
         <div><%= render partial: "notes/comments" %></div>
     <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -55,6 +55,8 @@
   <% comments = @node.comments_viewable_by(current_user) %>
   <h3><span id="comment-count"><%= comments.size %></span> Comments</h3>
     <div id="comments-list">
+    <%= javascript_include_tag "dragdrop" %>
+    <%= javascript_include_tag "comment" %>
       <% comments.includes([:node, :replied_comments]).order("timestamp ASC").each do |comment| %>
         <% if comment.reply_to.nil? %>
           <%= render :partial => "notes/comment", :locals => {:comment => comment} %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -32,8 +32,6 @@
 
     <div class="tab-pane active" id="tab-overview">
       <% if controller.action_name == 'comments' %>
-        <%= javascript_include_tag "dragdrop" %>
-        <%= javascript_include_tag "comment" %>
         <%= render partial: "notes/comments", :locals => {:nodes => @nodes} %>
       <% else %>
         <div <% unless @node.has_tag('style:wide') %>style="max-width:800px;"<% end %> id="content" class="pl-content wiki">

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -32,7 +32,9 @@
 
     <div class="tab-pane active" id="tab-overview">
       <% if controller.action_name == 'comments' %>
-          <%= render partial: "notes/comments", :locals => {:nodes => @nodes} %>
+        <%= javascript_include_tag "dragdrop" %>
+        <%= javascript_include_tag "comment" %>
+        <%= render partial: "notes/comments", :locals => {:nodes => @nodes} %>
       <% else %>
         <div <% unless @node.has_tag('style:wide') %>style="max-width:800px;"<% end %> id="content" class="pl-content wiki">
           <% if @node.has_tag('format:raw') %>


### PR DESCRIPTION
Part of an object-oriented refactoring of the Comment Editor. See #9004 for more details.

Currently `comment.js` and `dragdrop.js` are loaded once per every comment form on a page:
https://github.com/publiclab/plots2/blob/f0be879e5e0fb57590f4207a6ca059d92b203bdf/app/views/comments/_form.html.erb#L107-L110

They really only need to be loaded once per page (not 5 times on a page with 5 comments)! 

Both scripts (but particularly `dragdrop.js`) have eventListeners which can get attached multiple times to the same element if each script is loaded multiple times.

Simplifying the script loading is going to help with refactoring `editor.js`.

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #8775 for more context)
