### PR TITLE
Incoming mail monitoring/logging

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -232,24 +232,25 @@ class Comment < ApplicationRecord
     user_like_map
   end
 
-  def self.receive_mail(mail)
+  def self.new_comment_from_email(mail)
     user = User.where(email: mail.from.first).first
     if user
       node_id = mail.subject[/#([\d]+)/, 1] # This tooks out the node ID from the subject line
       comment_id = mail.subject[/#c([\d]+)/, 1] # This tooks out the comment ID from the subject line if it exists
       unless Comment.where(message_id: mail.message_id).any?
         if node_id.present? && !comment_id.present?
-          add_comment(mail, node_id, user)
+          parse_comment_from_email(mail, node_id, user)
         elsif comment_id.present?
           comment = Comment.find comment_id
-          add_comment(mail, comment.nid, user, [true, comment.id])
+          parse_comment_from_email(mail, comment.nid, user, [true, comment.id])
         end
       end
+      return node_id
     end
   end
 
   # parse mail and add comments based on emailed replies
-  def self.add_comment(mail, node_id, user, reply_to = [false, nil])
+  def self.parse_comment_from_email(mail, node_id, user, reply_to = [false, nil])
     node = Node.where(nid: node_id).first
     if node && mail&.html_part
       mail_doc = Nokogiri::HTML(mail&.html_part&.body&.decoded) # To parse the mail to extract comment content and reply content

--- a/script/mailman_server
+++ b/script/mailman_server
@@ -28,6 +28,7 @@ Mailman::Application.run do
 #       retries ||= 0
       # do something with the database that does not fetch mails yet (let's try to ensure we have a MySQL connection first)
       puts Comment.last.inspect
+      Mailman.logger.info "Mail received from #{mail.from.first}: '#{mail.subject}' - '#{mail&.html_part}'"
       Comment.receive_mail(message)
 #     rescue Exception => e
 #       Mailman.logger.error "Exception occurred while receiving message:\n#{message}"

--- a/script/mailman_server
+++ b/script/mailman_server
@@ -29,7 +29,14 @@ Mailman::Application.run do
       # do something with the database that does not fetch mails yet (let's try to ensure we have a MySQL connection first)
       puts Comment.last.inspect
       Mailman.logger.info "Mail received from #{message.from.first}: '#{message.subject}' - '#{message&.html_part}'"
+      if message.subject == "Incoming mail parsing test"
+        Mailman.logger.info "Received incoming mail parsing test from #{message.from.first} at #{Time.now.to_s}"
+      end
+      last_comment = Comment.last
       Comment.receive_mail(message)
+      if Comment.last.id != last_comment.id
+        Mailman.logger.info "Comment created from #{message.from.first}: '#{message.subject}''"
+      end
 #     rescue Exception => e
 #       Mailman.logger.error "Exception occurred while receiving message:\n#{message}"
 #       Mailman.logger.error [e, *e.backtrace].join("\n")

--- a/script/mailman_server
+++ b/script/mailman_server
@@ -33,9 +33,9 @@ Mailman::Application.run do
         Mailman.logger.info "Received incoming mail parsing test from #{message.from.first} at #{Time.now.to_s}"
       end
       last_comment = Comment.last
-      comment = Comment.new_comment_from_email(message)
+      comment_node_id = Comment.new_comment_from_email(message)
       if Comment.last.id != last_comment.id
-        Mailman.logger.info "Comment created from #{message.from.first}: '#{message.subject}' - https://publiclab.org/n/#{comment.node_id}"
+        Mailman.logger.info "Comment created from #{message.from.first}: '#{message.subject}' - https://publiclab.org/n/#{comment_node_id}"
       end
 #     rescue Exception => e
 #       Mailman.logger.error "Exception occurred while receiving message:\n#{message}"

--- a/script/mailman_server
+++ b/script/mailman_server
@@ -33,9 +33,9 @@ Mailman::Application.run do
         Mailman.logger.info "Received incoming mail parsing test from #{message.from.first} at #{Time.now.to_s}"
       end
       last_comment = Comment.last
-      Comment.receive_mail(message)
+      comment = Comment.new_comment_from_email(message)
       if Comment.last.id != last_comment.id
-        Mailman.logger.info "Comment created from #{message.from.first}: '#{message.subject}''"
+        Mailman.logger.info "Comment created from #{message.from.first}: '#{message.subject}' - https://publiclab.org/n/#{comment.node_id}"
       end
 #     rescue Exception => e
 #       Mailman.logger.error "Exception occurred while receiving message:\n#{message}"

--- a/script/mailman_server
+++ b/script/mailman_server
@@ -28,7 +28,7 @@ Mailman::Application.run do
 #       retries ||= 0
       # do something with the database that does not fetch mails yet (let's try to ensure we have a MySQL connection first)
       puts Comment.last.inspect
-      Mailman.logger.info "Mail received from #{mail.from.first}: '#{mail.subject}' - '#{mail&.html_part}'"
+      Mailman.logger.info "Mail received from #{message.from.first}: '#{message.subject}' - '#{message&.html_part}'"
       Comment.receive_mail(message)
 #     rescue Exception => e
 #       Mailman.logger.error "Exception occurred while receiving message:\n#{message}"

--- a/test/integration/incoming_mail_parsing_test/gmail_parsing_test.rb
+++ b/test/integration/incoming_mail_parsing_test/gmail_parsing_test.rb
@@ -6,7 +6,7 @@ class GmailParsingTest < ActionDispatch::IntegrationTest
     mail = Mail.read('test/fixtures/incoming_test_emails/gmail/incoming_gmail_email.eml')
     node = Node.find(21) # this is the nid used in the .eml fixture
     mail.subject = "Re: (##{node.id})"
-    Comment.receive_mail(mail)
+    Comment.new_comment_from_email(mail)
     f = File.open('test/fixtures/incoming_test_emails/gmail/final_parsed_comment.txt', 'r')
     reply = Comment.last # this should be the just-created comment
     user_email = mail.from.first

--- a/test/integration/incoming_mail_parsing_test/outlook_parsing_test.rb
+++ b/test/integration/incoming_mail_parsing_test/outlook_parsing_test.rb
@@ -7,7 +7,7 @@ class OutlookParsingTest < ActionDispatch::IntegrationTest
     mail = Mail.read('test/fixtures/incoming_test_emails/outlook/incoming_outlook_email.eml')
     comment = comments(:first)
     mail.subject = "Re: (##{comment.nid}) - #c#{comment.id}"
-    Comment.receive_mail(mail)
+    Comment.new_comment_from_email(mail)
     f = File.open('test/fixtures/incoming_test_emails/outlook/final_parsed_comment.txt', 'r')
     reply = Comment.last
     user_email = mail.from.first

--- a/test/integration/incoming_mail_parsing_test/yahoo_parsing_test.rb
+++ b/test/integration/incoming_mail_parsing_test/yahoo_parsing_test.rb
@@ -8,7 +8,7 @@ class YahooParsingTest < ActionDispatch::IntegrationTest
     # Mail contain ["01namangupta@gmail.com"] in from field.
     node = Node.find(21) # this is the nid used in the .eml fixture
     mail.subject = "Re: (##{node.id})"
-    Comment.receive_mail(mail)
+    Comment.new_comment_from_email(mail)
     f = File.open('test/fixtures/incoming_test_emails/yahoo/final_parsed_comment.txt', 'r')
     comment = Comment.last # this should be the just-created comment
     user_email = mail.from.first

--- a/test/integration/token_comment_test.rb
+++ b/test/integration/token_comment_test.rb
@@ -24,7 +24,7 @@ class TokenCommentTest < ActionDispatch::IntegrationTest
     node = Node.last
     mail.subject = "Re: #{node.title} (##{node.nid})"
     mail.from = ["jeff@publiclab.org"]
-    Comment.receive_mail(mail)
+    Comment.new_comment_from_email(mail)
     f = File.open('test/fixtures/incoming_test_emails/gmail/final_parsed_comment.txt', 'r')
     comment = Comment.last
     assert_equal comment.comment, f.read
@@ -40,7 +40,7 @@ class TokenCommentTest < ActionDispatch::IntegrationTest
     mail = Mail.read('test/fixtures/incoming_test_emails/yahoo/incoming_yahoo_email.eml')
     node = Node.last
     mail.subject = "Re: #{node.title} (##{node.nid})"
-    Comment.receive_mail(mail)
+    Comment.new_comment_from_email(mail)
     f = File.open('test/fixtures/incoming_test_emails/yahoo/final_parsed_comment.txt', 'r')
     comment = Comment.last
     user_email = mail.from.first


### PR DESCRIPTION
To monitor uptime for processing incoming mail, which is later processed by:

https://github.com/publiclab/plots2/blob/38e37eb20602d799ab935e4e281f32782e856fda/app/models/comment.rb#L235

This logs incoming messages to `log/mailman.log`

OK! Now it also logs /after/ processing the comment, to confirm it was received. 

And if it receives any email entitled exactly `Incoming mail parsing test`, it logs that specially as well with the timestamp.