### PR TITLE
Integrate Edit Comment Form JavaScript with editor.js

### DIFF
--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -12,119 +12,48 @@
     <!-- toolbar needs location & comment_id to make unique element IDs -->
     <%= render :partial => "editor/toolbar", :locals => { :comment_id => comment.id.to_s, :location => :edit } %>
     
-    <div id="c<%= comment.id%>div" class="form-group">
-    <textarea aria-label="Edit Comment" onFocus="editing=true" name="body" class="form-control" id="c<%= comment.id%>text" rows="6" cols="40" placeholder="<%= placeholder %>"><%= !(comment.is_a?Answer) ? comment.comment : comment.content %></textarea>
-    <div class="imagebar">
-      <div id="c<%= comment.id%>progress" style="display:none;" class="progress progress-bar-container active pull-right">
-        <div id="c<%= comment.id%>progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
-      </div>
-      <p>
-        <span id="c<%= comment.id%>uploading" class="uploading uploading-text" style="display:none;">
-          <%= translation('comments._edit.uploading') %>
-        </span>
-        <span id="c<%= comment.id%>prompt" class="prompt choose-one-prompt-text">
-          <span style="padding-right:4px;float:left;" class="hidden-xs">
-          <%= raw translation('comments._edit.drag_and_drop') %>
+    <div id="c<%= comment.id%>div" class="form-group dropzone">
+      <textarea aria-label="Edit Comment" onFocus="editing=true" name="body" class="form-control" id="text-input-edit-<%= comment.id%>" rows="6" cols="40" placeholder="<%= placeholder %>"><%= !(comment.is_a?Answer) ? comment.comment : comment.content %></textarea>
+      <div class="imagebar">
+        <div id="c<%= comment.id%>progress" style="display:none;" class="progress progress-bar-container active pull-right">
+          <div id="c<%= comment.id%>progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
+        </div>
+        <p>
+          <span id="c<%= comment.id%>uploading" class="uploading uploading-text" style="display:none;">
+            <%= translation('comments._edit.uploading') %>
           </span>
-          <label id="c<%= comment.id%>input_label" for="c<%= comment.id%>input">
-            <input id="c<%= comment.id%>input" type="file" name="image[photo]" style="display:none;" />
-            <a class="hidden-xs"><%= translation('comments._edit.choose_one') %></a>
-            <span class="visible-xs">
-              <i class="fa fa-upload"></i>
-              <a><%= translation('comments._edit.upload_image') %></a>
+          <span id="c<%= comment.id%>prompt" class="prompt choose-one-prompt-text">
+            <span style="padding-right:4px;float:left;" class="hidden-xs">
+            <%= raw translation('comments._edit.drag_and_drop') %>
             </span>
-          </label>
-        </span>
-      </p>
+            <label id="c<%= comment.id%>input_label" for="c<%= comment.id%>input">
+              <input id="c<%= comment.id%>input" type="file" name="image[photo]" style="display:none;" />
+              <a class="hidden-xs"><%= translation('comments._edit.choose_one') %></a>
+              <span class="visible-xs">
+                <i class="fa fa-upload"></i>
+                <a><%= translation('comments._edit.upload_image') %></a>
+              </span>
+            </label>
+          </span>
+        </p>
+        </div>
       </div>
-    </div>
-      <script type="application/javascript">
-        function setInit(id) {
-          const textArea = 'c'+id+'text';
-          const preview = 'c'+id+'preview';
-          $E.setState(textArea, preview);
-        }
-
-        $('#c<%= comment.id%>div').on('dragover',function(e) {
-          e.preventDefault();
-          $('#c<%= comment.id%>div').addClass('hover');
-        });
-
-        $('#c<%= comment.id%>div').on('dragout',function(e) {
-          $('#c<%= comment.id%>div').removeClass('hover');
-        });
-
-        $('#c<%= comment.id%>div').on('drop',function(e) {
-          e.preventDefault();
-          $D.selected = $(e.target).closest('div.comment-form-wrapper').eq(0);
-          setInit(<%= comment.id %>);
-        });
-
-        $('#c<%= comment.id%>div').fileupload({
-          url: "/images",
-          paramName: "image[photo]",
-          dropZone: $('#c<%= comment.id%>div'),
-          dataType: 'json',
-          formData: {
-            'uid':<%= current_user.uid %>,
-            'nid':<%= comment.uid %>
-          },
-          start: function(e) {
-            $('#c<%= comment.id%>progress').show()
-            $('#c<%= comment.id%>uploading').show()
-            $('#c<%= comment.id%>prompt').hide()
-            $('#c<%= comment.id%>div').removeClass('hover');
-          },
-          done: function (e, data) {
-            $('#c<%= comment.id%>progress').hide()
-            $('#c<%= comment.id%>progress #c<%= comment.id%>progress-bar').css('width', 0);
-            $('#c<%= comment.id%>uploading').hide()
-            $('#c<%= comment.id%>prompt').show()
-            var is_image = false
-            if (data.result['filename'].substr(-3,3) == "jpg") is_image = true
-            if (data.result['filename'].substr(-4,4) == "jpeg") is_image = true
-            if (data.result['filename'].substr(-3,3) == "png") is_image = true
-            if (data.result['filename'].substr(-3,3) == "gif") is_image = true
-            if (data.result['filename'].substr(-3,3) == "JPG") is_image = true
-            if (data.result['filename'].substr(-4,4) == "JPEG") is_image = true
-            if (data.result['filename'].substr(-3,3) == "PNG") is_image = true
-            if (data.result['filename'].substr(-3,3) == "GIF") is_image = true
-
-            if (is_image) {
-              image_url = data.result.url.split('?')[0];
-              orig_image_url = image_url.replace('medium','original');
-              $E.wrap('[![',']('+image_url+')]('+orig_image_url+')', {'newline': true, 'fallback': data.result['filename']});
-            } else {
-              $E.wrap('<a href="'+data.result.url.split('?')[0]+'"><i class="fa fa-file"></i> ','</a>', {'newline': true, 'fallback': data.result['filename']});
-            }
-
-            if ($('#node_images').val() && $('#node_images').val().split(',').length > 1) $('#node_images').val([$('#node_images').val(),data.result.id].join(','));
-            else $('#node_images').val(data.result.id)
-          },
-
-          // fileuploadfail: function(e,data) {},
-          progressall: function (e, data) {
-            var progress = parseInt(data.loaded / data.total * 100, 10);
-            $('#c<%= comment.id%>progress #c<%= comment.id%>progress-bar').css(
-                'width',
-                progress + '%'
-            );
-          }
-        });
-      </script>
-
-      <div class="comment-preview well col-md-11" id="c<%= comment.id %>preview" style="background:white;display: none">
+      <div class="comment-preview well col-md-11" id="comment-preview-edit-<%= comment.id %>" style="background:white;display: none">
       </div>
 
       <div class="control-group">
         <button type="submit" class="btn btn-primary"><%= translation('comments._edit.publish') %></button>
-          <a class="btn btn-default preview-btn"  data-previewing-text="Hide Preview"
-              onClick="$('#c<%= comment.id %>preview').toggle();
-              $('#c<%= comment.id %>text').toggle();
-              $('#c<%= comment.id %>text').next('#imagebar').toggle();
-              this.previewing = !this.previewing;
-              $('#c<%= comment.id %>edit .preview-btn').button(this.previewing ? 'previewing' : 'reset');
-              $E.generate_preview('c<%= comment.id %>preview',$('#c<%= comment.id %>text').val())">
+          <a 
+            class="btn btn-default preview-btn"  
+            data-previewing-text="Hide Preview" 
+            onClick="
+              $E.setState(
+                'text-input-edit-<%= comment.id%>', 
+                'comment-preview-edit-<%= comment.id %>'
+              );
+              $E.toggle_preview();
+            "
+          >
             Preview
           </a>
           <a class="btn btn-default" onClick="$('#c<%= comment.id %>show').toggle();$('#c<%= comment.id %>edit').toggle()">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -90,9 +90,6 @@
       <div id="preview<%= comment_form_id %>" class="comment-preview" style="background: white; display: none;">
       </div>
       <script>
-        jQuery(document).ready(function() {
-          $E.initialize();
-        });
         $D = {
           uid: <%= current_user.uid if current_user %>,
           type: 'comment'

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -53,7 +53,7 @@
         <i data-toggle="tooltip" title="This comment was posted by email." class="fa fa-envelope"></i>
       <% end %>
       <% if current_user && comment.uid == current_user.uid %>
-        <a aria-label="Edit comment" class="btn btn-outline-secondary btn-sm" id="edit-comment-btn" href="javascript:void(0)" onClick="$('#c<%= comment.cid %>edit').toggle();$('#c<%= comment.cid %>show').toggle();setInit(<%= comment.cid %>);">
+        <a aria-label="Edit comment" class="btn btn-outline-secondary btn-sm edit-comment-btn" href="javascript:void(0)" onClick="$('#c<%= comment.cid %>edit').toggle();$('#c<%= comment.cid %>show').toggle();">
           <i class="fa fa-pencil"></i>
         </a>
       <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -146,7 +146,8 @@
   $("#collapse-button").click(function(){
       $(this).remove();
   });
-  $(function(){
+  $(function() {
+    $E.initialize();
     $("img").lazyload();
   });
 </script>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -2,6 +2,7 @@
 <%= javascript_include_tag('notes') %>
 <%= javascript_include_tag('textbox_expand') %>
 <script> var comments_length = <%= @node.comments.length %>; $(function(){
+  $E.initialize();
   $("img").lazyload();
 });</script>
 <%= javascript_include_tag('question') %>

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -341,7 +341,7 @@ class CommentTest < ApplicationSystemTestCase
       # we need the comment ID:
       edit_comment_form_id = edit_comment_form[:id]
       # regex to strip the ID number out of string. ID format is #c1234edit
-      comment_id_num = /c(\d+)edit/.match(edit_comment_form_id)[1]
+      comment_id_num = /comment-form-edit-(\d+)/.match(edit_comment_form_id)[1]
       edit_preview_id = '#comment-preview-edit-' + comment_id_num
       # the <inputs> that take image uploads are hidden, so reveal them:
       Capybara.ignore_hidden_elements = false

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -179,10 +179,10 @@ class CommentTest < ApplicationSystemTestCase
       page.execute_script <<-JS
         var comment = $(".comment")[1];
         var commentID = comment.id;
-        var editCommentBtn = $(comment).find('.navbar-text #edit-comment-btn')
+        var editCommentBtn = $(comment).find('.navbar-text .edit-comment-btn')
         // Toggle edit mode
         $(editCommentBtn).click()
-        var commentTextarea = $('#' + commentID + 'text');
+        var commentTextarea = $('#text-input-edit-' + commentID);
         $(commentTextarea).val('Updated comment.')
         var submitCommentBtn = $('#' + commentID + ' .control-group .btn-primary')[1];
         $(submitCommentBtn).click()
@@ -263,7 +263,7 @@ class CommentTest < ApplicationSystemTestCase
       })
       visit get_path(page_type, nodes(node_name).path)
       # open the edit comment form:
-      page.find("#edit-comment-btn").click
+      page.find(".edit-comment-btn").click
       # find the parent of edit comment's fileinput:
       comment_fileinput_parent_id = page.find('[id^=dropzone-small-edit-]')[:id] # 'begins with' CSS selector
       comment_id_num = /dropzone-small-edit-(\d+)/.match(comment_fileinput_parent_id)[1]
@@ -336,13 +336,13 @@ class CommentTest < ApplicationSystemTestCase
       })
       visit get_path(page_type, nodes(node_name).path)
       # open up the edit comment form
-      page.find("#edit-comment-btn").click
+      page.find(".edit-comment-btn").click
       edit_comment_form = page.find('h4', text: 'Edit comment').find(:xpath, '..')
       # we need the comment ID:
       edit_comment_form_id = edit_comment_form[:id]
       # regex to strip the ID number out of string. ID format is #c1234edit
       comment_id_num = /c(\d+)edit/.match(edit_comment_form_id)[1]
-      edit_preview_id = '#c' + comment_id_num + 'preview'
+      edit_preview_id = '#comment-preview-edit-' + comment_id_num
       # the <inputs> that take image uploads are hidden, so reveal them:
       Capybara.ignore_hidden_elements = false
       file_input_element = edit_comment_form.all('input')[1]
@@ -443,7 +443,7 @@ class CommentTest < ApplicationSystemTestCase
       comment_id_num = /comment-body-(\d+)/.match(comment_id)[1]
       comment_dropzone_selector = '#c' + comment_id_num + 'div'
       # open the edit comment form
-      page.find("#edit-comment-btn").click
+      page.find(".edit-comment-btn").click
       # drop into the edit comment form
       Capybara.ignore_hidden_elements = false
       drop_in_dropzone("#{Rails.root.to_s}/public/images/pl.png", comment_dropzone_selector)
@@ -475,7 +475,7 @@ class CommentTest < ApplicationSystemTestCase
       })
       visit get_path(page_type, nodes(node_name).path)
       # open the edit comment form:
-      find("#edit-comment-btn").click
+      find(".edit-comment-btn").click
       # find the parent of edit comment's fileinput:
       comment_fileinput_parent_id = page.find('[id^=dropzone-small-edit-]')[:id] # 'begins with' CSS selector
       comment_id_num = /dropzone-small-edit-(\d+)/.match(comment_fileinput_parent_id)[1]
@@ -496,7 +496,7 @@ class CommentTest < ApplicationSystemTestCase
       page.find('#c' + comment_id_num + 'edit a', text: 'Preview').click
       # once preview is open, the images are embedded in the page.
       # there should be 1 image in main, and 1 image in edit
-      assert_selector('#c' + comment_id_num + 'preview img', count: 1)
+      assert_selector('#comment-preview-edit-' + comment_id_num + ' img', count: 1)
       assert_selector('#preview-main img', count: 1)
     end
 
@@ -512,12 +512,12 @@ class CommentTest < ApplicationSystemTestCase
       visit get_path(page_type, nodes(node_name).path)
       # find the EDIT id
       # open up the edit comment form
-      page.find("#edit-comment-btn").click
+      page.find(".edit-comment-btn").click
       edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
       # regex to strip the ID number out of string. ID format is #c1234edit
       edit_id_num = /c(\d+)edit/.match(edit_comment_form_id)[1]
       # open the edit comment form
-      edit_preview_id = '#c' + edit_id_num + 'preview'
+      edit_preview_id = '#comment-preview-edit-' + edit_id_num
       # find the REPLY id
       page.all('p', text: 'Reply to this comment...')[0].click
       reply_dropzone_id = page.find('[id^=dropzone-small-reply-]')[:id]
@@ -536,7 +536,7 @@ class CommentTest < ApplicationSystemTestCase
       # click preview buttons in reply and edit form
       page.find('#c' + edit_id_num + 'edit a', text: 'Preview').click
       page.first('a', text: 'Preview').click
-      assert_selector('#c' + edit_id_num + 'preview img', count: 1)
+      assert_selector('#comment-preview-edit-' + edit_id_num + ' img', count: 1)
       assert_selector('#preview-reply-' + reply_id_num, count: 1)
     end
 
@@ -559,7 +559,7 @@ class CommentTest < ApplicationSystemTestCase
       })
       visit get_path(page_type, nodes(node_name).path)
       # open up the edit comment form
-      page.find("#edit-comment-btn").click
+      page.find(".edit-comment-btn").click
       # find the EDIT id
       edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
       # open up the reply comment form


### PR DESCRIPTION
Part of an object-oriented refactoring of `editor.js`. See #9004 for more details.

Please merge #9062 first!

**SUMMARY:**
In the past, there were two separate kinds of comment form partials:
1. REPLY and MAIN comment forms rendered at `/app/views/comments/_form.html.erb`
2. EDIT comment forms rendered at `/app/views/comments/_edit.html.erb`

To boot, these two different comment form types relied on two separate sources for JavaScript editor functions like image upload, and rich-text editing:
1. REPLY and MAIN comment forms rely on `editor.js`.
2. EDIT comment forms rely on a `<script>` tag within the partial [here](https://github.com/publiclab/plots2/blob/38e37eb20602d799ab935e4e281f32782e856fda/app/views/comments/_edit.html.erb#L41-L114)

This made code maintainability more difficult because if a change was made in `editor.js`, it had to account for the `<script>` tag.

This PR integrates the two JS sources. Now `_edit.html.erb` relies on `editor.js`! Hooray!

**CHANGES:**
1. I changed CSS IDs in `_edit.html.erb` so that `editor.js` can access them:
  - `#c123preview` is now `#comment-preview-edit-123`
  - `#c123text` is now `#text-input-edit-123`
2. Deleted `<script>` tag in `_edit.html.erb` so now it relies on `editor.js` instead.

**Slightly unrelated changes:**
1. I deleted `setInit` function definition and calls in `_edit.html.erb`. `setInit` was kind of like a way that we used to setState in EDIT comment forms before. The problem is that we called it whenever the user opened up an edit comment form, or clicked on Preview, which I don't think is a good place to setState. See [this comment](https://github.com/publiclab/plots2/issues/9004#issue-784759413) for an explanation. 
2. Add a `.dropzone` class to `#c123div`, mainly so `editor.js` can toggle preview (Yes, we toggle on `.dropzone` when the user clicks on "Preview")
3. Move `$E.initialize()` call from `_form.html.erb` (REPLY and MAIN comment form partial) into higher level partials. This is so that `editor.js` isn't initialized 5 times on a page with 5 comments (this was happening before! :scream:)

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)