### PR TITLE
Style Fixes for _comment.html.erb Partial

### DIFF
--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -1,146 +1,152 @@
-<div class="comment-form-wrapper">
-  <div class="card card-body bg-light">
-    <form method="post" id="c<%= comment.id %>edit" style="display:none;" class="well" <% if comment.is_a?Answer %> action= "/answers/update/<%= comment.id %>" <% else %> action="/comment/update/<%= comment.id %>" <% end %>>
+<div id="edit-comment-form-wrapper-<%= comment.id %>" class="card card-body bg-light comment-form-wrapper" style="display: none;">
+  <form method="post" id="c<%= comment.id %>edit" style="display:none;" class="well" <% if comment.is_a?Answer %> action= "/answers/update/<%= comment.id %>" <% else %> action="/comment/update/<%= comment.id %>" <% end %>>
 
-      <h4 style="margin-top:0;"><%= title %></h4>
-      <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+    <h4 style="margin-top:0;"><%= title %></h4>
+    <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
 
-      <style>
-        #imagebar {width:100%;}
-      </style>
+    <style>
+      #imagebar {width:100%;}
+    </style>
 
-    <!-- toolbar needs location & comment_id to make unique element IDs -->
-    <%= render :partial => "editor/toolbar", :locals => { :comment_id => comment.id.to_s, :location => :edit } %>
-    
-    <div id="c<%= comment.id%>div" class="form-group">
-    <textarea aria-label="Edit Comment" onFocus="editing=true" name="body" class="form-control" id="c<%= comment.id%>text" rows="6" cols="40" placeholder="<%= placeholder %>"><%= !(comment.is_a?Answer) ? comment.comment : comment.content %></textarea>
-    <div class="imagebar">
-      <div id="c<%= comment.id%>progress" style="display:none;" class="progress progress-bar-container active pull-right">
-        <div id="c<%= comment.id%>progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
-      </div>
-      <p>
-        <span id="c<%= comment.id%>uploading" class="uploading uploading-text" style="display:none;">
-          <%= translation('comments._edit.uploading') %>
-        </span>
-        <span id="c<%= comment.id%>prompt" class="prompt choose-one-prompt-text">
-          <span style="padding-right:4px;float:left;" class="hidden-xs">
-          <%= raw translation('comments._edit.drag_and_drop') %>
-          </span>
-          <label id="c<%= comment.id%>input_label" for="c<%= comment.id%>input">
-            <input id="c<%= comment.id%>input" type="file" name="image[photo]" style="display:none;" />
-            <a class="hidden-xs"><%= translation('comments._edit.choose_one') %></a>
-            <span class="visible-xs">
-              <i class="fa fa-upload"></i>
-              <a><%= translation('comments._edit.upload_image') %></a>
-            </span>
-          </label>
-        </span>
-      </p>
-      </div>
+  <!-- toolbar needs location & comment_id to make unique element IDs -->
+  <%= render :partial => "editor/toolbar", :locals => { :comment_id => comment.id.to_s, :location => :edit } %>
+  
+  <div id="c<%= comment.id%>div" class="form-group">
+  <textarea aria-label="Edit Comment" onFocus="editing=true" name="body" class="form-control" id="c<%= comment.id%>text" rows="6" cols="40" placeholder="<%= placeholder %>"><%= !(comment.is_a?Answer) ? comment.comment : comment.content %></textarea>
+  <div class="imagebar">
+    <div id="c<%= comment.id%>progress" style="display:none;" class="progress progress-bar-container active pull-right">
+      <div id="c<%= comment.id%>progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
     </div>
-      <script type="application/javascript">
-        function setInit(id) {
-          const textArea = 'c'+id+'text';
-          const preview = 'c'+id+'preview';
-          $E.setState(textArea, preview);
-        }
-
-        $('#c<%= comment.id%>div').on('dragover',function(e) {
-          e.preventDefault();
-          $('#c<%= comment.id%>div').addClass('hover');
-        });
-
-        $('#c<%= comment.id%>div').on('dragout',function(e) {
-          $('#c<%= comment.id%>div').removeClass('hover');
-        });
-
-        $('#c<%= comment.id%>div').on('drop',function(e) {
-          e.preventDefault();
-          $D.selected = $(e.target).closest('div.comment-form-wrapper').eq(0);
-          setInit(<%= comment.id %>);
-        });
-
-        $('#c<%= comment.id%>div').fileupload({
-          url: "/images",
-          paramName: "image[photo]",
-          dropZone: $('#c<%= comment.id%>div'),
-          dataType: 'json',
-          formData: {
-            'uid':<%= current_user.uid %>,
-            'nid':<%= comment.uid %>
-          },
-          start: function(e) {
-            $('#c<%= comment.id%>progress').show()
-            $('#c<%= comment.id%>uploading').show()
-            $('#c<%= comment.id%>prompt').hide()
-            $('#c<%= comment.id%>div').removeClass('hover');
-          },
-          done: function (e, data) {
-            $('#c<%= comment.id%>progress').hide()
-            $('#c<%= comment.id%>progress #c<%= comment.id%>progress-bar').css('width', 0);
-            $('#c<%= comment.id%>uploading').hide()
-            $('#c<%= comment.id%>prompt').show()
-            var is_image = false
-            if (data.result['filename'].substr(-3,3) == "jpg") is_image = true
-            if (data.result['filename'].substr(-4,4) == "jpeg") is_image = true
-            if (data.result['filename'].substr(-3,3) == "png") is_image = true
-            if (data.result['filename'].substr(-3,3) == "gif") is_image = true
-            if (data.result['filename'].substr(-3,3) == "JPG") is_image = true
-            if (data.result['filename'].substr(-4,4) == "JPEG") is_image = true
-            if (data.result['filename'].substr(-3,3) == "PNG") is_image = true
-            if (data.result['filename'].substr(-3,3) == "GIF") is_image = true
-
-            if (is_image) {
-              image_url = data.result.url.split('?')[0];
-              orig_image_url = image_url.replace('medium','original');
-              $E.wrap('[![',']('+image_url+')]('+orig_image_url+')', {'newline': true, 'fallback': data.result['filename']});
-            } else {
-              $E.wrap('<a href="'+data.result.url.split('?')[0]+'"><i class="fa fa-file"></i> ','</a>', {'newline': true, 'fallback': data.result['filename']});
-            }
-
-            if ($('#node_images').val() && $('#node_images').val().split(',').length > 1) $('#node_images').val([$('#node_images').val(),data.result.id].join(','));
-            else $('#node_images').val(data.result.id)
-          },
-
-          // fileuploadfail: function(e,data) {},
-          progressall: function (e, data) {
-            var progress = parseInt(data.loaded / data.total * 100, 10);
-            $('#c<%= comment.id%>progress #c<%= comment.id%>progress-bar').css(
-                'width',
-                progress + '%'
-            );
-          }
-        });
-      </script>
-
-      <div class="comment-preview well col-md-11" id="c<%= comment.id %>preview" style="background:white;display: none">
-      </div>
-
-      <div class="control-group">
-        <button type="submit" class="btn btn-primary"><%= translation('comments._edit.publish') %></button>
-          <a class="btn btn-default preview-btn"  data-previewing-text="Hide Preview"
-              onClick="$('#c<%= comment.id %>preview').toggle();
-              $('#c<%= comment.id %>text').toggle();
-              $('#c<%= comment.id %>text').next('#imagebar').toggle();
-              this.previewing = !this.previewing;
-              $('#c<%= comment.id %>edit .preview-btn').button(this.previewing ? 'previewing' : 'reset');
-              $E.generate_preview('c<%= comment.id %>preview',$('#c<%= comment.id %>text').val())">
-            Preview
-          </a>
-          <a class="btn btn-default" onClick="$('#c<%= comment.id %>show').toggle();$('#c<%= comment.id %>edit').toggle()">
-            Cancel
-          </a>
-
-        <span class="form-grey"> &nbsp;
-          <br class="visible-xs" /><%= raw translation('comments._edit.logged_in', :username => current_user.username) %> |
-          <a target="_blank" href="/wiki/authoring-help#Formatting"><%= translation('comments._edit.formatting') %></a> |
-          <a onClick="$('#who-is-notified').toggle()"><%= translation('comments._edit.notifications') %></a>
+    <p>
+      <span id="c<%= comment.id%>uploading" class="uploading uploading-text" style="display:none;">
+        <%= translation('comments._edit.uploading') %>
+      </span>
+      <span id="c<%= comment.id%>prompt" class="prompt choose-one-prompt-text">
+        <span style="padding-right:4px;float:left;" class="hidden-xs">
+        <%= raw translation('comments._edit.drag_and_drop') %>
         </span>
-      </div>
-
-      <p id="who-is-notified" style="display:none;color:#888;">
-        <%= translation('comments._edit.email_notifications') %>
-      </p>
-    </form>
+        <label id="c<%= comment.id%>input_label" for="c<%= comment.id%>input">
+          <input id="c<%= comment.id%>input" type="file" name="image[photo]" style="display:none;" />
+          <a class="hidden-xs"><%= translation('comments._edit.choose_one') %></a>
+          <span class="visible-xs">
+            <i class="fa fa-upload"></i>
+            <a><%= translation('comments._edit.upload_image') %></a>
+          </span>
+        </label>
+      </span>
+    </p>
+    </div>
   </div>
+    <script type="application/javascript">
+      function setInit(id) {
+        const textArea = 'c'+id+'text';
+        const preview = 'c'+id+'preview';
+        $E.setState(textArea, preview);
+      }
+
+      $('#c<%= comment.id%>div').on('dragover',function(e) {
+        e.preventDefault();
+        $('#c<%= comment.id%>div').addClass('hover');
+      });
+
+      $('#c<%= comment.id%>div').on('dragout',function(e) {
+        $('#c<%= comment.id%>div').removeClass('hover');
+      });
+
+      $('#c<%= comment.id%>div').on('drop',function(e) {
+        e.preventDefault();
+        $D.selected = $(e.target).closest('div.comment-form-wrapper').eq(0);
+        setInit(<%= comment.id %>);
+      });
+
+      $('#c<%= comment.id%>div').fileupload({
+        url: "/images",
+        paramName: "image[photo]",
+        dropZone: $('#c<%= comment.id%>div'),
+        dataType: 'json',
+        formData: {
+          'uid':<%= current_user.uid %>,
+          'nid':<%= comment.uid %>
+        },
+        start: function(e) {
+          $('#c<%= comment.id%>progress').show()
+          $('#c<%= comment.id%>uploading').show()
+          $('#c<%= comment.id%>prompt').hide()
+          $('#c<%= comment.id%>div').removeClass('hover');
+        },
+        done: function (e, data) {
+          $('#c<%= comment.id%>progress').hide()
+          $('#c<%= comment.id%>progress #c<%= comment.id%>progress-bar').css('width', 0);
+          $('#c<%= comment.id%>uploading').hide()
+          $('#c<%= comment.id%>prompt').show()
+          var is_image = false
+          if (data.result['filename'].substr(-3,3) == "jpg") is_image = true
+          if (data.result['filename'].substr(-4,4) == "jpeg") is_image = true
+          if (data.result['filename'].substr(-3,3) == "png") is_image = true
+          if (data.result['filename'].substr(-3,3) == "gif") is_image = true
+          if (data.result['filename'].substr(-3,3) == "JPG") is_image = true
+          if (data.result['filename'].substr(-4,4) == "JPEG") is_image = true
+          if (data.result['filename'].substr(-3,3) == "PNG") is_image = true
+          if (data.result['filename'].substr(-3,3) == "GIF") is_image = true
+
+          if (is_image) {
+            image_url = data.result.url.split('?')[0];
+            orig_image_url = image_url.replace('medium','original');
+            $E.wrap('[![',']('+image_url+')]('+orig_image_url+')', {'newline': true, 'fallback': data.result['filename']});
+          } else {
+            $E.wrap('<a href="'+data.result.url.split('?')[0]+'"><i class="fa fa-file"></i> ','</a>', {'newline': true, 'fallback': data.result['filename']});
+          }
+
+          if ($('#node_images').val() && $('#node_images').val().split(',').length > 1) $('#node_images').val([$('#node_images').val(),data.result.id].join(','));
+          else $('#node_images').val(data.result.id)
+        },
+
+        // fileuploadfail: function(e,data) {},
+        progressall: function (e, data) {
+          var progress = parseInt(data.loaded / data.total * 100, 10);
+          $('#c<%= comment.id%>progress #c<%= comment.id%>progress-bar').css(
+              'width',
+              progress + '%'
+          );
+        }
+      });
+    </script>
+
+    <div class="comment-preview well col-md-11" id="c<%= comment.id %>preview" style="background:white;display: none">
+    </div>
+
+    <div class="control-group">
+      <button type="submit" class="btn btn-primary"><%= translation('comments._edit.publish') %></button>
+        <a class="btn btn-default preview-btn"  data-previewing-text="Hide Preview"
+            onClick="$('#c<%= comment.id %>preview').toggle();
+            $('#c<%= comment.id %>text').toggle();
+            $('#c<%= comment.id %>text').next('#imagebar').toggle();
+            this.previewing = !this.previewing;
+            $('#c<%= comment.id %>edit .preview-btn').button(this.previewing ? 'previewing' : 'reset');
+            $E.generate_preview('c<%= comment.id %>preview',$('#c<%= comment.id %>text').val())">
+          Preview
+        </a>
+        <a 
+          class="btn btn-default" 
+          onClick="
+            $('#edit-comment-form-wrapper-<%= comment.id %>').toggle();
+            $('#<%= comment.id %>-like-emojis').toggle();
+            $('#c<%= comment.id %>edit').toggle();
+            $('#c<%= comment.id %>show').toggle();
+          "
+        >
+          Cancel
+        </a>
+
+      <span class="form-grey"> &nbsp;
+        <br class="visible-xs" /><%= raw translation('comments._edit.logged_in', :username => current_user.username) %> |
+        <a target="_blank" href="/wiki/authoring-help#Formatting"><%= translation('comments._edit.formatting') %></a> |
+        <a onClick="$('#who-is-notified').toggle()"><%= translation('comments._edit.notifications') %></a>
+      </span>
+    </div>
+
+    <p id="who-is-notified" style="display:none;color:#888;">
+      <%= translation('comments._edit.email_notifications') %>
+    </p>
+  </form>
 </div>

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -1,4 +1,4 @@
-<div id="c<%= comment.cid %>" class="comment" style="margin-top: 20px;padding-bottom: 9px; word-wrap: break-word">
+<div id="c<%= comment.cid %>" class="comment" style="margin-top: 20px; margin-bottom: 20px; padding-bottom: 9px; word-wrap: break-word;">
 
   <div style="margin-bottom: 0;border-bottom-left-radius: 0;border-bottom-right-radius: 0;border-bottom: 0;" class="navbar navbar-light bg-light">
     <% if comment.status == 4 %>
@@ -53,12 +53,26 @@
         <i data-toggle="tooltip" title="This comment was posted by email." class="fa fa-envelope"></i>
       <% end %>
       <% if current_user && comment.uid == current_user.uid %>
-        <a aria-label="Edit comment" class="btn btn-outline-secondary btn-sm" id="edit-comment-btn" href="javascript:void(0)" onClick="$('#c<%= comment.cid %>edit').toggle();$('#c<%= comment.cid %>show').toggle();setInit(<%= comment.cid %>);">
+        <a 
+          aria-label="Edit Comment" 
+          class="btn btn-outline-secondary btn-sm" 
+          data-toggle="tooltip" 
+          id="edit-comment-btn" 
+          href="javascript:void(0)" 
+          onClick="
+            $('#edit-comment-form-wrapper-<%= comment.cid %>').toggle();
+            $('#<%= comment.cid %>-like-emojis').toggle();
+            $('#c<%= comment.cid %>edit').toggle();
+            $('#c<%= comment.cid %>show').toggle();
+            setInit(<%= comment.cid %>);
+          " 
+          title="Edit Comment"
+        >
           <i class="fa fa-pencil"></i>
         </a>
       <% end %>
       <% if current_user &. can_moderate? %>
-        <a aria-label="Mark as spam" rel="tooltip" title="Mark as spam: comment will disappear and user will be banned" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= comment.id %>" data-confirm="Are you sure? The user will no longer be able to log in or publish, and their content will be hidden except comments." href="/admin/mark_comment_spam/<%= comment.id %>">
+        <a aria-label="Mark Spam" rel="tooltip" title="Mark Spam: Remove Comment and Ban User" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= comment.id %>" data-confirm="Are you sure? The user will no longer be able to log in or publish, and their content will be hidden except comments." href="/admin/mark_comment_spam/<%= comment.id %>">
           <i class="fa fa-ban"></i>
         </a>
       <% else %>
@@ -67,17 +81,16 @@
         </a>
       <% end %>
       <% if logged_in_as(['admin', 'moderator']) || (current_user && (comment.uid == current_user.uid || comment.parent.uid == current_user.uid)) %>
-        <a aria-label="Delete comment" rel="tooltip" title="Delete comment" class="btn btn-outline-secondary btn-sm" id="c<%= comment.cid %>delete-btn">
+        <a aria-label="Delete Comment" rel="tooltip" title="Delete Comment" class="btn btn-outline-secondary btn-sm" id="c<%= comment.cid %>delete-btn">
           <i class='icon fa fa-trash'></i>
         </a>
       <% end %>
       <% if current_user %>
-        <button style="border: 1px solid;padding: 4px 6px;" class="btn btn-outline-secondary dropdown" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <i class='icon fa fa-smile-o'></i>
-          <sup style="font-size: 12px;">+</sup>
-        </button>    
+        <a aria-label="Leave an Emoji Reaction" rel="tooltip" title="Leave an Emoji Reaction" class="btn btn-outline-secondary btn-sm dropdown" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <i class='far fa-heart'></i>
+        </a>
         <div id="emoji-dropdown" style="background:#f8f8f8;padding:0;" class=" dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-          <p id="emoji-title" style="text-align: center;color: #586069; font-size:14px;margin:6px;">Pick your reaction</p>
+          <p id="emoji-title" style="text-align: center;color: #586069; font-size:14px;margin:6px;">Pick Your Reaction</p>
           <div id= "dropdown-divider" style="display: block;height: 0;border-top: 1px solid #e1e4e8;">
           </div>         
           <div id="emoji-list" class="emoji-container">              
@@ -157,7 +170,7 @@
         <%= render :partial => "notes/comment", :locals => {:comment => replied_comment} %>
       <% end %>
 
-      <p style="color: #006dcc;cursor: pointer;margin-top: 20px;" id="comment-<%= comment.cid %>-reply-toggle">Reply to this comment...</p>
+      <p style="color: #006dcc; cursor: pointer; user-select: none;" id="comment-<%= comment.cid %>-reply-toggle">Reply to this comment...</p>
       <div id="comment-<%= comment.cid %>-reply" style="margin-top: 30px;display: none;">
         <div id="comment-<%= comment.cid %>-reply-section">
           <% if current_user %>
@@ -182,9 +195,9 @@
 
   </div>
   <% str = "#{comment.id}-like-emojis" %>
-  <div id="<%= str %>" class="navbar-text float-right" style="margin: 0;width: 100%;display: flex;border: 1px solid #e7e7e7;border-top: 0;">
-    <% emoji_names, emoji_image_map = emoji_info %>
-    <% user_reactions_map = comment.user_reactions_map %>
+  <% emoji_names, emoji_image_map = emoji_info %>
+  <% user_reactions_map = comment.user_reactions_map %>
+  <div id="<%= str %>" class="float-right comment-reactions-container" style="margin: 0; width: 100%; display: flex; border: 1px solid #e7e7e7; border-top: 0;">
     <% emoji_names.each do |e| %>
       <% capitalized_emoji_name = e.split("-").map(&:capitalize).join %>
       <% str = "#{comment.id}-emoji-button-#{e}" %>
@@ -192,7 +205,7 @@
       <% display = user_reactions_exist ? "display: flex;" : "display: none;" %>
       <% title = user_reactions_exist ? user_reactions_map[capitalized_emoji_name][:users_string] : "" %>
       <% likes_num = user_reactions_exist ? user_reactions_map[capitalized_emoji_name][:likes_num] : "" %>
-      <button aria-label="Reaction" id="<%= str %>" style="border: 0;background: #f1f8ff;border-radius: 0;border-right: 1px solid #e7e7e7;<%= display %>" type="button" class="btn btn-outline-secondary btn-sm" data-toggle="tooltip" data-placement="bottom" title="<%= title %>">
+      <button aria-label="Reaction" id="<%= str %>" style="border: 0; border-radius: 0px; background: #f1f8ff; border-right: 1px solid #e7e7e7; padding-top: 8px; padding-bottom: 8px; <%= display %>" type="button" class="btn btn-sm" data-toggle="tooltip" data-placement="bottom" title="<%= title %>">
         <img alt="<%= str %>" height="20" width="20" src="<%= emoji_image_map[e] %>">
         <div style="margin-left: 6px;font-size: 14px;"><%= likes_num %></div>
       </button>

--- a/test/system/comment_test.rb
+++ b/test/system/comment_test.rb
@@ -150,7 +150,7 @@ class CommentTest < ApplicationSystemTestCase
         .click
       page.find(".noty_body", text: "Comment Added!")
       # Delete a comment
-      find('.btn[data-original-title="Delete comment"]', match: :first).click()
+      find('.btn[data-original-title="Delete Comment"]', match: :first).click()
       # Click "confirm" on modal
       page.evaluate_script('document.querySelector(".jconfirm-buttons .btn:first-of-type").click()')
       assert_selector('#comments-list .comment', count: 1)


### PR DESCRIPTION
- Removes the weird grey bar that Jeffrey noticed in [this comment](https://github.com/publiclab/plots2/issues/8775#issuecomment-762424107)
  - Fixed by assigning unique ID to edit comment form wrapper, and toggling on **that**
- Removes extra `padding-top` and `padding-top` around emoji reaction buttons (also mentioned in that comment)
- Increase margin space between comments
- Add tooltips for Edit Comment and Emoji Reaction
- Add `user-select: none;` to `Reply to comment` link (makes it un-highlight-able by the user)
- Change hover style on emojis
- Opening Edit Comment form now toggles to hide emoji reactions bar

Will leave detailed notes in the code review, and screenshots!

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)