### PR TITLE
[Outreachy] Tag Model Activity

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -54,7 +54,15 @@ class HomeController < ApplicationController
       # Tags without the blog tag and everything tag to avoid double display
       exclude_tids = Tag.where(name: %w(blog everything)).pluck(:tid)
       # Not all tags have notes, some are wikis. A text will be displayed to show this.
-      @pagy, @tag_subscriptions = pagy(current_user.subscriptions(:tag).includes(:tag).where.not(tid: exclude_tids))
+      # @pagy, @tag_subscriptions = pagy(current_user.subscriptions(:tag).includes(:tag).where.not(tid: exclude_tids))
+      @pagy, @tag_subscriptions = pagy(
+        TagSelection
+        .select('tag_selections.tid, term_data.name')
+        .where(user_id: current_user.id, following: true)
+        .where.not(tid: exclude_tids)
+        .joins("INNER JOIN term_data ON tag_selections.tid = term_data.tid")
+        .order("term_data.activity_timestamp DESC")
+      )
       @trending_tags = trending
       render template: 'dashboard_v2/dashboard'
     else

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -53,8 +53,6 @@ class HomeController < ApplicationController
       @blog = Tag.find_nodes_by_type('blog', 'note', 1).limit(1).first
       # Tags without the blog tag and everything tag to avoid double display
       exclude_tids = Tag.where(name: %w(blog everything)).pluck(:tid)
-      # Not all tags have notes, some are wikis. A text will be displayed to show this.
-      # @pagy, @tag_subscriptions = pagy(current_user.subscriptions(:tag).includes(:tag).where.not(tid: exclude_tids))
       @pagy, @tag_subscriptions = pagy(
         TagSelection
         .select('tag_selections.tid, term_data.name')

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -486,9 +486,14 @@ class WikiController < ApplicationController
         @node.main_image_id = img.id
         img.save
       end
-
       @node.save
+      update_tags if @node.valid?
     end
+  end
+
+  def update_tags
+    tids = NodeTag.where(nid: @node.nid).pluck(:tid)
+    Tag.update_tag_activity(tids, @node.nid)
   end
 
   def author

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -493,7 +493,7 @@ class WikiController < ApplicationController
 
   def update_tags
     tids = NodeTag.where(nid: @node.nid).pluck(:tid)
-    Tag.update_tag_activity(tids, @node.nid)
+    Tag.update_tags_activity(tids, @node.nid)
   end
 
   def author

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -492,7 +492,7 @@ class WikiController < ApplicationController
   end
 
   def update_tags
-    tids = NodeTag.where(nid: @node.nid).pluck(:tid)
+    tids = @node.tag.pluck(:tid)
     Tag.update_tags_activity(tids, @node.nid)
   end
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -675,7 +675,7 @@ class Node < ActiveRecord::Base
   def update_tag_timestamp(cid)
     tids = NodeTag.where(nid: nid).pluck(:tid)
     comment_id = "c#{cid}"
-    Tag.update_tag_activity(tids, comment_id)
+    Tag.update_tags_activity(tids, comment_id)
   end
 
   def new_revision(params)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -668,11 +668,11 @@ class Node < ActiveRecord::Base
                     message_id: params[:message_id],
                     tweet_id: params[:tweet_id])
     c.save
-    update_tag_timestamp(c.cid) if c.valid?
+    update_tag_activity(c.cid) if c.valid?
     c
   end
 
-  def update_tag_timestamp(cid)
+  def update_tag_activity(cid)
     tids = NodeTag.where(nid: nid).pluck(:tid)
     comment_id = "c#{cid}"
     Tag.update_tags_activity(tids, comment_id)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -668,11 +668,11 @@ class Node < ActiveRecord::Base
                     message_id: params[:message_id],
                     tweet_id: params[:tweet_id])
     c.save
-    update_tag_activity(c.cid) if c.valid?
+    tag_activity(c.cid) if c.valid?
     c
   end
 
-  def update_tag_activity(cid)
+  def tag_activity(cid)
     tids = NodeTag.where(nid: nid).pluck(:tid)
     comment_id = "c#{cid}"
     Tag.update_tags_activity(tids, comment_id)
@@ -878,7 +878,6 @@ class Node < ActiveRecord::Base
 
             if node_tag.save
               saved = true
-              tag.run_count # update count of tag usage # REMEMBER The node_tag model has a callback that updates run_count
               # send email notification if there are subscribers, status is OK, and less than 1 month old
               isStatusValid = status == 3 || status == 4
               isMonthOld = created < (DateTime.now - 1.month).to_i

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -673,9 +673,9 @@ class Node < ActiveRecord::Base
   end
 
   def update_tag_timestamp(cid)
-    tags_ids = NodeTag.where(nid: nid).pluck(:tid)
+    tids = NodeTag.where(nid: nid).pluck(:tid)
     comment_id = "c#{cid}"
-    Tag.where(tid: tags_ids).update_all(activity_timestamp: DateTime.now, latest_activity_nid: comment_id)
+    Tag.update_tag_activity(tids, comment_id)
   end
 
   def new_revision(params)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -673,7 +673,7 @@ class Node < ActiveRecord::Base
   end
 
   def tag_activity(cid)
-    tids = self.tag.pluck(:tid)
+    tids = tag.pluck(:tid)
     comment_id = "c#{cid}"
     Tag.update_tags_activity(tids, comment_id)
   end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -668,7 +668,13 @@ class Node < ActiveRecord::Base
                     message_id: params[:message_id],
                     tweet_id: params[:tweet_id])
     c.save
+    update_tag_timestamp if c.valid?
     c
+  end
+
+  def update_tag_timestamp
+    tags_ids = NodeTag.where(nid: nid).pluck(:tid)
+    Tag.where(tid: tags_ids).update_all(activity_timestamp: DateTime.now)
   end
 
   def new_revision(params)
@@ -871,7 +877,7 @@ class Node < ActiveRecord::Base
 
             if node_tag.save
               saved = true
-              tag.run_count # update count of tag usage
+              tag.run_count # update count of tag usage # REMEMBER The node_tag model has a callback that updates run_count
               # send email notification if there are subscribers, status is OK, and less than 1 month old
               isStatusValid = status == 3 || status == 4
               isMonthOld = created < (DateTime.now - 1.month).to_i

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -673,7 +673,7 @@ class Node < ActiveRecord::Base
   end
 
   def tag_activity(cid)
-    tids = NodeTag.where(nid: nid).pluck(:tid)
+    tids = self.tag.pluck(:tid)
     comment_id = "c#{cid}"
     Tag.update_tags_activity(tids, comment_id)
   end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -668,13 +668,14 @@ class Node < ActiveRecord::Base
                     message_id: params[:message_id],
                     tweet_id: params[:tweet_id])
     c.save
-    update_tag_timestamp if c.valid?
+    update_tag_timestamp(c.cid) if c.valid?
     c
   end
 
-  def update_tag_timestamp
+  def update_tag_timestamp(cid)
     tags_ids = NodeTag.where(nid: nid).pluck(:tid)
-    Tag.where(tid: tags_ids).update_all(activity_timestamp: DateTime.now)
+    comment_id = "c#{cid}"
+    Tag.where(tid: tags_ids).update_all(activity_timestamp: DateTime.now, latest_activity_nid: comment_id)
   end
 
   def new_revision(params)

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -8,7 +8,7 @@ class NodeTag < ApplicationRecord
   has_many :tag_selections, foreign_key: 'tid'
   accepts_nested_attributes_for :tag
 
-  after_create :update_count
+  after_create :update_count, :update_timestamp
   after_destroy :update_count
 
   def update_count
@@ -29,5 +29,10 @@ class NodeTag < ApplicationRecord
 
   def description
     tag.description if tag&.description && !tag.description.empty?
+  end
+
+  def update_tag_timestamp
+    tag.update_activity_timestamp
+    tag.save
   end
 end

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -31,7 +31,7 @@ class NodeTag < ApplicationRecord
     tag.description if tag&.description && !tag.description.empty?
   end
 
-  def update_tag_timestamp
+  def update_timestamp
     tag.update_activity_timestamp
     tag.save
   end

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -32,7 +32,7 @@ class NodeTag < ApplicationRecord
   end
 
   def update_timestamp
-    tag.update_activity_timestamp = DateTime.now
+    tag.activity_timestamp = DateTime.now
     tag.latest_activity_nid = nid
     tag.save
   end

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -37,3 +37,5 @@ class NodeTag < ApplicationRecord
     tag.save
   end
 end
+
+unnecessary

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -32,7 +32,7 @@ class NodeTag < ApplicationRecord
   end
 
   def update_timestamp
-    tag.update_activity_timestamp
+    tag.update_activity_timestamp = DateTime.now
     tag.latest_activity_nid = nid
     tag.save
   end

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -33,6 +33,8 @@ class NodeTag < ApplicationRecord
 
   def update_timestamp
     tag.update_activity_timestamp
+    tag.latest_activity_nid = nid
+    # binding.pry
     tag.save
   end
 end

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -8,7 +8,7 @@ class NodeTag < ApplicationRecord
   has_many :tag_selections, foreign_key: 'tid'
   accepts_nested_attributes_for :tag
 
-  after_create :update_count, :update_timestamp
+  after_create :update_count, :update_activity
   after_destroy :update_count
 
   def update_count
@@ -31,7 +31,7 @@ class NodeTag < ApplicationRecord
     tag.description if tag&.description && !tag.description.empty?
   end
 
-  def update_timestamp
+  def update_activity
     tag.activity_timestamp = DateTime.now
     tag.latest_activity_nid = nid
     tag.save

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -34,7 +34,6 @@ class NodeTag < ApplicationRecord
   def update_timestamp
     tag.update_activity_timestamp
     tag.latest_activity_nid = nid
-    # binding.pry
     tag.save
   end
 end

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -37,5 +37,3 @@ class NodeTag < ApplicationRecord
     tag.save
   end
 end
-
-unnecessary

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -438,6 +438,10 @@ class Tag < ApplicationRecord
     save
   end
 
+  def self.update_tag_activity(tids = [], activity_id = nil)
+    Tag.where(tid: tids).update_all(activity_timestamp: DateTime.now, latest_activity_nid: activity_id)
+  end
+
   private
 
   def tids

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -433,11 +433,6 @@ class Tag < ApplicationRecord
     hash.sort_by { |_, v| v }.reverse.first(limit).to_h
   end
 
-  def update_activity_timestamp
-    self.activity_timestamp = DateTime.now
-    save
-  end
-
   def self.update_tag_activity(tids = [], activity_id = nil)
     Tag.where(tid: tids).update_all(activity_timestamp: DateTime.now, latest_activity_nid: activity_id)
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -434,7 +434,7 @@ class Tag < ApplicationRecord
   end
 
   def update_activity_timestamp
-    self.activity_timestamp =  DateTime.now
+    self.activity_timestamp = DateTime.now
     save
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -433,7 +433,7 @@ class Tag < ApplicationRecord
     hash.sort_by { |_, v| v }.reverse.first(limit).to_h
   end
 
-  def self.update_tag_activity(tids = [], activity_id = nil)
+  def self.update_tags_activity(tids = [], activity_id = nil)
     Tag.where(tid: tids).update_all(activity_timestamp: DateTime.now, latest_activity_nid: activity_id)
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -433,6 +433,11 @@ class Tag < ApplicationRecord
     hash.sort_by { |_, v| v }.reverse.first(limit).to_h
   end
 
+  def update_activity_timestamp
+    self.activity_timestamp =  DateTime.now
+    save
+  end
+
   private
 
   def tids

--- a/app/views/dashboard_v2/_topicCard.html.erb
+++ b/app/views/dashboard_v2/_topicCard.html.erb
@@ -2,26 +2,27 @@
 <% subscriptions ||= @tag_subscriptions  # allow overriding with local variable %>
 <% shown_nids = [@blog.nid] %>
 <% subscriptions.each do |subscription| %>
-  <% notes = Tag.find_nodes_by_type(subscription.tag.name, type = 'note', limit = 3).where.not(nid: shown_nids)  %>
+  <% tag_name = subscription.tagname %>
+  <% notes = Tag.find_nodes_by_type(tag_name, type = 'note', limit = 3).where.not(nid: shown_nids)  %>
     <% if notes.present?  %> <%# Topics without notes will not be displayed. If pagination shows many empty pages, refer to https://github.com/publiclab/plots2/issues/8964#issuecomment-763303076 %>
       <div class="card-view pt-5">
           <div class="card shadow-sm p-2 mb-3 bg-white rounded" >
             <div class="card-header mt-2" style=" padding:0.8em; background-color: inherit; border:none;">
             <%# Unfollow section %>
-              <% if current_user && current_user.following(subscription.tag.name) %>
+              <% if current_user && current_user.following(tag_name) %>
                 <a class="ellipsis pull-right" data-toggle="dropdown" style="cursor:pointer" aria-expanded="true"><i class="fa fa-ellipsis-h" style="color:#ccc;font-size:18px;margin-right:10px;"></i></a>
                 <div class="dropdown-menu">
                   <div class="dropdown-item">
-                    <a style="margin-top:-8px;" data-method="delete" data-confirm="Are you sure you'd like to unfollow this topic?" rel="tooltip" title="<%= translation('tag.show.unfollow') %>" href="/unsubscribe/tag/<%= subscription.tag.name %>">
+                    <a style="margin-top:-8px;" data-method="delete" data-confirm="Are you sure you'd like to unfollow this topic?" rel="tooltip" title="<%= translation('tag.show.unfollow') %>" href="/unsubscribe/tag/<%= tag_name %>">
                       <%= translation('tag.show.unfollow_text') %>
                     </a>
                   </div>
                 </div>
               <% end %>
             <%# Topic name %>
-              <h4 style="display: inline-block;"><a href="/tag/<%= subscription.tag.name %>"><%= subscription.tag.name %></a></h4>
+              <h4 style="display: inline-block;"><a href="/tag/<%= tag_name %>"><%= tag_name %></a></h4>
             <%# Follower count  %>
-              <p style="display: inline-block; color: #808080;"><a style="text-decoration: underline; color: #808080;" href="/tag/<%= subscription.tag.name %>"><%= Tag.follower_count(subscription.tag.name) %> <%= translation('tag.show.following') %></a></p>
+              <p style="display: inline-block; color: #808080;"><a style="text-decoration: underline; color: #808080;" href="/tag/<%= tag_name %>"><%= Tag.follower_count(tag_name) %> <%= translation('tag.show.following') %></a></p>
             </div>
             <div class="card-body" style="padding:0.8em;">
             <%# First 3 notes in the Topic  %>
@@ -48,15 +49,15 @@
             </div>
 
             <div class="card-footer" style="background-color: inherit; border:none;">
-              <% note_count = post_count(subscription.tag.name, 'note') %>
-              <% wiki_count = post_count(subscription.tag.name, 'page') %>
-              <a style="padding-top:15px;text-decoration:underline;color:#808080;display:inline-block;" href="/tag/<%= subscription.tag.name %>"><%= note_count %> <% if note_count > 1 %> <%= translation('tag.index.post').pluralize %> <% else %> <%= translation('tag.index.post') %> <% end %></a> |
-              <a style="text-decoration:underline;color:#808080;display:inline-block;" href="/wiki/<%= subscription.tag.name %>"><%= wiki_count %><% if wiki_count > 1 %> <%= translation('tag.index.wiki').pluralize %> <% else %> <%= translation('tag.index.wiki') %> <% end %></a>
+              <% note_count = post_count(tag_name, 'note') %>
+              <% wiki_count = post_count(tag_name, 'page') %>
+              <a style="padding-top:15px;text-decoration:underline;color:#808080;display:inline-block;" href="/tag/<%= tag_name %>"><%= note_count %> <% if note_count > 1 %> <%= translation('tag.index.post').pluralize %> <% else %> <%= translation('tag.index.post') %> <% end %></a> |
+              <a style="text-decoration:underline;color:#808080;display:inline-block;" href="/wiki/<%= tag_name %>"><%= wiki_count %><% if wiki_count > 1 %> <%= translation('tag.index.wiki').pluralize %> <% else %> <%= translation('tag.index.wiki') %> <% end %></a>
               <div id="new-post" style="float:right;margin:10px 0 10px 10px;">
                 <% if current_user %>
-                  <a rel="tooltip" title="<%= translation('sidebar._post_button.share_your_work') %>" data-placement="bottom" href="/post?tags=<%= subscription.tag.name %>" class="btn btn-primary btn-sm requireLogin"><%= translation('tag.show.new_post') %> <i class="fa fa-plus fa-white"></i></a>
+                  <a rel="tooltip" title="<%= translation('sidebar._post_button.share_your_work') %>" data-placement="bottom" href="/post?tags=<%= tag_name %>" class="btn btn-primary btn-sm requireLogin"><%= translation('tag.show.new_post') %> <i class="fa fa-plus fa-white"></i></a>
                 <% else %>
-                  <a class="btn btn-primary btn-sm index-follow-buttons follow-btn-remote requireLogin" href="/subscribe/tag/<%= subscription.tag.name %>" data-remote="true"><%= translation('tag.index.follow') %></a>
+                  <a class="btn btn-primary btn-sm index-follow-buttons follow-btn-remote requireLogin" href="/subscribe/tag/<%= tag_name %>" data-remote="true"><%= translation('tag.index.follow') %></a>
                 <% end %>
               </div>
             </div>

--- a/db/migrate/20210208151828_add_activity_timestamp_to_tag.rb
+++ b/db/migrate/20210208151828_add_activity_timestamp_to_tag.rb
@@ -1,0 +1,5 @@
+class AddActivityTimestampToTag < ActiveRecord::Migration[5.2]
+  def change
+    add_column :term_data, :activity_timestamp, :datetime
+  end
+end

--- a/db/migrate/20210210155509_add_latest_activity_nid_to_tag.rb
+++ b/db/migrate/20210210155509_add_latest_activity_nid_to_tag.rb
@@ -1,0 +1,5 @@
+class AddLatestActivityNidToTag < ActiveRecord::Migration[5.2]
+  def change
+    add_column :term_data, :latest_activity_nid, :string
+  end
+end

--- a/test/fixtures/node_tags.yml
+++ b/test/fixtures/node_tags.yml
@@ -279,3 +279,8 @@ question_with_multiple_comments: # another question for testing comments
   tid: 35
   uid: 2
   nid: 40
+
+sub_tag:
+  tid: 37
+  nid: 1
+  uid: 2

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -44,9 +44,18 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should create note comments' do
     UserSession.create(users(:bob))
+    node = nodes(:one)
     assert_difference 'Comment.count' do
-      post :create, params: { id: nodes(:one).nid, body: '[notes:awesome]' }, xhr: true
+      post :create, params: { id: node.nid, body: '[notes:awesome]' }, xhr: true
     end
+
+    # latest_activity_nid for the node should be updated with the comment id in the format 'c_comment_id'
+    cid = Comment.where(comment: '[notes:awesome]').first.cid
+    expected_activity_nid = "c#{cid}"
+    node_tid = node.tag.first.tid
+    returned_activity_nid = Tag.where(tid: node_tid).first.latest_activity_nid
+
+    assert_equal expected_activity_nid, returned_activity_nid
     assert_response :success
     assert_not_nil :comment
     assert_template partial: 'notes/_comment'

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -278,6 +278,9 @@ class NotesControllerTest < ActionController::TestCase
       email = ActionMailer::Base.deliveries.last
       assert_equal '[PublicLab] ' + title + ' (#' + Node.last.id.to_s + ') ', email.subject
       assert_equal 1, Node.last.status
+      # Tag count should increase
+      tag = Node.last.tag.first
+      assert_equal 1, tag.count
       assert_redirected_to '/notes/' + users(:jeff).username + '/' + Time.now.strftime('%m-%d-%Y') + '/' + title.parameterize
     end
   end

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -747,6 +747,12 @@ class NotesControllerTest < ActionController::TestCase
            body: 'Some text.',
            tags: 'event'
            }
+      # latest_activity_nid should be updated with the node nid created in all tags
+      nid = Tag.where(name: 'event').first.latest_activity_nid.to_i
+      node = Node.where(nid: nid).first
+
+      assert_equal node.title, title + lang.to_s
+      assert_equal node.latest.body, 'Some text.'
 
       assert_equal I18n.t('notes_controller.research_note_published'), flash[:notice]
     end

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -109,7 +109,7 @@ class WikiControllerTest < ActionController::TestCase
          body:  'This is fascinating documentation about balloon mapping.',
          tags:  'balloon-mapping,event'
          }
-    # latest_activity_nid should be updated with wiki nid created in all tags
+    # latest_activity_nid should be updated with the wiki nid created in all tags
     wiki_nid = Tag.where(name: 'balloon-mapping').first.latest_activity_nid.to_i
     wiki = Node.where(nid: wiki_nid).first
 

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -109,7 +109,12 @@ class WikiControllerTest < ActionController::TestCase
          body:  'This is fascinating documentation about balloon mapping.',
          tags:  'balloon-mapping,event'
          }
+    # latest_activity_nid should be updated with wiki nid created in all tags
+    wiki_nid = Tag.where(name: 'balloon-mapping').first.latest_activity_nid.to_i
+    wiki = Node.where(nid: wiki_nid).first
 
+    assert_equal wiki.title, title
+    assert_equal wiki.latest.body, 'This is fascinating documentation about balloon mapping.'
     assert_redirected_to '/wiki/' + title.parameterize
   end
 
@@ -173,7 +178,10 @@ class WikiControllerTest < ActionController::TestCase
     newtitle = 'New Title'
 
     post :update, params: { id: wiki.nid, uid: users(:bob).id, title: newtitle, body: 'Editing about Page' }
+    # latest_activity_nid should be updated in all tags related to the wiki
+    latest_activity_nid = wiki.tag.first.latest_activity_nid.to_i
 
+    assert_equal latest_activity_nid, wiki.nid
     assert_redirected_to wiki.path
     assert_equal flash[:notice], 'Edits saved.'
   end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -296,9 +296,9 @@ class NodeTest < ActiveSupport::TestCase
     assert !node.node_tags.empty?
     assert_not_nil node.tagnames
     assert node.tagnames.first.is_a?(String)
-    assert_equal 'test awesome spectrometer activity:spectrometer', node.tagnames.join(' ')
+    assert_equal 'test awesome spectrometer activity:spectrometer sub:tag', node.tagnames.join(' ')
     # used to generate CSS classes:
-    assert_equal 'tag-test tag-awesome tag-spectrometer tag-activity-spectrometer', node.tagnames_as_classes
+    assert_equal 'tag-test tag-awesome tag-spectrometer tag-activity-spectrometer tag-sub-tag', node.tagnames_as_classes
   end
 
   test 'should have subscribers' do


### PR DESCRIPTION
Fixes https://github.com/publiclab/plots2/issues/9160

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

If a comment, note, or wiki is created within a topic, the topic latest_activity_nid and activity_timestamp attributes get updated with the comment id "c#{comment_id}", note id, wiki id.

This also happens when a wiki is edited.
