### PR TITLE
Tweak config for MySQL 5.7 compatibility

### DIFF
--- a/config/my.cnf
+++ b/config/my.cnf
@@ -12,7 +12,7 @@ pid-file = /var/lib/mysql/mysqld
 #
 # * Fine Tuning
 #
-key_buffer		= 16M
+# key_buffer		= 16M     # Not compatible with MySQL 5.7
 max_allowed_packet	= 16M
 thread_stack		= 192K
 thread_cache_size       = 8


### PR DESCRIPTION
This is to fix configuration for the MySQL 5.7 container