### PR TITLE
Add Tooltips to Fresh Comments

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -392,6 +392,7 @@ class Tag < ApplicationRecord
         .group(:tid)
         .where('node.status': 1)
         .where('term_data.name NOT LIKE (?)', '%:%')
+        .where.not(name: 'first-time-poster')
         .order(count: :desc)
         .limit(limit).each do |tag|
         data["tags"] << {

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -392,7 +392,6 @@ class Tag < ApplicationRecord
         .group(:tid)
         .where('node.status': 1)
         .where('term_data.name NOT LIKE (?)', '%:%')
-        .where.not(name: 'first-time-poster')
         .order(count: :desc)
         .limit(limit).each do |tag|
         data["tags"] << {

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -8,7 +8,7 @@
   style="
     background-color: #f8f8f8; 
     border: 1px solid #e7e7e7;
-    padding: 18px;
+    padding: 36px;
     <%= "display: none" if location == :edit  %>
   "
 >

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -41,3 +41,5 @@ fileUploadElements.forEach(function(element) {
 });
 notyNotification('mint', 3000, 'success', 'topRight', 'Comment Added!');
 $('#comment-count')[0].innerHTML = parseInt($('#comment-count')[0].innerHTML, 10)+1;
+// attach tooltips to comment buttons
+$('[data-toggle="tooltip"]').tooltip();

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -83,7 +83,7 @@
         </a>
       <% end %>
       <% if current_user %>
-        <a aria-label="Leave an Emoji Reaction" data-toggle="tooltip" title="Leave an Emoji Reaction" class="btn btn-outline-secondary btn-sm dropdown" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a aria-label="Leave an Emoji Reaction" rel="tooltip" title="Leave an Emoji Reaction" class="btn btn-outline-secondary btn-sm dropdown" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i class='far fa-heart'></i>
         </a>
         <div id="emoji-dropdown" style="background:#f8f8f8;padding:0;" class=" dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -56,7 +56,7 @@
         <a 
           aria-label="Edit Comment" 
           class="btn btn-outline-secondary btn-sm edit-comment-btn" 
-          rel="tooltip" 
+          data-toggle="tooltip" 
           title="Edit Comment"
           href="javascript:void(0)" onClick="
             $('#comment-form-wrapper-edit-<%= comment.cid %>').toggle();
@@ -69,21 +69,21 @@
         </a>
       <% end %>
       <% if current_user &. can_moderate? %>
-        <a aria-label="Mark Spam" rel="tooltip" title="Mark Spam: Remove Comment and Ban User" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= comment.id %>" data-confirm="Are you sure? The user will no longer be able to log in or publish, and their content will be hidden except comments." href="/admin/mark_comment_spam/<%= comment.id %>">
+        <a aria-label="Mark Spam" data-toggle="tooltip" title="Mark Spam: Remove Comment and Ban User" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= comment.id %>" data-confirm="Are you sure? The user will no longer be able to log in or publish, and their content will be hidden except comments." href="/admin/mark_comment_spam/<%= comment.id %>">
           <i class="fa fa-ban"></i>
         </a>
       <% else %>
-        <a aria-label="Flag as spam" rel="tooltip" title="Flag as spam to moderators" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= comment.id %>" href="/moderate/flag_comment/<%= comment.id %>" data-toggle="tooltip" data-placement="top" title="Flag this Comment">
+        <a aria-label="Flag as spam" data-toggle="tooltip" title="Flag as spam to moderators" class="btn btn-sm btn-outline-secondary btn-flag-spam-<%= comment.id %>" href="/moderate/flag_comment/<%= comment.id %>" data-toggle="tooltip" data-placement="top" title="Flag this Comment">
           <i class="fa fa-flag"></i>
         </a>
       <% end %>
       <% if logged_in_as(['admin', 'moderator']) || (current_user && (comment.uid == current_user.uid || comment.parent.uid == current_user.uid)) %>
-        <a aria-label="Delete Comment" rel="tooltip" title="Delete Comment" class="btn btn-outline-secondary btn-sm" id="c<%= comment.cid %>delete-btn">
+        <a aria-label="Delete Comment" data-toggle="tooltip" title="Delete Comment" class="btn btn-outline-secondary btn-sm" id="c<%= comment.cid %>delete-btn">
           <i class='icon fa fa-trash'></i>
         </a>
       <% end %>
       <% if current_user %>
-        <a aria-label="Leave an Emoji Reaction" rel="tooltip" title="Leave an Emoji Reaction" class="btn btn-outline-secondary btn-sm dropdown" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a aria-label="Leave an Emoji Reaction" data-toggle="tooltip" title="Leave an Emoji Reaction" class="btn btn-outline-secondary btn-sm dropdown" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i class='far fa-heart'></i>
         </a>
         <div id="emoji-dropdown" style="background:#f8f8f8;padding:0;" class=" dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
@@ -132,13 +132,9 @@
         }
       });
     });
-
-    $(function () {
-      $('[data-toggle="tooltip"]').tooltip()
-    })
   </script>
 
-  <div style="border: 1px solid #e7e7e7;padding: 18px;" id="c<%= comment.cid %>show">
+  <div style="border: 1px solid #e7e7e7;padding: 36px;" id="c<%= comment.cid %>show">
 
     <% comment_body = comment.render_body %>
     <div class="comment-body" id="comment-body-<%= comment.cid %>">

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -36,5 +36,7 @@
   $(function() {
     // create an instance of the editor
     $E = new Editor();
+    // attach tooltips to comment buttons
+    $('[data-toggle="tooltip"]').tooltip();
   });
 </script>

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -38,5 +38,6 @@
     $E = new Editor();
     // attach tooltips to comment buttons
     $('[data-toggle="tooltip"]').tooltip();
+    $('[rel="tooltip"]').tooltip();
   });
 </script>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -9,6 +9,7 @@
     $E = new Editor();
     // attach tooltips to comment buttons
     $('[data-toggle="tooltip"]').tooltip();
+    $('[rel="tooltip"]').tooltip();
   });
 </script>
 <%= javascript_include_tag('question') %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -7,6 +7,8 @@
     $("img").lazyload();
     // create an instance of the editor
     $E = new Editor();
+    // attach tooltips to comment buttons
+    $('[data-toggle="tooltip"]').tooltip();
   });
 </script>
 <%= javascript_include_tag('question') %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -71,6 +71,7 @@
       $E = new Editor();
       // attach tooltips to comment buttons
       $('[data-toggle="tooltip"]').tooltip();
+      $('[rel="tooltip"]').tooltip();
     <% end %>
 
     setupWiki(<%= @node.id %>, "<%= @node.title %>", <%= params[:raw] == 'true' %>, <%= current_user.nil? != true %>);

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -69,6 +69,8 @@
     <% if controller.action_name == 'comments' %>
       // create an instance of the editor
       $E = new Editor();
+      // attach tooltips to comment buttons
+      $('[data-toggle="tooltip"]').tooltip();
     <% end %>
 
     setupWiki(<%= @node.id %>, "<%= @node.title %>", <%= params[:raw] == 'true' %>, <%= current_user.nil? != true %>);


### PR DESCRIPTION
I noticed that hover tooltips weren't showing for fresh comments. Made some slight tweaks in the views so this would happen.

Also adjusted the padding for comments... The padding has seemed a little too narrow lately and I remember it being a bit wider.

Before:
<img width="620" alt="Screen Shot 2021-02-14 at 1 39 39 PM" src="https://user-images.githubusercontent.com/4361605/107889834-19c93d00-6eca-11eb-899a-56b930d8ef6a.png">

After:
<img width="603" alt="Screen Shot 2021-02-14 at 1 34 27 PM" src="https://user-images.githubusercontent.com/4361605/107889816-f900e780-6ec9-11eb-8908-32d1a61250bb.png">

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)