### PR TITLE
Fix for preview button

### DIFF
--- a/app/views/editor/post.html.erb
+++ b/app/views/editor/post.html.erb
@@ -108,7 +108,7 @@
           <% end %>
 
           <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg">Publish</a>
-          <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()">Preview</a>
+          <a tabindex="6" id="toggle-preview-button-main" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
 
           <%= render partial: 'editor/event' %>
 

--- a/app/views/editor/question.html.erb
+++ b/app/views/editor/question.html.erb
@@ -108,8 +108,7 @@
           <% end %>
 
           <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg">Publish</a>
-          <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()">Preview</a>
-
+          <a tabindex="6" id="toggle-preview-button-main" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
           <%= render partial: 'editor/event' %>
 
         </div>

--- a/app/views/features/_form.html.erb
+++ b/app/views/features/_form.html.erb
@@ -23,5 +23,5 @@
 </div>
 <div>
   <input type="submit" id="publish" tabindex="5" class="publish btn btn-primary btn-lg" value="Save" />
-  <a tabindex="6" data-previewing-text="Previewing (click to edit)" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()">Preview</a>
+  <a tabindex="6" id="toggle-preview-button-main" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
 </div>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -74,7 +74,7 @@
           <br>
           <a id="publish" tabindex="5" class="publish btn btn-primary btn-lg"><%= translation('wiki.edit.publish') %></a>
           <!-- due to translation helper issues the following line cannot use the `translation()` helper - https://github.com/publiclab/plots2/issues/7798 -->
-          <a tabindex="6" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
+          <a tabindex="6" id="toggle-preview-button-main" data-previewing-text="<%= t('wiki.edit.previewing_text') %>" class="btn btn-outline-secondary btn-lg preview-btn" onClick="$E.toggle_preview()"><%= t('wiki.edit.preview') %></a>
           <a class="btn btn-outline-secondary btn-lg" href="/wiki/<%= params["id"] %>">Cancel</a>
 
         </div>


### PR DESCRIPTION
Fixes #7122  
On clicking the Preview button the text in button was not changing as intended 
![previewnotwrk](https://user-images.githubusercontent.com/38528640/108607126-81105100-73e4-11eb-9f8a-c52326fd2312.gif)


[here](https://github.com/publiclab/plots2/blob/cc98fd8a2b325fef7c7b7ab1dcc08ed83d76b04e/app/assets/javascripts/editor.js#L138) the previewBtn is defined based on id of tag but [here](https://github.com/publiclab/plots2/blob/cc98fd8a2b325fef7c7b7ab1dcc08ed83d76b04e/app/views/wiki/edit.html.erb#L77) there is no such tag .So I declared the id same as the one being used in the .js file and it solves the issue.
After changes
![previewworking](https://user-images.githubusercontent.com/38528640/108607122-7c4b9d00-73e4-11eb-87aa-ebdeeeb5a791.gif)


I also found some other files having similar declaration so I changed them too.
