### PR TITLE
Rename restful_typeahead.js to restfulTypeahead.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -49,7 +49,7 @@
 //= require editor.js
 //= require like.js
 //= require mainImage.js
-//= require restful_typeahead.js
+//= require restfulTypeahead.js
 //= require users.js
 //= require searchform.js
 //= require tagging.js

--- a/app/assets/javascripts/restfulTypeahead.js
+++ b/app/assets/javascripts/restfulTypeahead.js
@@ -1,5 +1,5 @@
 /**
-  The restful_typeahead.js script provides generic typeahead functionality for the plots2 Rails app.
+  The restfulTypeahead.js script provides generic typeahead functionality for the plots2 Rails app.
   The set of functions here are intended to provide a link between the data available through the RESTful
   search API and the UI components.
   Documentation here: https://github.com/bassjobsen/Bootstrap-3-Typeahead


### PR DESCRIPTION
Fixes #9150

restful_typeahead.js --> restfulTypeahead.js camelCase. The name is also changed at other places as described in the issue #9150 