### PR TITLE
Rename restful typeahead

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -49,7 +49,7 @@
 //= require editor.js
 //= require like.js
 //= require mainImage.js
-//= require restful_typeahead.js
+//= require restfulTypeahead.js
 //= require users.js
 //= require searchform.js
 //= require tagging.js

--- a/app/assets/javascripts/restfulTypeahead.js
+++ b/app/assets/javascripts/restfulTypeahead.js
@@ -1,5 +1,5 @@
 /**
-  The restful_typeahead.js script provides generic typeahead functionality for the plots2 Rails app.
+  The restfulTypeahead.js script provides generic typeahead functionality for the plots2 Rails app.
   The set of functions here are intended to provide a link between the data available through the RESTful
   search API and the UI components.
   Documentation here: https://github.com/bassjobsen/Bootstrap-3-Typeahead

--- a/app/assets/javascripts/restfulTypeahead.js
+++ b/app/assets/javascripts/restfulTypeahead.js
@@ -5,8 +5,8 @@
   Documentation here: https://github.com/bassjobsen/Bootstrap-3-Typeahead
 **/
 
-$(function() {
-  $('input.search-query.typeahead').each(function(i, el){
+$(function () {
+  $('input.search-query.typeahead').each(function (i, el) {
 
     var typeahead = $(el).typeahead({
       items: "all",
@@ -17,13 +17,9 @@ $(function() {
       source: debounce(function (query, process) {
 
         query = query.replace(' ', '-'); // replace spaces with hyphens
-        var encoded_query = encodeURIComponent(query); 
-        var qryType = $(el).attr('qryType'); 
-        if (qryType == "tags") {
-          var queryUrl = '/tag/suggested/' + encoded_query;
-        } else {
-          var queryUrl = 'api/srch/' + qryType + '?query=' + encoded_query;
-        }
+        var encoded_query = encodeURIComponent(query);
+        var qryType = $(el).attr('qryType');
+        const queryUrl = (qryType === "tags") ? "/tag/suggested/" + encoded_query : "api/srch/" + qryType + "?query=" + encoded_query;
 
         // search analytics
         if (window.hasOwnProperty('ga')) {
@@ -31,15 +27,15 @@ $(function() {
           tracker.send("pageview", queryUrl + '&typeahead=true');
         }
 
-        if (qryType == "tags") {
-         return $.post('/tag/suggested/' + encoded_query, {}, function (data) { 
-           var objects = data.map(function(a) { return { doc_title: a } });
-           return process(objects);
-         });
+        if (qryType === "tags") {
+          return $.post('/tag/suggested/' + encoded_query, {}, function (data) {
+            var objects = data.map(function (a) { return { doc_title: a } });
+            return process(objects);
+          });
         } else {
           return $.getJSON('/' + queryUrl, function (data) {
             return process(data.items);
-          },'json');
+          }, 'json');
         }
 
       }, 350),
@@ -48,15 +44,15 @@ $(function() {
         return item.doc_title;
       },
 
-      matcher: function() {
+      matcher: function () {
         return true;
       },
 
-      displayText: function(item) {
+      displayText: function (item) {
         return item.doc_title;
       },
 
-      updater: function(item) {
+      updater: function (item) {
         if (item.hasOwnProperty('showAll') && item.showAll) {
           var query = this.value;
           window.location = window.location.origin + "/search/?q=" + query;
@@ -70,7 +66,8 @@ $(function() {
         return item;
       },
 
-      addItem: { doc_title: 'Search all content',
+      addItem: {
+        doc_title: 'Search all content',
         showAll: true
       }
     });


### PR DESCRIPTION
Fixes #9150

restful_typeahead.js --> restfulTypeahead.js camelCase. The name is also changed at other places as described in the issue #9150. Improved #9227 