### PR TITLE
Hide <textarea> When Toggling Preview in Legacy Editor

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -3,12 +3,13 @@ class Editor {
   //   defaultForm - when the Editor is initialized, there needs to be a default editor form:
   //     1. the main comment form in multi-comment wikis, questions, & research notes.
   //     2. the only editor form on /wiki/new and /wiki/edit
-  //   elementIDPrefixes - the ID naming conventions are different depending on context:
+  //   isSingleFormPage - to distinguish between a) pages with multiple comments b) pages like /wiki/new, and /features/new with only one comment form
+  //     elements have different ID naming conventions on the two kinds of pages:
   //     1. multi-form pages with multiple comments: #comment-preview-123
   //     2. /wiki/new and /wiki/edit: #preview-main
-  constructor(defaultForm = "main", elementIDPrefixes = {}) {
+  constructor(defaultForm = "main", isSingleFormPage = false) {
     this.commentFormID = defaultForm;
-    this.elementIDPrefixes = elementIDPrefixes;
+    this.isSingleFormPage = isSingleFormPage;
     // this will get deleted in the next few PRs, so collapsing into one line to pass codeclimate
     this.templates = { 'blog': "## The beginning\n\n## What we did\n\n## Why it matters\n\n## How can you help", 'default': "## What I want to do\n\n## My attempt and results\n\n## Questions and next steps\n\n## Why I'm interested", 'support': "## Details about the problem\n\n## A photo or screenshot of the setup", 'event': "## Event details\n\nWhen, where, what\n\n## Background\n\nWho, why", 'question': "## What I want to do or know\n\n## Background story" };
       
@@ -40,11 +41,8 @@ class Editor {
     return this.textAreaElement.val(); 
   }
   get previewElement() {
-    let previewIDPrefix = "#comment-preview-";
-    if (this.elementIDPrefixes.hasOwnProperty("preview")) {
-      // eg. on /wiki/new & /wiki/edit, the preview element is called #preview-main
-      previewIDPrefix = "#" + this.elementIDPrefixes["preview"] + "-";
-    }
+    // eg. on /wiki/new & /wiki/edit, the preview element is called #preview-main
+    const previewIDPrefix = this.isSingleFormPage ? "#preview-" : "#comment-preview-"
     const previewID = previewIDPrefix + this.commentFormID;
     return $(previewID);
   }
@@ -136,7 +134,8 @@ class Editor {
     // if the element is part of a multi-comment page,
     // ensure to grab the current element and not the other comment element.
     const previewBtn = $("#toggle-preview-button-" + this.commentFormID);
-    const commentFormBody = $("#comment-form-body-" + this.commentFormID);
+    const formIdPrefix = this.isSingleFormPage ? "#form-body-" : "#comment-form-body-";
+    const commentFormBody = $(formIdPrefix + this.commentFormID);
 
     this.previewElement[0].innerHTML = marked(this.textAreaValue);
     this.previewElement.toggle();

--- a/app/views/editor/_editor.html.erb
+++ b/app/views/editor/_editor.html.erb
@@ -1,7 +1,7 @@
 <%# toolbar needs location & comment_id to make unique element IDs%>
 <%= render :partial => "editor/toolbar", :locals => { :location => :main } %>
 
-<div class="form-group dropzone dropzone-large" data-form-id="main">
+<div id="form-body-main" class="form-group dropzone dropzone-large" data-form-id="main">
   <textarea 
     id="text-input-main" 
     class="form-control text-input" 
@@ -56,7 +56,7 @@
   jQuery(document).ready(function() {
     $E = new Editor(
       "main", 
-      { "preview": "preview" } // the preview element here is #preview-main, not #comment-preview-main
+      true // isSingleFormPage = true
     );
   })
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -556,7 +556,7 @@ en:
       create_page: "Create page"
       publish: "Publish"
       preview: "Preview"
-      previewing_text: "Previewing (click to edit)"
+      previewing_text: "Hide Preview"
       agree_to_open_source_work: "By publishing, you agree to <a target='_blank' href='%{url1}'>open
         source your work</a> so that others may use it."
       last_edited_by: "This page was last edited %{time} ago by <a href='%{url1}'>%{author}</a>"

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -122,6 +122,20 @@ class PostTest < ApplicationSystemTestCase
     page.assert_selector('#preview-main img', count: 1)
   end
 
+  test 'preview works in legacy wiki editor' do
+    visit '/wiki/new'
+    legacy_editor = page.find('#legacy-editor-container')
+    preview_button = page.find("#toggle-preview-button-main")
+    legacy_editor
+      .find('#text-input-main')
+      .click
+      .fill_in with: 'stuff!'
+    preview_button.click
+    assert_equal('Hide Preview', preview_button.text)
+    assert_selector('#preview-main')
+    assert legacy_editor.has_no_selector?('#text-input-main')
+  end
+
   test "changing and reverting versions works correctly for wiki" do
     visit '/wiki/wiki-page-path/'
 


### PR DESCRIPTION
Fix for this bug mentioned in this comment: https://github.com/publiclab/plots2/pull/9221#issuecomment-782782858

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)