### PR TITLE
Removed answered_questions code

### DIFF
--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -214,7 +214,6 @@ class TagController < ApplicationController
     @notes = nodes.where('node.nid NOT IN (?)', qids) if @node_type == 'note'
     @questions = nodes.where('node.nid IN (?)', qids) if @node_type == 'questions'
     ans_ques = Answer.where(uid: @user.id, accepted: true).includes(:node).map(&:node)
-    @answered_questions = ans_ques.paginate(page: params[:page], per_page: 24)
     @wikis = nodes if @node_type == 'wiki'
     @nodes = nodes if @node_type == 'maps'
     @title = "'" + @tagname.to_s + "' by " + params[:author]

--- a/app/controllers/tag_controller.rb
+++ b/app/controllers/tag_controller.rb
@@ -213,7 +213,6 @@ class TagController < ApplicationController
 
     @notes = nodes.where('node.nid NOT IN (?)', qids) if @node_type == 'note'
     @questions = nodes.where('node.nid IN (?)', qids) if @node_type == 'questions'
-    ans_ques = Answer.where(uid: @user.id, accepted: true).includes(:node).map(&:node)
     @wikis = nodes if @node_type == 'wiki'
     @nodes = nodes if @node_type == 'maps'
     @title = "'" + @tagname.to_s + "' by " + params[:author]

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -558,14 +558,6 @@ class TagControllerTest < ActionController::TestCase
     assert_equal selector.size, 1
   end
 
-  test 'should list answered questions' do
-    tag = tags(:question)
-
-    get :show_for_author, params: { id: tag.name, author: 'jeff' }
-
-    assert_not_nil assigns(:answered_questions)
-  end
-
   test 'should take node type as note if tag is not a question tag for show_for_author' do
     tag = tags(:awesome)
 


### PR DESCRIPTION
Fixes #8804  (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!

@jywarren I just observed that there was another instance of `answered questions` which I hadn't removed in my previous PR #9119
