### PR TITLE
Add Default Option for Maps Display: People Layer

### DIFF
--- a/app/views/map/_leaflet.html.erb
+++ b/app/views/map/_leaflet.html.erb
@@ -32,8 +32,12 @@
     <% end %>
 
     var markers_hash<%= unique_id %> = new Map() ;
-
-    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>);
+    var options<%= unique_id %> = {
+        layers: ['PLpeople'],
+        mainContent: "content",
+        setHash: false
+      }
+    setupLEL(map<%= unique_id %>, markers_hash<%= unique_id %>, options<%= unique_id %>);
 
     map<%= unique_id %>.on('zoomend' , function () {
        var NWlat = map<%= unique_id %>.getBounds().getNorthWest().lat ;


### PR DESCRIPTION
Fixes #8513

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

![Screenshot 2021-03-08 at 20 30 15](https://user-images.githubusercontent.com/7622875/110359142-33375200-804e-11eb-8678-d7bc06f9d4ba.png)

While running this locally, I noticed this URL being fetched. It attaches the owmloading.gif to the browser path. However, it doesn't seem to affect the loading icon on the map, it is still displayed.
![Screenshot 2021-03-08 at 19 48 07](https://user-images.githubusercontent.com/7622875/110359472-96c17f80-804e-11eb-9036-5411179c9add.png)
