### PR TITLE
refine comment mailer functional tests

### DIFF
--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -290,8 +290,10 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send mail to moderator if comment has status 4' do
     UserSession.create(users(:moderator))
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true
+    perform_enqueued_jobs do 
+      assert_changes 'ActionMailer::Base.deliveries.size' do
+        post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true
+      end
     end
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:moderator).email])
   end
@@ -306,8 +308,10 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send mail to tag followers in the comment' do
     UserSession.create(users(:jeff))
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      post :create, params: { id: nodes(:question).nid, body: 'Question #awesome', type: 'question' }, xhr: true
+    perform_enqueued_jobs do 
+      assert_changes 'ActionMailer::Base.deliveries.size' do
+        post :create, params: { id: nodes(:question).nid, body: 'Question #awesome', type: 'question' }, xhr: true
+      end
     end
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:bob).email])
     # tag followers can be found in tag_selection.yml
@@ -315,8 +319,10 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send mail to multiple tag followers in the comment' do
     UserSession.create(users(:jeff))
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      post :create, params: { id: nodes(:question).nid, body: 'Question #everything #awesome', type: 'question' }, xhr: true
+    perform_enqueued_jobs do 
+      assert_changes 'ActionMailer::Base.deliveries.size' do
+        post :create, params: { id: nodes(:question).nid, body: 'Question #everything #awesome', type: 'question' }, xhr: true
+      end
     end
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:bob).email])
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:moderator).email])
@@ -325,8 +331,10 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send notification email upon a new wiki comment' do
     UserSession.create(users(:jeff))
-    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      post :create, params: { id: nodes(:wiki_page).nid, body: 'A comment by Jeff on a wiki page of author bob', type: 'page' }, xhr: true
+    perform_enqueued_jobs do 
+      assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+        post :create, params: { id: nodes(:wiki_page).nid, body: 'A comment by Jeff on a wiki page of author bob', type: 'page' }, xhr: true
+      end
     end
     assert ActionMailer::Base.deliveries.collect(&:subject).include?("New comment on Wiki page title (#11) - #c#{Comment.last.id}")
   end
@@ -376,11 +384,13 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should not send notification email to author if notify-comment-direct:false usertag is present' do
     UserSession.create(users(:jeff))
-    assert_difference 'ActionMailer::Base.deliveries.size', 0 do
-      post :create, params: {
-        id: nodes(:activity).nid,
-        body: 'A comment by Jeff on note of author test_user'
-      }, xhr: true
+    perform_enqueued_jobs do 
+      assert_difference 'ActionMailer::Base.deliveries.size', 0 do
+        post :create, params: {
+          id: nodes(:activity).nid,
+          body: 'A comment by Jeff on note of author test_user'
+        }, xhr: true
+      end
     end
     assert_not ActionMailer::Base.deliveries.collect(&:subject).include?("New comment on #{nodes(:activity).title} (##{nodes(:activity).nid}) ")
     assert_not ActionMailer::Base.deliveries.collect(&:to).include?([users(:test_user).email])

--- a/test/functional/comment_controller_test.rb
+++ b/test/functional/comment_controller_test.rb
@@ -290,7 +290,9 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send mail to moderator if comment has status 4' do
     UserSession.create(users(:moderator))
-    post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      post :create, params: { id: nodes(:one).nid, body: 'example', status: 4 }, xhr: true
+    end
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:moderator).email])
   end
 
@@ -304,14 +306,18 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send mail to tag followers in the comment' do
     UserSession.create(users(:jeff))
-    post :create, params: { id: nodes(:question).nid, body: 'Question #awesome', type: 'question' }, xhr: true
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      post :create, params: { id: nodes(:question).nid, body: 'Question #awesome', type: 'question' }, xhr: true
+    end
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:bob).email])
     # tag followers can be found in tag_selection.yml
   end
 
   test 'should send mail to multiple tag followers in the comment' do
     UserSession.create(users(:jeff))
-    post :create, params: { id: nodes(:question).nid, body: 'Question #everything #awesome', type: 'question' }, xhr: true
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      post :create, params: { id: nodes(:question).nid, body: 'Question #everything #awesome', type: 'question' }, xhr: true
+    end
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:bob).email])
     assert ActionMailer::Base.deliveries.collect(&:to).include?([users(:moderator).email])
     # tag followers can be found in tag_selection.yml
@@ -319,7 +325,9 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should send notification email upon a new wiki comment' do
     UserSession.create(users(:jeff))
-    post :create, params: { id: nodes(:wiki_page).nid, body: 'A comment by Jeff on a wiki page of author bob', type: 'page' }, xhr: true
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      post :create, params: { id: nodes(:wiki_page).nid, body: 'A comment by Jeff on a wiki page of author bob', type: 'page' }, xhr: true
+    end
     assert ActionMailer::Base.deliveries.collect(&:subject).include?("New comment on Wiki page title (#11) - #c#{Comment.last.id}")
   end
 
@@ -368,11 +376,12 @@ class CommentControllerTest < ActionController::TestCase
 
   test 'should not send notification email to author if notify-comment-direct:false usertag is present' do
     UserSession.create(users(:jeff))
-    post :create, params: {
+    assert_difference 'ActionMailer::Base.deliveries.size', 0 do
+      post :create, params: {
         id: nodes(:activity).nid,
         body: 'A comment by Jeff on note of author test_user'
-    }, xhr: true
-
+      }, xhr: true
+    end
     assert_not ActionMailer::Base.deliveries.collect(&:subject).include?("New comment on #{nodes(:activity).title} (##{nodes(:activity).nid}) ")
     assert_not ActionMailer::Base.deliveries.collect(&:to).include?([users(:test_user).email])
   end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -48,7 +48,7 @@ class SearchControllerTest < ActionController::TestCase
   test "search question at /search/questions/question" do
     get :questions, params: { query: 'question' }
     assert_response :success
-    assert_equal assigns(:questions).include?(nodes(:question))
+    assert assigns(:questions).include?(nodes(:question))
   end
 
   test "search places page at /search/places/map" do

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -48,7 +48,7 @@ class SearchControllerTest < ActionController::TestCase
   test "search question at /search/questions/question" do
     get :questions, params: { query: 'question' }
     assert_response :success
-    assert_equal nodes(:question).nid, assigns(:questions).first.nid
+    assert_equal assigns(:questions).include?(nodes(:question))
   end
 
   test "search places page at /search/places/map" do


### PR DESCRIPTION
Attempt to fix #9247 

However i think we may need to wrap them in enqueue statements too, if the emails are getting sent later.

```ruby
perform_enqueued_jobs do 
  ...
end
```
