### PR TITLE
Hide first-time or spam replied-comments

### DIFF
--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -160,9 +160,20 @@
 
     <% if comment.reply_to.nil? %>
       <% comment.replied_comments.order("timestamp ASC").each do |replied_comment| %>
-        <%= render :partial => "notes/comment", :locals => {:comment => replied_comment} %>
+        <% if logged_in_as(['admin','moderator'])%>
+          <% if replied_comment.status == 4 || replied_comment.status == 1 %>
+            <%= render :partial => "notes/comment", :locals => {:comment => replied_comment} %>
+          <% end %>
+        <% elsif current_user && current_user.id = replied_comment.author.id %>
+          <% if replied_comment.status == 1 || (replied_comment.status == 4 && replied_comment.uid = current_user.id) %>
+            <%= render :partial => "notes/comment", :locals => {:comment => replied_comment} %>
+          <% end %>
+        <% else %>
+          <% if replied_comment.status == 1 %>
+            <%= render :partial => "notes/comment", :locals => {:comment => replied_comment} %>
+          <% end %>
+        <% end %>
       <% end %>
-
       <p style="color: #006dcc; cursor: pointer; user-select: none;" id="comment-<%= comment.cid %>-reply-toggle">Reply to this comment...</p>
       <div id="comment-<%= comment.cid %>-reply" style="margin-top: 30px;display: none;">
         <div id="comment-<%= comment.cid %>-reply-section">

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div id="comments" class="col-lg-10 comments">
     <% comments = @node.comments_viewable_by(current_user) %>
+    <% comments = comments.where('reply_to IS NULL OR reply_to IN (?)', Array.wrap(comments.pluck(:cid)))%>
     <h3><span id="comment-count"><%= comments.size %></span> <%= translation('notes._comments.comments') %></h3>
     <%= javascript_include_tag "editorToolbar" %>
     <%= javascript_include_tag "comment" %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -275,3 +275,16 @@ user_without_tag_subscriptions:
   bio: ''
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+sushmita:
+  username: sushmita
+  status: 1
+  email: 17sushmita@gmail.com
+  id: 23
+  last_request_at: <%= Time.now %>
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("secretive" + salt) %>
+  persistence_token: <%= Authlogic::Random.hex_token %>
+  bio: ''
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>


### PR DESCRIPTION
Fixes #8854 

- Hide spam or first time replies to comments
- Added tests to confirm the if the spam or first-time replied comment is visible to different group of users or not.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] ask `@publiclab/reviewers` for help, in a comment below

