### PR TITLE
Ignore empty string in SMTP configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,10 +71,10 @@ Plots2::Application.configure do
   :port => ENV["SMTP_PORT"] || 25
   }
 
-  if ENV["SMTP_USER"] then config.action_mailer.smtp_settings[:user_name] = ENV["SMTP_USER"] end
-  if ENV["SMTP_PASS"] then config.action_mailer.smtp_settings[:password] = ENV["SMTP_PASS"] end
-  if ENV["SMTP_AUTH"] then config.action_mailer.smtp_settings[:authentication] = ENV["SMTP_AUTH"] end
-  if ENV["SMTP_STLS"] then config.action_mailer.smtp_settings[:enable_starttls_auto] = ENV["SMTP_STLS"] end
+  if not ENV["SMTP_USER"].blank? then config.action_mailer.smtp_settings[:user_name] = ENV["SMTP_USER"] end
+  if not ENV["SMTP_PASS"].blank? then config.action_mailer.smtp_settings[:password] = ENV["SMTP_PASS"] end
+  if not ENV["SMTP_AUTH"].blank? then config.action_mailer.smtp_settings[:authentication] = ENV["SMTP_AUTH"] end
+  if not ENV["SMTP_STLS"].blank? then config.action_mailer.smtp_settings[:enable_starttls_auto] = ENV["SMTP_STLS"] end
 
   # Enable threaded mode
   # config.threadsafe!


### PR DESCRIPTION
This PR fixes an issue found in https://github.com/publiclab/plots2/pull/9043 because `docker-compose` declares missing environment variables with an empty string. This patch fixes configuration of production to ignore empty strings.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
