### PR TITLE
Remove rule from home.html.erb that created visual inconsistency

### DIFF
--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -68,9 +68,6 @@
   margin: 0 calc((100% / 2) - 50vw);
   padding: 40px 0px;
 }
-.row {
-  margin-right: 0;
-}
 .projects .row {
   padding: 50px 20px;
   color: #222;


### PR DESCRIPTION
Fixes #9474

This removes the rule `margin-right: 0` which created a white gap on the right side of the "Community Projects" section. It should now stretch across the screen and look better on both desktop and mobile devices.