### PR TITLE
Revert "Fix ActiveRecord::RecordNotFound when clicking on 'step-by-step activity'"

### DIFF
--- a/app/views/sidebar/_dashboard.html.erb
+++ b/app/views/sidebar/_dashboard.html.erb
@@ -7,7 +7,7 @@
         <span class="sr-only">Toggle Dropdown</span>
       </a>
       <div class="dropdown-menu dropdown-menu-right mt-2">
-        <a class="dropdown-item" href="/post?title=How%20to%20...&tags=activity:new,draft"><%= translation('dashboard._header.dropdown.share_activity') %></a>
+        <a class="dropdown-item" href="/post?n=15322&title=How%20to%20...&tags=activity:new,draft"><%= translation('dashboard._header.dropdown.share_activity') %></a>
         <a class="dropdown-item" href="/post"><%= translation('dashboard._header.dropdown.share_research_note') %></a>
         <a class="dropdown-item" href="/questions/new?tags=question:general"><%= translation('dashboard._header.dropdown.ask_question') %></a>
         <a class="dropdown-item" href="/post?template=event&tags=event"><%= translation('dashboard._header.dropdown.post_event') %></a>


### PR DESCRIPTION
Reverts publiclab/plots2#9503

I have just realized that the stable of the production site have the nid we removed...
Here: https://publiclab.org/post?n=15322&title=How%20to%20...&tags=activity:new,draft
and 
Here: https://stable.publiclab.org/post?n=15322&title=How%20to%20...&tags=activity:new,draft

