### PR TITLE
Add missing envvars to docker-compose to fix SMTP errors in Sidekiq

### DIFF
--- a/containers/docker-compose-production.yml
+++ b/containers/docker-compose-production.yml
@@ -85,6 +85,12 @@ services:
       - DB_PASS=${DB_PASS}
       - DB_HOST=${DB_HOST}
       - DB_SOCKET=${DB_SOCKET}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASS=${SMTP_PASS}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_AUTH=${SMTP_AUTH}
+      - SMTP_STLS=${SMTP_STLS}
   mailman:
     build: ..
     command: script/mailman_server

--- a/containers/docker-compose-stable.yml
+++ b/containers/docker-compose-stable.yml
@@ -79,6 +79,17 @@ services:
       - RAILS_ENV=${RAILS_ENV}
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY_BASE=${SECRET_KEY_BASE}
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_SOCKET=${DB_SOCKET}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASS=${SMTP_PASS}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_AUTH=${SMTP_AUTH}
+      - SMTP_STLS=${SMTP_STLS}
   mailman:
     build: ..
     command: script/mailman_server
@@ -88,5 +99,10 @@ services:
       - SERVER_ADDRESS=${SERVER_ADDRESS}
       - USERNAME=${USERNAME}
       - EMAIL_PASSWORD=${EMAIL_PASSWORD}
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_SOCKET=${DB_SOCKET}
     volumes:
       - ..:/app

--- a/containers/docker-compose-testing.yml
+++ b/containers/docker-compose-testing.yml
@@ -64,5 +64,17 @@ services:
     volumes:
       - .:/app
     environment:
+      - RAILS_ENV=${RAILS_ENV}
       - REDIS_URL=redis://redis:6379/0
-
+      - SECRET_KEY_BASE=${SECRET_KEY_BASE}
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_SOCKET=${DB_SOCKET}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASS=${SMTP_PASS}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_AUTH=${SMTP_AUTH}
+      - SMTP_STLS=${SMTP_STLS}

--- a/containers/docker-compose-unstable.yml
+++ b/containers/docker-compose-unstable.yml
@@ -79,6 +79,17 @@ services:
       - RAILS_ENV=${RAILS_ENV}
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY_BASE=${SECRET_KEY_BASE}
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_SOCKET=${DB_SOCKET}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASS=${SMTP_PASS}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_AUTH=${SMTP_AUTH}
+      - SMTP_STLS=${SMTP_STLS}
   mailman:
     build: ..
     command: script/mailman_server
@@ -88,5 +99,10 @@ services:
       - SERVER_ADDRESS=${SERVER_ADDRESS}
       - USERNAME=${USERNAME}
       - EMAIL_PASSWORD=${EMAIL_PASSWORD}
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_SOCKET=${DB_SOCKET}
     volumes:
       - ..:/app


### PR DESCRIPTION
We've had some errors from Sidekiq that it could not find the smtp host: https://sentry.io/share/issue/e1e982cd853e40abb440c7d4f40755b2/

It was missing references to the SMTP server. Previously this was fine as we were using the default configuration.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
