### PR TITLE
Remove old 'parent' code from tag pages

### DIFF
--- a/app/views/tag/show/_user_controls.html.erb
+++ b/app/views/tag/show/_user_controls.html.erb
@@ -38,11 +38,6 @@
     <div class="dropdown-item tag-dropdown">Statistics for all topics</div>
     </a>
 
-    <% unless @tags.try(:first).try(:parent).nil? %>
-      <div class="dropdown-divider"></div>
-      <small>Alias of: <%= @tags.first.parent %></small>
-    <% end %>
-
   <% end %>
 </div>
 <!-- AJAXify -->


### PR DESCRIPTION
The following lines of code have been removed from "app/views/tag/show/_user_controls.html.erb"
```html
    <% unless @tags.try(:first).try(:parent).nil? %>
      <div class="dropdown-divider"></div>
      <small>Alias of: <%= @tags.first.parent %></small>
    <% end %>

```
Fixes #9499