### PR TITLE
Revert "Bump sidekiq from 5.2.9 to 6.2.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     composite_primary_keys (11.2.0)
       activerecord (~> 5.2.1)
     concurrent-ruby (1.1.8)
-    connection_pool (2.2.5)
+    connection_pool (2.2.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -375,6 +375,8 @@ GEM
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
+    rack-protection (2.0.8.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -428,7 +430,7 @@ GEM
       tilt
     recaptcha (4.14.0)
       json
-    redis (4.2.5)
+    redis (4.1.4)
     regexp_parser (2.1.1)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -496,10 +498,11 @@ GEM
     semantic_range (2.3.1)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
-    sidekiq (6.2.1)
-      connection_pool (>= 2.2.2)
+    sidekiq (5.2.9)
+      connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
-      redis (>= 4.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 4.2)
     signet (0.15.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)


### PR DESCRIPTION
Reverts publiclab/plots2#9514 to fix https://github.com/publiclab/plots2/issues/9573

We'll try some other fixes first but this is the fallback.