### PR TITLE
Changed HTML in Nav Bar for translation fixes

### DIFF
--- a/app/views/dashboard/_wiki.html.erb
+++ b/app/views/dashboard/_wiki.html.erb
@@ -4,7 +4,7 @@
   <div class="col-lg-8 col-md-7 col-sm-7 col-7">
     <div class="input-group">
       <form class="search-form-wiki form-inline" role="search" autocomplete="off">
-        <input type="text" class="search-wiki form-control form-control-sm" id="sidebar-searchform-input" style="width:70%;" placeholder="<%= translation('dashboard._wiki.search') %>" required>
+        <input type="text" class="search-wiki form-control form-control-sm" id="sidebar-searchform-input" style="width:70%;" placeholder="<%= t('dashboard._wiki.search') %>" required>
         <div class="input-group-append">
           <button class="btn btn-sm btn-outline-secondary" type="submit"><i class="fa fa-search"></i></button>
         </div>
@@ -13,8 +13,8 @@
     </div>
   </div>
 
-  <div class="col-xl-4 col-lg-5 col-md-5 col-5">
-    <a href="/wiki/new" class="btn btn-primary btn-sm text-white" type="button" >
+  <div class="col-xl-4 col-lg-5 col-md-5 col-5 btn btn-primary btn-sm" type="button" >
+    <a href="/wiki/new" class="text-white">
       <i class="fa fa-plus-circle text-white" ></i> 
         <%= translation('dashboard._wiki.new_page') %>
     </a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -31,49 +31,90 @@
         <% end %>
 
         <li class="nav-item dropdown" style="min-width:80px;">
-          <a class="nav-link" data-toggle="dropdown" href="#">
+          <div class="nav-link" data-toggle="dropdown" onclick="location.href='#">
             <%= translation('layout._header.community.community_title') %>
-          </a>
+          </div>  
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="/getting-started"><b><%= translation('layout._header.community.get_started') %> &raquo;</b></a>
+            <div class="dropdown-item">
+              <a class="text-body" href="/getting-started"><b><%= translation('layout._header.community.get_started') %> &raquo;</b></a>
+            </div>
             <div class="dropdown-divider"></div>
-            <a class="dropdown-item" href="/people"><%= translation('layout._header.community.people') %></a>
-            <a class="dropdown-item" href="/map"><%= translation('layout._header.community.places') %></a>
-            <a class="dropdown-item" href="/projects"><%= translation('layout._header.community.projects') %></a>
-            <a class="dropdown-item" href="/events"><%= translation('layout._header.community.events') %></a>
-            <a class="dropdown-item" href="/questions"><%= translation('layout._header.community.questions') %></a>
-            <a class="dropdown-item" href="/chat"><%= translation('layout._header.community.chat') %></a>
+            <div class="dropdown-item">
+              <a class="text-body" href="/people"><%= translation('layout._header.community.people') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="/map"><%= translation('layout._header.community.places') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="/projects"><%= translation('layout._header.community.projects') %></a>
+            </div>
+            <div class="dropdown-item">  
+              <a class="text-body" href="/events"><%= translation('layout._header.community.events') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="/questions"><%= translation('layout._header.community.questions') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="/chat"><%= translation('layout._header.community.chat') %></a>
+            </div>
           </div>
         </li>
 
         <li class="nav-item dropdown" style="min-width:80px;">
-          <a class="nav-link" data-toggle="dropdown" href="#">
+          
+            <div class="nav-link" data-toggle="dropdown" onclick="location.href='#">
             <%= translation('layout._header.tools.tools_title') %>
-          </a>
+            </div>
+          
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="/methods"><%= translation('layout._header.tools.methods') %></a>
+          <div class="nav-link dropdown-item">
+            <a class="text-body" href="/methods"><%= translation('layout._header.tools.methods') %></a>
+          </div>
             <div class="dropdown-divider"></div>
             <h6 class="dropdown-header">Kits</h6>
-            <a class="dropdown-item" href="/kits"><%= translation('layout._header.tools.kits_initiative') %></a>
-            <a class="dropdown-item" href="//store.publiclab.org"><%= translation('layout._header.tools.store') %></a>
+            <div class="dropdown-item">
+              <a class="text-body" href="/kits"><%= translation('layout._header.tools.kits_initiative') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="//store.publiclab.org"><%= translation('layout._header.tools.store') %></a>
+            </div>
             <div class="dropdown-divider"></div>
             <h6 class="dropdown-header">Software</h6>
-            <a class="dropdown-item" href="https://mapknitter.org"><%= translation('layout._header.tools.map_knitter') %></a>
-            <a class="dropdown-item" href="https://infragram.org"><%= translation('layout._header.tools.infragram') %></a>
-            <a class="dropdown-item" href="https://spectralworkbench.org"><%= translation('layout._header.tools.spectral_workbench') %></a>
-            <a class="dropdown-item" href="https://code.publiclab.org#r=all"><%= translation('layout._header.tools.code_community') %></a>
+            <div class="dropdown-item">
+              <a class="text-body" href="https://mapknitter.org"><%= translation('layout._header.tools.map_knitter') %></a>
+            </div>
+            <div class="dropdown-item">
+            <a class="text-body" href="https://infragram.org"><%= translation('layout._header.tools.infragram') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="https://spectralworkbench.org"><%= translation('layout._header.tools.spectral_workbench') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="https://code.publiclab.org#r=all"><%= translation('layout._header.tools.code_community') %></a>
+            </div>
           </div>
         </li>
 
         <li class="nav-item dropdown" style="min-width:80px;">
-          <a class="nav-link" data-toggle="dropdown" href="#">
+          <div class="nav-link" data-toggle="dropdown" onclick="location.href='#'">
+            <!-- <a > -->
             <%= t('layout._header.about.about_title') %>
-          </a>
+            <!-- </a> -->
+          </div>
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="/about"><%= translation('layout._header.about.about_public_lab') %></a>
-            <a class="dropdown-item" href="/blog"><%= translation('layout._header.about.blog') %></a>
-            <a class="dropdown-item" href="/newsletter"><%= translation('Newsletter') %></a>
-            <a class="dropdown-item" href="/wiki/contact"><%= translation('layout._header.about.contact') %></a>
+            <div class="dropdown-item">
+              <a class="text-body" href="/about"><%= translation('layout._header.about.about_public_lab') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="/blog"><%= translation('layout._header.about.blog') %></a>
+            </div>
+            <div class="dropdown-item">
+            <a class="text-body" href="/newsletter"><%= translation('Newsletter') %></a>
+            </div>
+            <div class="dropdown-item">
+              <a class="text-body" href="/wiki/contact">
+                <%= translation(' layout._header.about.contact') %></a>
+            </div>
           </div>
         </li>
 
@@ -121,12 +162,22 @@
                     <% end %>
                   </h5>
 
-                    <a class="dropdown-item" href="/profile/<%= current_user.username %>"><%= translation('layout._header.profile') %></a>
-                    <a class="dropdown-item" href="/profile/edit"><%= translation('layout._header.edit_profile') %></a>
-                    <a class="dropdown-item" href="/settings" >Notifications</a>
+                    <div class="dropdown-item">
+                      <a class="text-body" href="/profile/<%= current_user.username %>"><%= translation('layout._header.profile') %></a>
+                    </div>
+                    <div class="dropdown-item">
+                      <a class="text-body" href="/profile/edit"><%= translation('layout._header.edit_profile') %></a>
+                    </div>
+                    <div class="dropdown-item">
+                      <a class="text-body" href="/settings" >Notifications</a>
+                    </div>
                     <div class="dropdown-divider"></div>
-                    <a class="dropdown-item" href="/subscriptions"><%= translation('layout._header.subscriptions') %></a>
-                    <a class="dropdown-item" href="/profile/<%= current_user.username %>/likes"><%= translation('layout._header.notes_liked') %></a>
+                    <div class="dropdown-item">
+                      <a class="text-body" href="/subscriptions"><%= translation('layout._header.subscriptions') %></a>
+                    </div>
+                    <div class="dropdown-item">
+                      <a class="text-body" href="/profile/<%= current_user.username %>/likes"><%= translation('layout._header.notes_liked') %></a>
+                    </div>
                     <div class="dropdown-divider"></div>
                       <% if logged_in_as(['admin']) %>
                       <a class="dropdown-item" href="/useremail">Email search</a>
@@ -136,7 +187,9 @@
                       <a class="dropdown-item" href="/features">Features</a>
                       <div class="dropdown-divider"></div>
                       <% end %>
-                      <%= link_to translation('layout._header.logout'), logout_path, class: "dropdown-item" %>
+                      <div class="dropdown-item">
+                      <%= link_to translation('layout._header.logout'), logout_path, class: "text-body" %>
+                      </div>
                     <a class="dropdown-item" href="/logoutRemotely">Logout from all devices</a>
                   </div>
               </li>


### PR DESCRIPTION
Fixes #9686
Navigation bar UI fix 
The function was not rendering correctly in some places as the HTML tag returned by the [translation function ](https://github.com/publiclab/plots2/blob/3450fdf8f333b3a20a1d1d2969865e5cace37df6/app/helpers/application_helper.rb#L157) contains an anchor tag redirecting user to the Translation site. In HTML we cannot render an anchor inside another anchor tag so whenever function is called inside an anchor tag it is rendered separately in both Chrome and Firefox(not sure about other browsers). I even tried to make anchor tag in translation function as a clickable div using simple js, but it also does not work.
For now, I have wrapped the anchor tag where the function is called,  inside another div and copied anchor tags styling to its parent div. This resolves the rendering problem in these cases.
Current UI 
![Screenshot from 2021-05-28 01-23-35](https://user-images.githubusercontent.com/38528640/119889278-fba4bb80-bf53-11eb-942f-dfa99dbec882.png)
After Changes 
![Screenshot from 2021-05-28 01-23-50](https://user-images.githubusercontent.com/38528640/119889318-08c1aa80-bf54-11eb-941e-ed6bc6828683.png)

I'm still looking into ways to embed an anchor tag inside another anchor tag, and UI changes in other pages is yet to be added.
