### PR TITLE
Translation helper improvement (added html parameter)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -154,12 +154,12 @@ module ApplicationHelper
     'is-active' if request.path == page
   end
 
-  def translation(key, options = {})
+  def translation(key, options = {},html = true)
     translated_string = t(key, options)
     options[:fallback] = false
     translated_string2 = t(key, options)
 
-    if current_user&.has_tag('translation-helper') && translated_string2.include?("translation missing") && !translated_string.include?("<")
+    if html && current_user&.has_tag('translation-helper') && translated_string2.include?("translation missing") && !translated_string.include?("<")
       raw(%(<span>#{translated_string} <a href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
           <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate this text.' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
        </span>))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -154,7 +154,7 @@ module ApplicationHelper
     'is-active' if request.path == page
   end
 
-  def translation(key, options = {},html = true)
+  def translation(key, options = {}, html = true)
     translated_string = t(key, options)
     options[:fallback] = false
     translated_string2 = t(key, options)

--- a/app/views/dashboard/_wiki.html.erb
+++ b/app/views/dashboard/_wiki.html.erb
@@ -4,7 +4,7 @@
   <div class="col-lg-8 col-md-7 col-sm-7 col-7">
     <div class="input-group">
       <form class="search-form-wiki form-inline" role="search" autocomplete="off">
-        <input type="text" class="search-wiki form-control form-control-sm" id="sidebar-searchform-input" style="width:70%;" placeholder="<%= translation('dashboard._wiki.search') %>" required>
+        <input type="text" class="search-wiki form-control form-control-sm" id="sidebar-searchform-input" style="width:70%;" placeholder="<%= translation('dashboard._wiki.search',{},false) %>" required>
         <div class="input-group-append">
           <button class="btn btn-sm btn-outline-secondary" type="submit"><i class="fa fa-search"></i></button>
         </div>

--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -46,7 +46,7 @@
     <div class="form-group">
       <div class="row">
         <div class="col-md-7">
-          <input aria-label="Enter tags" type="text" name="name" class="form-control" placeholder="<%= translation('home.subscriptions.enter_tags') %>" data-provide="typeahead" data-source='<%= Tag.all_tags_by_popularity %>' autocomplete="off" required="required">
+          <input aria-label="Enter tags" type="text" name="name" class="form-control" placeholder="<%= translation('home.subscriptions.enter_tags',{},false) %>" data-provide="typeahead" data-source='<%= Tag.all_tags_by_popularity %>' autocomplete="off" required="required">
         </div>
         <div class="col-md-2 pl-md-1">
           <button type="submit" class="btn btn-primary add-subscriptions"><i class="fa fa-plus fa fa-white"></i> <%= translation('home.subscriptions.add') %></button>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,7 +17,7 @@
     <div class="collapse navbar-collapse" id="header-navbar-collapse">
       <form class="form-inline mr-3" id="searchform" autocomplete="off">
         <div class="input-group">
-          <input aria-label="Enter Search Query" type="text" id="searchform_input" class="form-control search-query typeahead" role="search" qryType="tags" placeholder="<%= t('layout._header.search') %>"  value="<%= params[:query] %>" required>
+          <input aria-label="Enter Search Query" type="text" id="searchform_input" class="form-control search-query typeahead" role="search" qryType="tags" placeholder="<%= translation('layout._header.search',{},false) %>"  value="<%= params[:query] %>" required>
           <div class="input-group-append">
             <button class="btn btn-light" type="submit" title="Search button" aria-label="Search Button"><i class="fa fa-search"></i></button>
           </div>

--- a/app/views/tag/_form.html.erb
+++ b/app/views/tag/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="control-group">
     <input class="form-control" name="remote" type="hidden" value="true" />
     <div class="input-group">
-      <input aria-label="Enter tag name" autocomplete="off" class="tag-input form-control" name="name" type="text" placeholder="<%= translation('tag._tagging.enter_tags') %>" data-provide="typeahead" />
+      <input aria-label="Enter tag name" autocomplete="off" class="tag-input form-control" name="name" type="text" placeholder="<%= translation('tag._tagging.enter_tags',{},false) %>" data-provide="typeahead" />
       <div class="input-group-append">
         <%= render partial: 'tag/advanced_tagging' %>
       </div>

--- a/app/views/users/reset.html.erb
+++ b/app/views/users/reset.html.erb
@@ -11,9 +11,9 @@
 <form class='form'>
 
   <input class="form-control" name="key" type="hidden" value="<%= params[:key] %>" /> 
-  <input class="form-control" name="user[username]" placeholder="<%= translation('users.reset.username_placeholder') %>" tabindex='2' type="text" /> <br />
-  <input class="form-control" name="user[password]" placeholder="<%= translation('users.reset.password_placeholder') %>" tabindex='3' type="password" /> <br />
-  <input class="form-control" name="user[password_confirmation]" placeholder="<%= translation('users.reset.retype_password_placeholder') %>" tabindex='4' type="password" /> <br />
+  <input class="form-control" name="user[username]" placeholder="<%= translation('users.reset.username_placeholder',{},false) %>" tabindex='2' type="text" /> <br />
+  <input class="form-control" name="user[password]" placeholder="<%= translation('users.reset.password_placeholder',{},false) %>" tabindex='3' type="password" /> <br />
+  <input class="form-control" name="user[password_confirmation]" placeholder="<%= translation('users.reset.retype_password_placeholder',{},false) %>" tabindex='4' type="password" /> <br />
 
   <button class="btn btn-lg btn-primary" type="submit" tabindex="5"><%= translation('users.reset.save') %></button>
 


### PR DESCRIPTION
Part of #9686 
Fixes #7798 #9494 
As the translation function was called inside the HTML tag, there were rendering issues; I fixed it by adding an `HTML = true` optional parameter in the function, now we can pass `html=false` in cases where the function is called inside the HTML tag.
Current UI
![Screenshot from 2021-05-30 17-22-52](https://user-images.githubusercontent.com/38528640/120104787-d2fb0c80-c173-11eb-99cf-92b1a6ae1fa8.png)

After changes 
![Screenshot from 2021-05-30 17-23-32](https://user-images.githubusercontent.com/38528640/120104808-ed34ea80-c173-11eb-988d-d67a533ce3f8.png)


