### PR TITLE
Add Test for React Edit Comment

### DIFF
--- a/app/javascript/components/CommentToolbarButton.js
+++ b/app/javascript/components/CommentToolbarButton.js
@@ -2,12 +2,26 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const CommentToolbarButton = ({
+  buttonType,
   icon,
   onClick
 }) => {
+  let additionalClass;
+  
+  switch(buttonType) {
+    case "edit":
+      additionalClass = " edit-comment-btn";
+      break;
+    case "delete":
+      additionalClass = " delete-comment-btn";
+      break;
+    default:
+      additionalClass = "";
+  }
+
   return (
     <a 
-      className="btn btn-outline-secondary btn-sm"
+      className={"btn btn-outline-secondary btn-sm" + additionalClass}
       onClick={onClick}
     >
       {icon}
@@ -16,6 +30,7 @@ const CommentToolbarButton = ({
 }
 
 CommentToolbarButton.propTypes = {
+  buttonType: PropTypes.string,
   icon: PropTypes.element,
   onClick: PropTypes.func
 };

--- a/app/javascript/components/CommentsList.js
+++ b/app/javascript/components/CommentsList.js
@@ -42,12 +42,14 @@ const CommentsList = ({
   
       // each comment comes with a button to toggle edit form visible
       const toggleEditButton = <CommentToolbarButton 
+        buttonType="edit"
         icon={<i className="fa fa-pencil"></i>}
         onClick={() => handleFormVisibilityToggle("edit-" + comment.commentId)}
       />;
   
       // and a delete button
       const deleteButton = <CommentToolbarButton
+        buttonType="delete"
         icon={<i className='icon fa fa-trash'></i>}
         onClick={() => handleDeleteComment(comment.commentId)}
       />;


### PR DESCRIPTION
Part of the React rewrite of the comment system. See #9365

Added system test for editing comments that handles both React and Rails comment systems.

Also tweaked the `CommentToolbarButton` component so that it displays a class for `edit-comment-btn`s

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)