### PR TITLE
Alert box overlapping table of contents menu in wikis #9727

### DIFF
--- a/app/assets/stylesheets/wiki.css
+++ b/app/assets/stylesheets/wiki.css
@@ -84,6 +84,11 @@ a.navbar-offset {
   overflow: auto;
   line-height: 2;
   border: 1px solid #e1e4e8;
+  z-index: 1000;
+}
+
+.js-toc > .toc-list {
+  margin-top: 20px;
 }
 
 .toc-list {

--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -44,7 +44,7 @@
       </span>
       <details class="d-inline-flex flex-column position-relative">
         <summary id="toc-menu" class="btn btn-light" role="button" aria-label="Table of Contents" aria-haspopup="menu"><i class="fa fa-list-ul" aria-hidden="true"></i></summary>
-        <span class="js-toc position-absolute shadow p-0 pt-4 rounded" role="menu"></span>
+        <span class="js-toc position-absolute shadow p-0 rounded" role="menu"></span>
       </details>
     </div>
   </div>


### PR DESCRIPTION
Fixes #9727 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
