### PR TITLE
Add React PropTypes for Array and Object Props

### DIFF
--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -52,10 +52,39 @@ const App = ({
 }
 
 App.propTypes = {
-  currentUser: PropTypes.object,
-  elementText: PropTypes.object.isRequired,
-  initialComments: PropTypes.array.isRequired,
-  node: PropTypes.object.isRequired
+  currentUser: PropTypes.shape({
+    canModerate: PropTypes.bool,
+    id: PropTypes.number,
+    role: PropTypes.string,
+    status: PropTypes.number
+  }),
+  elementText: PropTypes.exact({
+    commentFormPlaceholder: PropTypes.string.isRequired,
+    commentsHeaderText: PropTypes.string.isRequired,
+    commentPreviewText: PropTypes.string.isRequired,
+    commentPublishText: PropTypes.string.isRequired,
+    userCommentedText: PropTypes.string.isRequired
+  }).isRequired,
+  initialComments: PropTypes.arrayOf(
+    PropTypes.shape({
+      authorId: PropTypes.number.isRequired,
+      authorPicFilename: PropTypes.string,
+      authorPicUrl: PropTypes.string,
+      authorUsername: PropTypes.string.isRequired,
+      commentId: PropTypes.number.isRequired,
+      commentName: PropTypes.string,
+      createdAt: PropTypes.string.isRequired,
+      htmlCommentText: PropTypes.string.isRequired,
+      rawCommentText: PropTypes.string.isRequired,
+      replies: PropTypes.array,
+      replyTo: PropTypes.number,
+      timeCreatedString: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  node: PropTypes.exact({
+    nodeId: PropTypes.number.isRequired,
+    nodeAuthorId: PropTypes.number.isRequired
+  }).isRequired
 };
 
 export default App;

--- a/app/javascript/components/CommentReplies.js
+++ b/app/javascript/components/CommentReplies.js
@@ -34,7 +34,7 @@ const CommentReplies = ({
 }
 
 CommentReplies.propTypes = {
-  children: PropTypes.array,
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
   commentId: PropTypes.number.isRequired,
   isReplyFormVisible: PropTypes.bool.isRequired,
   handleReplyFormToggle: PropTypes.func,

--- a/app/javascript/components/CommentsContainer.js
+++ b/app/javascript/components/CommentsContainer.js
@@ -159,9 +159,9 @@ const CommentsContainer = ({
 }
 
 CommentsContainer.propTypes = {
-  initialCommentFormToggleState: PropTypes.object.isRequired,
+  initialCommentFormToggleState: PropTypes.objectOf(PropTypes.bool).isRequired,
   initialComments: PropTypes.array.isRequired,
-  initialTextAreaValues: PropTypes.object.isRequired,
+  initialTextAreaValues: PropTypes.objectOf(PropTypes.string).isRequired,
   nodeId: PropTypes.number.isRequired
 };
 

--- a/app/javascript/components/CommentsList.js
+++ b/app/javascript/components/CommentsList.js
@@ -141,7 +141,7 @@ const CommentsList = ({
 };
 
 CommentsList.propTypes = {
-  commentFormsVisibility: PropTypes.object.isRequired,
+  commentFormsVisibility: PropTypes.objectOf(PropTypes.bool).isRequired,
   comments: PropTypes.array.isRequired,
   currentUser: PropTypes.object,
   handleCreateComment: PropTypes.func.isRequired,
@@ -150,7 +150,7 @@ CommentsList.propTypes = {
   handleTextAreaChange: PropTypes.func.isRequired,
   handleUpdateComment: PropTypes.func.isRequired,
   setTextAreaValues: PropTypes.func.isRequired,
-  textAreaValues: PropTypes.object.isRequired
+  textAreaValues: PropTypes.objectOf(PropTypes.string).isRequired
 };
 
 export default CommentsList;


### PR DESCRIPTION
Part of a React rewrite of the comment system, see #9365.

See [React docs on PropTypes](https://reactjs.org/docs/typechecking-with-proptypes.html). This PR adds PropType checking for array and object data that's passed down as props throughout the `App`. 

**BEFORE:** check to see if `currentUser` is an object.
```
App.propTypes = {
  currentUser: PropTypes.object
};
```

**AFTER:** check to see if `currentUser` is an object **AND** typecheck its properties:
```
App.propTypes = {
  currentUser: PropTypes.shape({
    canModerate: PropTypes.bool,
    id: PropTypes.number,
    role: PropTypes.string,
    status: PropTypes.number
  })
};
```

This increases the long-term maintainability of this project. PropTypes help with debugging and ensure that the data the app receives is valid.

@jywarren mentioned writing functional tests to make sure the controller is sending valid data to the client... IMO PropTypes can easily substitute for functional tests! 😄 

_(Example: PropTypes logs an error to the console if data doesn't match expectations:)_
<img width="767" alt="Screen Shot 2021-06-06 at 8 20 55 PM" src="https://user-images.githubusercontent.com/4361605/120954782-cbec7500-c704-11eb-92a9-d2ec69a4460a.png">

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)