### PR TITLE
Prune Comment System Tests for Faster CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,7 +171,7 @@ jobs:
         DB_PASSWORD: root
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
       run: bundle exec rails g webpacker:install && bundle exec rails g webpacker:install:react && bundle exec rails g react:install
-    - name: "System Tests"
+    - name: "Comment System Tests"
       env:
         RAILS_ENV: test
         DB_PASSWORD: root
@@ -181,7 +181,7 @@ jobs:
       run: |
         export DISPLAY=:99
         chromedriver --url-base=/wd/hub &
-        bundle exec rails test:comment_system_tests
+        bundle exec rails test test/comment_system_tests
     - name: Archive system test screenshots
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,6 +141,53 @@ jobs:
         name: system-test-screenshots
         path: tmp/screenshots/*
 
+  comment-system-tests:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6.6 # Not needed with a .ruby-version file
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically (not working?)
+    - uses: nanasess/setup-chromedriver@v1.0.1
+    - uses: ./.github/actions/setup-test-environment
+    - name: Install JavaScript dependencies with Yarn
+      run: yarn check || yarn install --frozen-lockfile;
+    - name: Run webpacker setup
+      env:
+        RAILS_ENV: test
+        DB_PASSWORD: root
+        DB_PORT: ${{ job.services.mysql.ports[3306] }}
+      run: bundle exec rails g webpacker:install && bundle exec rails g webpacker:install:react && bundle exec rails g react:install
+    - name: "System Tests"
+      env:
+        RAILS_ENV: test
+        DB_PASSWORD: root
+        DB_PORT: ${{ job.services.mysql.ports[3306] }}
+        REDIS_HOST: localhost
+        REDIS_PORT: 6379
+      run: |
+        export DISPLAY=:99
+        chromedriver --url-base=/wd/hub &
+        bundle exec rails test:comment_system_tests
+    - name: Archive system test screenshots
+      uses: actions/upload-artifact@v2
+      with:
+        name: system-test-screenshots
+        path: tmp/screenshots/*
+
   remove-labels:
     runs-on: ubuntu-latest
     needs: [add-label, unit-tests, functional-tests, integration-tests, system-tests]

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
-  after_n_builds: 4
+  after_n_builds: 5
   require_changes: true  # if true: only post the comment if coverage changes
   require_base: yes       # [yes :: must have a base report to post]
   require_head: yes       # [yes :: must have a head report to post]
@@ -27,4 +27,4 @@ codecov:
   # https://docs.codecov.io/v4.3.6/docs/comparing-commits
   allow_coverage_offsets: true
   notify:
-    after_n_builds: 4
+    after_n_builds: 5

--- a/test/comment_system_tests/comment_test.rb
+++ b/test/comment_system_tests/comment_test.rb
@@ -475,7 +475,6 @@ class CommentTest < ApplicationSystemTestCase
       # checks for the list of recently active users
       assert_selector('#atwho-ground-text-input-main .atwho-view .atwho-view-ul li')
     end
-  end
 
     test "#{page_type_string}: IMMEDIATE image SELECT upload into REPLY comment form" do
       nodes(node_name).add_comment({

--- a/test/comment_system_tests/comment_test.rb
+++ b/test/comment_system_tests/comment_test.rb
@@ -716,38 +716,38 @@ class CommentTest < ApplicationSystemTestCase
     # there are many variations of this bug. this particular test involves:
     #  DRAG & DROP upload into MAIN comment form
     #  DRAG & DROP into EDIT comment form (.dropzone button)
-    # test "#{page_type_string}: image DRAG & DROP into EDIT form isn't cross-wired with MAIN form" do
-    #   # setup page with editable comment
-    #   nodes(node_name).add_comment({
-    #     uid: 2,
-    #     body: comment_text
-    #   })
-    #   visit get_path(page_type, nodes(node_name).path)
-    #   # .dropzone is hidden, so reveal it for Capybara's finders:
-    #   Capybara.ignore_hidden_elements = false
-    #   # drag & drop the image. drop_in_dropzone simulates 'drop' event, see application_system_test_case.rb
-    #   drop_in_dropzone("#{Rails.root.to_s}/public/images/pl.png", '#comments-list + div .dropzone-large') # this CSS selects .dropzones that belong to sibling element immediately following #comments-list. technically, there are two .dropzones in the main comment form.
-    #   Capybara.ignore_hidden_elements = true
-    #   wait_for_ajax
-    #   # we need the ID of parent div that contains <p>comment_text</p>:
-    #   comment_id = page.find('p', text: comment_text).find(:xpath, '..')[:id]
-    #   # regex to strip the ID number out of string. ID format is comment-body-4231
-    #   comment_id_num = /comment-body-(\d+)/.match(comment_id)[1]
-    #   comment_dropzone_selector = '#comment-form-body-edit-' + comment_id_num
-    #   # open the edit comment form
-    #   page.find(".edit-comment-btn").click
-    #   # drop into the edit comment form
-    #   Capybara.ignore_hidden_elements = false
-    #   drop_in_dropzone("#{Rails.root.to_s}/public/images/pl.png", comment_dropzone_selector)
-    #   Capybara.ignore_hidden_elements = true
-    #   wait_for_ajax
-    #   # open the preview for the main comment form
-    #   page.find('#toggle-preview-button-main').click
-    #   # once preview is open, the images are embedded in the page.
-    #   # there should only be 1 image in the main comment form!
-    #   preview_imgs = page.all('#comment-preview-main img').size
-    #   assert_equal(1, preview_imgs)
-    # end
+    test "#{page_type_string}: image DRAG & DROP into EDIT form isn't cross-wired with MAIN form" do
+      # setup page with editable comment
+      nodes(node_name).add_comment({
+        uid: 2,
+        body: comment_text
+      })
+      visit get_path(page_type, nodes(node_name).path)
+      # .dropzone is hidden, so reveal it for Capybara's finders:
+      Capybara.ignore_hidden_elements = false
+      # drag & drop the image. drop_in_dropzone simulates 'drop' event, see application_system_test_case.rb
+      drop_in_dropzone("#{Rails.root.to_s}/public/images/pl.png", '#comments-list + div .dropzone-large') # this CSS selects .dropzones that belong to sibling element immediately following #comments-list. technically, there are two .dropzones in the main comment form.
+      Capybara.ignore_hidden_elements = true
+      wait_for_ajax
+      # we need the ID of parent div that contains <p>comment_text</p>:
+      comment_id = page.find('p', text: comment_text).find(:xpath, '..')[:id]
+      # regex to strip the ID number out of string. ID format is comment-body-4231
+      comment_id_num = /comment-body-(\d+)/.match(comment_id)[1]
+      comment_dropzone_selector = '#comment-form-body-edit-' + comment_id_num
+      # open the edit comment form
+      page.find(".edit-comment-btn").click
+      # drop into the edit comment form
+      Capybara.ignore_hidden_elements = false
+      drop_in_dropzone("#{Rails.root.to_s}/public/images/pl.png", comment_dropzone_selector)
+      Capybara.ignore_hidden_elements = true
+      wait_for_ajax
+      # open the preview for the main comment form
+      page.find('#toggle-preview-button-main').click
+      # once preview is open, the images are embedded in the page.
+      # there should only be 1 image in the main comment form!
+      preview_imgs = page.all('#comment-preview-main img').size
+      assert_equal(1, preview_imgs)
+    end
 
     # cross-wiring test: 
     # SELECT image upload in both:
@@ -756,103 +756,103 @@ class CommentTest < ApplicationSystemTestCase
 
     # NOTE: this is also a test for:
     #   IMMEDIATE image SELECT upload into MAIN comment form
-    # test "#{page_type_string}: image SELECT upload into EDIT form isn't CROSS-WIRED with MAIN form" do
-    #   nodes(node_name).add_comment({
-    #     uid: 5,
-    #     body: comment_text
-    #   })
-    #   nodes(node_name).add_comment({
-    #     uid: 2,
-    #     body: comment_text
-    #   })
-    #   visit get_path(page_type, nodes(node_name).path)
-    #   # open the edit comment form:
-    #   find(".edit-comment-btn").click
-    #   # find the parent of edit comment's fileinput:
-    #   comment_fileinput_parent_id = page.find('[id^=dropzone-small-edit-]')[:id] # 'begins with' CSS selector
-    #   comment_id_num = /dropzone-small-edit-(\d+)/.match(comment_fileinput_parent_id)[1]
-    #   # upload images
-    #   # the <inputs> that take image uploads are hidden, so reveal them:
-    #   Capybara.ignore_hidden_elements = false
-    #   # upload an image in the main comment form
-    #   page.find('#fileinput-button-main').set("#{Rails.root.to_s}/public/images/pl.png")
-    #   wait_for_ajax
-    #   # find edit comment's fileinput:
-    #   page.find('#fileinput-button-edit-' + comment_id_num).set("#{Rails.root.to_s}/public/images/pl.png")
-    #   wait_for_ajax
-    #   Capybara.ignore_hidden_elements = true
-    #   # click preview buttons in main and edit form
-    #   page.find('h4', text: /Post comment|Post Comment/) # title text on wikis is 'Post comment'
-    #     .find(:xpath, '..')
-    #     .find('a', text: 'Preview').click
-    #   page.find('#comment-form-edit-' + comment_id_num + ' a', text: 'Preview').click
-    #   # once preview is open, the images are embedded in the page.
-    #   # there should be 1 image in main, and 1 image in edit
-    #   assert_selector('#comment-preview-edit-' + comment_id_num + ' img', count: 1)
-    #   assert_selector('#comment-preview-main img', count: 1)
-    # end
+    test "#{page_type_string}: image SELECT upload into EDIT form isn't CROSS-WIRED with MAIN form" do
+      nodes(node_name).add_comment({
+        uid: 5,
+        body: comment_text
+      })
+      nodes(node_name).add_comment({
+        uid: 2,
+        body: comment_text
+      })
+      visit get_path(page_type, nodes(node_name).path)
+      # open the edit comment form:
+      find(".edit-comment-btn").click
+      # find the parent of edit comment's fileinput:
+      comment_fileinput_parent_id = page.find('[id^=dropzone-small-edit-]')[:id] # 'begins with' CSS selector
+      comment_id_num = /dropzone-small-edit-(\d+)/.match(comment_fileinput_parent_id)[1]
+      # upload images
+      # the <inputs> that take image uploads are hidden, so reveal them:
+      Capybara.ignore_hidden_elements = false
+      # upload an image in the main comment form
+      page.find('#fileinput-button-main').set("#{Rails.root.to_s}/public/images/pl.png")
+      wait_for_ajax
+      # find edit comment's fileinput:
+      page.find('#fileinput-button-edit-' + comment_id_num).set("#{Rails.root.to_s}/public/images/pl.png")
+      wait_for_ajax
+      Capybara.ignore_hidden_elements = true
+      # click preview buttons in main and edit form
+      page.find('h4', text: /Post comment|Post Comment/) # title text on wikis is 'Post comment'
+        .find(:xpath, '..')
+        .find('a', text: 'Preview').click
+      page.find('#comment-form-edit-' + comment_id_num + ' a', text: 'Preview').click
+      # once preview is open, the images are embedded in the page.
+      # there should be 1 image in main, and 1 image in edit
+      assert_selector('#comment-preview-edit-' + comment_id_num + ' img', count: 1)
+      assert_selector('#comment-preview-main img', count: 1)
+    end
 
     # cross-wiring test
     # SELECT image upload in both:
     #   EDIT FORM
     #   REPLY form
-    # test "#{page_type_string}:  image SELECT upload into EDIT form isn't CROSS-WIRED with REPLY form" do
-    #   nodes(node_name).add_comment({
-    #     uid: 2,
-    #     body: comment_text
-    #   })
-    #   visit get_path(page_type, nodes(node_name).path)
-    #   # find the EDIT id
-    #   # open up the edit comment form
-    #   page.find(".edit-comment-btn").click
-    #   edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
-    #   # regex to strip the ID number out of string. ID format is #c1234edit
-    #   edit_id_num = /comment-form-edit-(\d+)/.match(edit_comment_form_id)[1]
-    #   # open the edit comment form
-    #   edit_preview_id = '#comment-preview-edit-' + edit_id_num
-    #   # find the REPLY id
-    #   page.all('p', text: 'Reply to this comment...')[0].click
-    #   reply_dropzone_id = page.find('[id^=dropzone-small-reply-]')[:id]
-    #   # ID begins with...
-    #   reply_id_num = /dropzone-small-reply-(\d+)/.match(reply_dropzone_id)[1]
-    #   # upload images
-    #   # the <inputs> that take image uploads are hidden, so reveal them:
-    #   Capybara.ignore_hidden_elements = false
-    #   # upload an image in the reply comment form
-    #   page.find('#fileinput-button-reply-' + reply_id_num).set("#{Rails.root.to_s}/public/images/pl.png")
-    #   wait_for_ajax
-    #   # upload an image in the edit comment form
-    #   page.find('#fileinput-button-edit-' + edit_id_num).set("#{Rails.root.to_s}/public/images/pl.png")
-    #   Capybara.ignore_hidden_elements = true
-    #   wait_for_ajax
-    #   # click preview buttons in reply and edit form
-    #   page.find('#comment-form-edit-' + edit_id_num + ' a', text: 'Preview').click
-    #   page.first('a', text: 'Preview').click
-    #   assert_selector('#comment-preview-edit-' + edit_id_num + ' img', count: 1)
-    #   assert_selector('#comment-preview-reply-' + reply_id_num, count: 1)
-    # end
+    test "#{page_type_string}:  image SELECT upload into EDIT form isn't CROSS-WIRED with REPLY form" do
+      nodes(node_name).add_comment({
+        uid: 2,
+        body: comment_text
+      })
+      visit get_path(page_type, nodes(node_name).path)
+      # find the EDIT id
+      # open up the edit comment form
+      page.find(".edit-comment-btn").click
+      edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
+      # regex to strip the ID number out of string. ID format is #c1234edit
+      edit_id_num = /comment-form-edit-(\d+)/.match(edit_comment_form_id)[1]
+      # open the edit comment form
+      edit_preview_id = '#comment-preview-edit-' + edit_id_num
+      # find the REPLY id
+      page.all('p', text: 'Reply to this comment...')[0].click
+      reply_dropzone_id = page.find('[id^=dropzone-small-reply-]')[:id]
+      # ID begins with...
+      reply_id_num = /dropzone-small-reply-(\d+)/.match(reply_dropzone_id)[1]
+      # upload images
+      # the <inputs> that take image uploads are hidden, so reveal them:
+      Capybara.ignore_hidden_elements = false
+      # upload an image in the reply comment form
+      page.find('#fileinput-button-reply-' + reply_id_num).set("#{Rails.root.to_s}/public/images/pl.png")
+      wait_for_ajax
+      # upload an image in the edit comment form
+      page.find('#fileinput-button-edit-' + edit_id_num).set("#{Rails.root.to_s}/public/images/pl.png")
+      Capybara.ignore_hidden_elements = true
+      wait_for_ajax
+      # click preview buttons in reply and edit form
+      page.find('#comment-form-edit-' + edit_id_num + ' a', text: 'Preview').click
+      page.first('a', text: 'Preview').click
+      assert_selector('#comment-preview-edit-' + edit_id_num + ' img', count: 1)
+      assert_selector('#comment-preview-reply-' + reply_id_num, count: 1)
+    end
 
-    # test "#{page_type_string}: rich-text input into REPLY form isn't CROSS-WIRED with EDIT form" do
-    #   nodes(node_name).add_comment({
-    #     uid: 5,
-    #     body: comment_text
-    #   })
-    #   nodes(node_name).add_comment({
-    #     uid: 2,
-    #     body: comment_text
-    #   })
-    #   visit get_path(page_type, nodes(node_name).path)
-    #   # open up the edit comment form
-    #   page.find(".edit-comment-btn").click
-    #   # find the EDIT id
-    #   edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
-    #   # open up the reply comment form
-    #   page.all('p', text: 'Reply to this comment...')[1].click
-    #   page.all("[data-original-title='Bold']")[0].click
-    #   reply_input_value = page.find('[id^=text-input-reply-]').value
-    #   edit_input_value = page.find('#' + edit_comment_form_id + ' textarea').value
-    #   assert_equal(comment_text, edit_input_value)
-    #   assert_equal('****', reply_input_value)
-    # end
+    test "#{page_type_string}: rich-text input into REPLY form isn't CROSS-WIRED with EDIT form" do
+      nodes(node_name).add_comment({
+        uid: 5,
+        body: comment_text
+      })
+      nodes(node_name).add_comment({
+        uid: 2,
+        body: comment_text
+      })
+      visit get_path(page_type, nodes(node_name).path)
+      # open up the edit comment form
+      page.find(".edit-comment-btn").click
+      # find the EDIT id
+      edit_comment_form_id = page.find('h4', text: 'Edit comment').find(:xpath, '..')[:id]
+      # open up the reply comment form
+      page.all('p', text: 'Reply to this comment...')[1].click
+      page.all("[data-original-title='Bold']")[0].click
+      reply_input_value = page.find('[id^=text-input-reply-]').value
+      edit_input_value = page.find('#' + edit_comment_form_id + ' textarea').value
+      assert_equal(comment_text, edit_input_value)
+      assert_equal('****', reply_input_value)
+    end
   end
 end


### PR DESCRIPTION
This should have happened a long time ago...

This is all up for debate, but I'm pruning the comment system tests so that System Test CI doesn't take 20 minutes. Locally, when I run this PR, the comment system tests take 4 minutes. Big improvement!

I know the structure of `comment_test.rb` is confusing, so I'll break it down here. The system tests are divided into 3 parts:

1. Posting comments, posting comment replies, deleting comments, and editing comments. These four basic CRUD-type functions are tested for the Rails commenting system, and then run a **second** time on the React commenting system.
2. The vast majority of comment tests are run on research notes.
3. A select few tests are run on research notes, **AND** wikis, **AND** questions. 

This PR does the following:
- Comments out tests for cross-wiring image upload bugs (see #8670 for more context). The comment system rewrite reduces the likelihood of these bugs occurring. But if they ever come back, we can un-comment these again.
- Moves comment moderation tests from Part 3 to Part 2, so they're only run on research notes, and not the other two page types.
- Moves image upload and rich-text tests from Part 3 to Part 2 as well.

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)