### PR TITLE
Changed pop-up statement

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -161,7 +161,7 @@ module ApplicationHelper
 
     if html && current_user&.has_tag('translation-helper') && translated_string2.include?("translation missing") && !translated_string.include?("<")
       raw(%(<span>#{translated_string} <a href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
-          <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate this text.' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
+          <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate the text \" #{translated_string} \"' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
        </span>))
     else
       raw(translated_string)


### PR DESCRIPTION
Part of #9686 
![Screenshot from 2021-06-16 02-38-19](https://user-images.githubusercontent.com/38528640/122123752-00baa380-ce4c-11eb-8176-61666d330a4c.png)
I think instead of `this text` we can have pop-up with `the text "string to be translated" `, it makes pop-up bit more clear but makes the pop-up a bit longer.  

![Screenshot from 2021-06-16 02-34-19](https://user-images.githubusercontent.com/38528640/122123651-dbc63080-ce4b-11eb-8382-b5ced23a5739.png)

