### PR TITLE
Reduced globe icon count

### DIFF
--- a/app/assets/javascripts/translation.js
+++ b/app/assets/javascripts/translation.js
@@ -1,0 +1,5 @@
+$(document).ready(function () {
+  $('.translationIcon').filter(function(i) {
+  return (i + 1) % 3 == 0
+  }).show();
+});

--- a/app/assets/javascripts/translation.js
+++ b/app/assets/javascripts/translation.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
   $('.translationIcon').filter(function(i) {
-  return (i + 1) % 3 == 0
+  return (i + 1) % 3 === 0
   }).show();
 });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,7 +160,7 @@ module ApplicationHelper
     translated_string2 = t(key, options)
 
     if html && current_user&.has_tag('translation-helper') && translated_string2.include?("translation missing") && !translated_string.include?("<")
-      raw(%(<span>#{translated_string} <a href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
+      raw(%(<span>#{translated_string} <a class="translationIcon" style='display: none;' href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
           <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate this text.' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
        </span>))
     else

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -78,3 +78,4 @@
 </div>
 <%= stylesheet_link_tag "dashboard" %>
 <%= javascript_include_tag "dashboard" %>
+<%= javascript_include_tag "translation" %>

--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -8,6 +8,7 @@
     }
   });
 </script>
+<%= javascript_include_tag "translation" %>
 
 <div class="col-lg-3">
 

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -274,6 +274,7 @@
   </div>
 
 </div>
+<%= javascript_include_tag "translation" %>
 
 <script src = "https://cdn.jsdelivr.net/npm/frappe-charts@0.0.8/dist/frappe-charts.min.iife.js"></script>
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,6 +15,7 @@ Rails.application.config.assets.precompile += [
   'question.js',
   'sidebar.js',
   'textBoxExpand.js',
+  'translation.js',
 
   'blog.css',
   'comments.css',


### PR DESCRIPTION
Part of #9686 
To reduce the count of globe icons on the site I initially made all globe icons invisible and then add a javascript that runs on the DOM and toggles every 3rd globe icon. This prevents grouping the icons in one place and icons appear uniforms across the site.

For now, I tried this out with /dashboard /subscriptions /profile/admin pages .
These are some screenshots after the change.

**Dashboard**
![Screenshot from 2021-06-18 00-09-38](https://user-images.githubusercontent.com/38528640/122455812-70569d00-cfca-11eb-9d57-ca2624d06ed3.png)
After changes
![Screenshot from 2021-06-17 23-43-37](https://user-images.githubusercontent.com/38528640/122455811-70569d00-cfca-11eb-8ab6-a3655175ef38.png)

**Subscriptons Page**
![Screenshot from 2021-06-18 00-10-07](https://user-images.githubusercontent.com/38528640/122456004-a8f67680-cfca-11eb-8fa1-f562a49dc21e.png)
After changes
![Screenshot from 2021-06-17 23-46-21](https://user-images.githubusercontent.com/38528640/122456016-abf16700-cfca-11eb-8452-8895e10c5a63.png)

**Profile Page**
![Screenshot from 2021-06-18 00-19-27](https://user-images.githubusercontent.com/38528640/122456242-f541b680-cfca-11eb-928f-624e13c5dd55.png)
After Changes
![Screenshot from 2021-06-18 00-22-25](https://user-images.githubusercontent.com/38528640/122456560-58334d80-cfcb-11eb-968e-730c97273d5a.png)


