### PR TITLE
functional and system tests for preventing adding tags by first-time-posters

### DIFF
--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -669,4 +669,20 @@ class TagControllerTest < ActionController::TestCase
     assert_equal 2, counts[:wiki], "Wiki count should match"
     assert_equal 0, assigns(:total_posts), "Total posts should match"
   end
+  
+  test 'should prevent first time posters to add tags on other users posts' do
+    UserSession.create(users(:newcomer))
+
+    post :create, params: { name: 'mytag', nid: nodes(:one).nid }
+
+    assert_equal 'Adding tags to other people’s posts is not available to you until your own first post has been approved by site moderators', assigns[:output][:errors][0]
+  end
+
+  test 'should allow first time posters to add tags on their own posts' do
+    UserSession.create(users(:newcomer))
+
+    post :create, params: { name: 'mytag', nid: nodes(:first_timer_note).nid }
+
+    assert_equal 'mytag', assigns[:tags].last.name
+  end
 end

--- a/test/system/tag_test.rb
+++ b/test/system/tag_test.rb
@@ -52,4 +52,80 @@ class TagTest < ApplicationSystemTestCase
 
   end
 
+  test 'hide add tag form from first time posters' do
+    visit "/wiki/wiki-page-path"
+
+    # check whether element with id `tags-open` present or not for normal user
+    assert_selector("#tags-open")
+    
+    find("#sidebar-tags a").click()
+    # check whether element with id `tagform` present or not for normal user
+    assert_selector("#tagform")
+
+    # logout
+    visit '/logout'
+    visit '/'
+
+    # login to first time user
+    find(".nav-link.loginToggle").click()
+    fill_in("username-login", with: "sushmita")
+    fill_in("password-signup", with: "secretive")
+
+    find(".login-modal-form #login-button").click()
+
+    visit "/wiki/wiki-page-path"
+
+    # check whether element with id `tags-open` present or not
+    assert_selector("#tags-open", count: 0)
+    
+    find("#sidebar-tags a").click()
+
+    # check whether element with id `tagform` present or not
+    assert_selector("#tagform", count: 0)
+    # check that the error message showed up on the page
+    assert_selector(".popover-body", text: 'Adding tags to other people’s posts is not available to you until your own first post has been approved by site moderators')
+
+  end
+
+  test 'block adding tag using javascript by first time posters' do
+    # logout
+    visit '/logout'
+    visit '/'
+
+    # login to first time poster
+    find(".nav-link.loginToggle").click()
+    fill_in("username-login", with: "sushmita")
+    fill_in("password-signup", with: "secretive")
+
+    find(".login-modal-form #login-button").click()
+
+    visit "/wiki/wiki-page-path"
+
+    # run the javascript function
+    page.evaluate_script("addTag('bluebell')")
+
+    # check if tag showed up on the page
+    assert_selector('.tags-list a', {count: 0, text: 'bluebell'})
+  end
+
+  test 'block adding tag using javascript with only url by first time posters' do
+    # logout
+    visit '/logout'
+    visit '/'
+
+    # login to first time poster
+    find(".nav-link.loginToggle").click()
+    fill_in("username-login", with: "sushmita")
+    fill_in("password-signup", with: "secretive")
+
+    find(".login-modal-form #login-button").click()
+
+    visit "/wiki/wiki-page-path"
+
+    # run the javascript function
+    page.evaluate_script("addTag('mytag', '/tag/create/11')")
+
+    # check if tag showed up on the page
+    assert_selector('.tags-list a', {count: 0, text: 'mytag'})
+  end
 end


### PR DESCRIPTION
Fixes #9850 

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below