### PR TITLE
Implement useReducer for commentFormsVisibility

### DIFF
--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { UserContext } from "./user-context";
 import { StaticPropsContext } from "./static-props-context";
-import { getEditTextAreaValues, getInitialCommentFormToggleState } from "./helpers";
+import { getEditTextAreaValues, getInitialCommentFormsVisibility } from "./helpers";
 
 import CommentsContainer from "./CommentsContainer";
 
@@ -23,7 +23,7 @@ const App = ({
   // this is an object containing boolean values like: { "reply-33": false, "edit-1": true }
   // this is used as the initial state showing whether or not an edit or reply comment form is shown or hidden
   // false means the comment form is closed, true means open
-  const initialCommentFormToggleState = getInitialCommentFormToggleState(initialComments);
+  const initialCommentFormsVisibility = getInitialCommentFormsVisibility(initialComments);
 
   // this is used as initial state for the content of <textarea>s inside comment forms
   // main and reply comment forms are an empty string
@@ -41,7 +41,7 @@ const App = ({
     <UserContext.Provider value={currentUser}>
       <StaticPropsContext.Provider value={{ node, elementText }}>
         <CommentsContainer 
-          initialCommentFormToggleState={initialCommentFormToggleState}
+          initialCommentFormsVisibility={initialCommentFormsVisibility}
           initialComments={initialComments} 
           initialTextAreaValues={initialTextAreaValues}
           nodeId={nodeId}

--- a/app/javascript/components/CommentReplies.js
+++ b/app/javascript/components/CommentReplies.js
@@ -4,13 +4,16 @@ import PropTypes from "prop-types";
 const CommentReplies = ({
   children,
   commentId,
+  dispatch,
   isReplyFormVisible,
-  handleReplyFormToggle,
   replyCommentForm
 }) => {
   const replyToggleLink = <p
     id={"comment-" + commentId + "-reply-toggle"}
-    onClick={() => handleReplyFormToggle("reply-" + commentId)}
+    onClick={() => dispatch({
+      type: "TOGGLE COMMENT FORM VISIBILITY",
+      commentFormId: "reply-" + commentId
+    })}
     style={{
       color: "#006dcc",
       cursor: "pointer",
@@ -36,6 +39,7 @@ const CommentReplies = ({
 CommentReplies.propTypes = {
   children: PropTypes.array,
   commentId: PropTypes.number.isRequired,
+  dispatch: PropTypes.func.isRequired,
   isReplyFormVisible: PropTypes.bool.isRequired,
   handleReplyFormToggle: PropTypes.func,
   replyCommentForm: PropTypes.element

--- a/app/javascript/components/CommentsContainer.js
+++ b/app/javascript/components/CommentsContainer.js
@@ -57,11 +57,17 @@ const CommentsContainer = ({
         // blank out the value of textarea & also create a value for the new comment's edit form
         setTextAreaValues(oldState => ({ ...oldState, [formId]: "", ["edit-" + newCommentId]: newCommentRawText }));
         // the new comment form comes with an edit form, its toggle state needs to be created as well
-        setCommentFormsVisibility(oldState => ({ ...oldState, ["edit-" + newCommentId]: false }));
+        dispatch({
+          type: "HIDE COMMENT FORM",
+          commentFormId: "edit-" + newCommentId
+        })
         // if the comment doesn't have a replyTo, then it's a parent comment
         // parent comments have reply forms, this needs to be set in state as well.
         if (!data.comment[0].replyTo) {
-          setCommentFormsVisibility(oldState => ({ ...oldState, ["reply-" + newCommentId]: false }));
+          dispatch({
+            type: "HIDE COMMENT FORM",
+            commentFormId: "reply-" + newCommentId
+          })
         }
         // call useReducer's dispatch function to push the comment into state
         dispatch({
@@ -70,7 +76,10 @@ const CommentsContainer = ({
         })
         // close the comment form
         if (formType !== "main") {
-          setCommentFormsVisibility(oldState => (Object.assign({}, oldState, { [formId]: false })));
+          dispatch({
+            type: "HIDE COMMENT FORM",
+            commentFormId: formId
+          });
         }
       }
     );
@@ -93,7 +102,10 @@ const CommentsContainer = ({
           newComment: data.comment[0]
         })
         // close the edit comment form
-        setCommentFormsVisibility(oldState => (Object.assign({}, oldState, { [formId]: false })));
+        dispatch({
+          type: "HIDE COMMENT FORM",
+          commentFormId: formId
+        });
         notyNotification('mint', 3000, 'success', 'topRight', 'Comment Updated!');
       }
     );

--- a/app/javascript/components/CommentsContainer.js
+++ b/app/javascript/components/CommentsContainer.js
@@ -9,26 +9,18 @@ import CommentsHeader from "./CommentsHeader";
 import CommentsList from "./CommentsList"
 
 const CommentsContainer = ({
-  initialCommentFormToggleState,
+  initialCommentFormsVisibility,
   initialComments,
   initialTextAreaValues,
   nodeId
 }) => {
   const initialState = {
     comments: initialComments,
-    commentFormsVisibility: initialCommentFormToggleState,
+    commentFormsVisibility: initialCommentFormsVisibility,
     textAreaValues: initialTextAreaValues
   }
 
   const [state, dispatch] = useReducer(reducer, initialState);
-
-  // React Hook: Visibility for Reply and Edit Comment Forms
-  const [commentFormsVisibility, setCommentFormsVisibility] = useState(initialCommentFormToggleState);
-
-  // hide and reveal reply & edit comment forms
-  const handleFormVisibilityToggle = (commentFormId) => {
-    setCommentFormsVisibility(oldState => (Object.assign({}, oldState, { [commentFormId]: !oldState[commentFormId] })));
-  }
 
   // React Hook: <textarea> Input State for Comment Forms
   //   ie. the value that shows inside a comment form's <textarea>
@@ -132,12 +124,12 @@ const CommentsContainer = ({
           <div id="comments" className="col-lg-10 comments">
             <CommentsHeader comments={state.comments} />
             <CommentsList 
-              commentFormsVisibility={commentFormsVisibility}
+              commentFormsVisibility={state.commentFormsVisibility}
               comments={state.comments}
               currentUser={currentUser}
+              dispatch={dispatch}
               handleCreateComment={handleCreateComment}
               handleDeleteComment={handleDeleteComment}
-              handleFormVisibilityToggle={handleFormVisibilityToggle}
               handleTextAreaChange={handleTextAreaChange}
               handleUpdateComment={handleUpdateComment}
               setTextAreaValues={setTextAreaValues}
@@ -159,7 +151,7 @@ const CommentsContainer = ({
 }
 
 CommentsContainer.propTypes = {
-  initialCommentFormToggleState: PropTypes.object.isRequired,
+  initialCommentFormsVisibility: PropTypes.object.isRequired,
   initialComments: PropTypes.array.isRequired,
   initialTextAreaValues: PropTypes.object.isRequired,
   nodeId: PropTypes.number.isRequired

--- a/app/javascript/components/CommentsList.js
+++ b/app/javascript/components/CommentsList.js
@@ -12,9 +12,9 @@ const CommentsList = ({
   commentFormsVisibility,
   comments,
   currentUser,
+  dispatch,
   handleCreateComment,
   handleDeleteComment,
-  handleFormVisibilityToggle,
   handleTextAreaChange,
   handleUpdateComment,
   setTextAreaValues,
@@ -44,7 +44,10 @@ const CommentsList = ({
       const toggleEditButton = <CommentToolbarButton 
         buttonType="edit"
         icon={<i className="fa fa-pencil"></i>}
-        onClick={() => handleFormVisibilityToggle("edit-" + comment.commentId)}
+        onClick={() => dispatch({ 
+          type: "TOGGLE COMMENT FORM VISIBILITY",
+          commentFormId: "edit-" + comment.commentId 
+        })}
       />;
   
       // and a delete button
@@ -85,7 +88,7 @@ const CommentsList = ({
         replySection = <CommentReplies 
           commentId={comment.commentId}
           isReplyFormVisible={commentFormsVisibility[replyFormId]}
-          handleReplyFormToggle={handleFormVisibilityToggle}
+          dispatch={dispatch}
           replyCommentForm={replyCommentForm}
         >
           {replies}
@@ -146,9 +149,9 @@ CommentsList.propTypes = {
   commentFormsVisibility: PropTypes.object.isRequired,
   comments: PropTypes.array.isRequired,
   currentUser: PropTypes.object,
+  dispatch: PropTypes.func.isRequired,
   handleCreateComment: PropTypes.func.isRequired,
   handleDeleteComment: PropTypes.func.isRequired,
-  handleFormVisibilityToggle: PropTypes.func.isRequired,
   handleTextAreaChange: PropTypes.func.isRequired,
   handleUpdateComment: PropTypes.func.isRequired,
   setTextAreaValues: PropTypes.func.isRequired,

--- a/app/javascript/components/helpers.js
+++ b/app/javascript/components/helpers.js
@@ -13,19 +13,19 @@ const getEditTextAreaValues = (commentsArray) => {
   return editTextValues;
 };
 
-const getInitialCommentFormToggleState = (commentsArray) => {
-  let commentFormToggleState = {};
+const getInitialCommentFormsVisibility = (commentsArray) => {
+  let commentFormVisibility = {};
 
   for (let i = 0; i < commentsArray.length; i++) {
     if (!commentsArray[i].replyTo) {
       const replyFormId = "reply-" + commentsArray[i].commentId;
-      commentFormToggleState[replyFormId] = false;
+      commentFormVisibility[replyFormId] = false;
     }
     const editFormID = "edit-" + commentsArray[i].commentId;
-    commentFormToggleState[editFormID] = false;
+    commentFormVisibility[editFormID] = false;
   }
 
-  return commentFormToggleState;
+  return commentFormVisibility;
 };
 
 // for making deep copies of nested arrays and objects
@@ -52,6 +52,6 @@ const makeDeepCopy = (input) => {
 
 export { 
   getEditTextAreaValues,
-  getInitialCommentFormToggleState, 
+  getInitialCommentFormsVisibility, 
   makeDeepCopy 
 };

--- a/app/javascript/components/reducers.js
+++ b/app/javascript/components/reducers.js
@@ -48,6 +48,14 @@ const reducer = (state, action) => {
           [action.commentFormId]: !state.commentFormsVisibility[action.commentFormId]
         }
       };
+    case "HIDE COMMENT FORM":
+      return {
+        ...state,
+        commentFormsVisibility: {
+          ...state.commentFormsVisibility,
+          [action.commentFormId]: false
+        }
+      }
     default:
       throw new Error(); // default should never be called
   }

--- a/app/javascript/components/reducers.js
+++ b/app/javascript/components/reducers.js
@@ -40,6 +40,14 @@ const reducer = (state, action) => {
         }
       }
       break;
+    case "TOGGLE COMMENT FORM VISIBILITY": // shows/hides reply & edit comment forms when user clicks the toggle button
+      return {
+        ...state,
+        commentFormsVisibility: {
+          ...state.commentFormsVisibility,
+          [action.commentFormId]: !state.commentFormsVisibility[action.commentFormId]
+        }
+      };
     default:
       throw new Error(); // default should never be called
   }

--- a/app/javascript/components/reducers.js
+++ b/app/javascript/components/reducers.js
@@ -1,0 +1,50 @@
+/* eslint-disable complexity */
+import { makeDeepCopy } from "./helpers";
+
+const reducer = (state, action) => {
+  switch(action.type) {
+    case "CREATE COMMENT":
+      return {
+        ...state,
+        comments: [
+          ...state.comments, 
+          action.newComment
+        ]
+      };
+    case "UPDATE COMMENT":
+      for (let i = 0; i < state.comments.length; i++) {
+        // find the comment in state
+        if (state.comments[i].commentId === action.newComment.commentId) {
+          let newComment = makeDeepCopy(state.comments[i]);
+          newComment.htmlCommentText = action.newComment.htmlCommentText; // update comment text
+          newComment.rawCommentText = action.newComment.rawCommentText;
+          return {
+            ...state,
+            comments: Object.assign(
+              [],
+              state.comments,
+              { [i]: newComment }
+            )
+          }; // keep the rest of state.comments, but replace comment at index i with newComment
+        }
+      }
+      break;
+    case "DELETE COMMENT":
+      for (let i = 0; i < state.comments.length; i++) {
+        // find the comment in state by ID
+        if (state.comments[i].commentId === action.commentId) {
+          return {
+            ...state,
+            comments: state.comments.filter(comment => action.commentId !== comment.commentId)
+          };
+        }
+      }
+      break;
+    default:
+      throw new Error(); // default should never be called
+  }
+}
+
+export {
+  reducer
+}


### PR DESCRIPTION
Part of a React rewrite of the commenting system, see #9365 for more context.

This PR is a follow-up to #9801. In that PR, I started to implement React's `useReducer` to handle state management, which is becoming more complex.

Basically, #9801 converted `state`'s `comments` object to `useReducer`. This PR converts `state`'s `commentFormsVisibility` to `useReducer`. `commentFormsVisibility` is a bit of data in statethat models whether or not an edit/reply comment form is visible on the page

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issue #9069 for more context)