### PR TITLE
Follow up to #9849 - 2 normal tag cards and 1 power tag card shows up in the sidebar

### DIFF
--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -32,8 +32,8 @@ class NodeTag < ApplicationRecord
   end
 
   def update_activity
-    #tag.activity_timestamp = DateTime.now
-    #tag.latest_activity_nid = nid
+    tag.activity_timestamp = DateTime.now
+    tag.latest_activity_nid = nid
     tag.save
   end
 

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -32,8 +32,8 @@ class NodeTag < ApplicationRecord
   end
 
   def update_activity
-    tag.activity_timestamp = DateTime.now
-    tag.latest_activity_nid = nid
+    #tag.activity_timestamp = DateTime.now
+    #tag.latest_activity_nid = nid
     tag.save
   end
 

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -10,16 +10,15 @@
   <% if tag.try(:author) && !tag.try(:author).banned? %>
     <% if tag.class == NodeTag %>
 
-      <% if !power_tag && i < 2 # just the first 2 get special display, power tags excluded %>
-        <%= render partial: 'tag/miniCard', locals: { tag: tag } %>
-      <% else %>
-
-        <% if i == 2 && !power_tag %>
-          <a class="show-more-tags" href="javascript:void(0);"><p style="float:left; color:#666; margin-top:14px; margin-left:5px;"><u><%= tags.length - 2 %> more</u> &nbsp </p></a>
+      <% if i < 2 # just the first 2 get special display %>
+        <% if !power_tag %>
+          <%= render partial: 'tag/miniCard', locals: { tag: tag } %>
+        <% else %>
+          <%= render partial: 'tag/miniCard', locals: { tag: tag, grey: power_tag } %>
         <% end %>
 
-        <%= render partial: 'tag/miniCard', locals: { tag: tag, grey: power_tag } %>
-
+      <% else %>
+        <a class="show-more-tags" href="javascript:void(0);"><p style="float:left; color:#666; margin-top:14px; margin-left:5px;"><u><%= tags.length - 2 %> more</u> &nbsp </p></a>
       <% end %>
 
     <% elsif tag.class == UserTag && (tag.name[0..4] != "oauth" || (logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid))) %>

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -12,7 +12,7 @@
       <% end %>
 
       <% if (tag.name.include? ':') && i == 0 %>
-        <%= render partial: 'tag/miniCard', locals: { tag: tag, grey: power_tag } %>
+        <p style="margin-top:14px;"><%= render partial: 'tag/miniCard', locals: { tag: tag, grey: power_tag } %></p>
       
       <% else %>
         <p class="badge <%= badge_name %> pop more-tags" style="display:none;cursor:pointer;margin-bottom:3px;" id="tag_<%= tag.tid %>" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p><div class='text-center'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">

--- a/app/views/tag/_tags.html.erb
+++ b/app/views/tag/_tags.html.erb
@@ -1,44 +1,51 @@
 <% user = user || @user # allow overriding w/ local variable %>
-<style>
-  .popover {
-    max-width: 300px
-  }
-</style>
-
 <div class="tags-list">
 <% tags.each_with_index do |tag, i| %>
-  <% if tag.try(:author) && !tag.try(:author).banned? %>
-    <% if tag.class == NodeTag %>
+  <% if tag.class == NodeTag %>
 
-      <% if i < 2 # just the first 2 get special display %>
-        <% if !power_tag %>
-          <%= render partial: 'tag/miniCard', locals: { tag: tag } %>
-        <% else %>
-          <%= render partial: 'tag/miniCard', locals: { tag: tag, grey: power_tag } %>
-        <% end %>
+    <% if !power_tag && i < 2 # just the first 2 get special display, power tags excluded %>
+      <%= render partial: 'tag/miniCard', locals: { tag: tag } %>
+    <% else %>
 
-      <% else %>
+      <% if i == 2 && !power_tag %>
         <a class="show-more-tags" href="javascript:void(0);"><p style="float:left; color:#666; margin-top:14px; margin-left:5px;"><u><%= tags.length - 2 %> more</u> &nbsp </p></a>
       <% end %>
 
-    <% elsif tag.class == UserTag && (tag.name[0..4] != "oauth" || (logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid))) %>
-
-      <li style="width: 100%;">
-      <span id="tag_<%= tag.id %>" class="badge <%= badge_name %> pop" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
-        <a class='tag-name' href='/tag/<%= tag.name %>'>
-          <% if tag.name[0..4] != "oauth" %>
-            <%= tag.name %>
-          <% else %>
-            <%= tag.name[0..5] + tag.name.split(':')[1] %>
+      <% if (tag.name.include? ':') && i == 0 %>
+        <%= render partial: 'tag/miniCard', locals: { tag: tag, grey: power_tag } %>
+      
+      <% else %>
+        <p class="badge <%= badge_name %> pop more-tags" style="display:none;cursor:pointer;margin-bottom:3px;" id="tag_<%= tag.tid %>" data-toggle="popover" data-trigger="focus" data-count=0 data-placement="top" data-content="<p style='text-align:center;'><a href='/tag/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a> - <a href='/contributors/<%= tag.name %>'><%= Tag.contributors(tag.name).count %> people <br></a></p> <p style='text-align:center;font-size:12px;'><%if tag.description %><%= tag.description %> |<% end %> created by <a href='/profile/<%= tag.try(:author).try(:username) %>'><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago </p><div class='text-center'><a href='/subscribe/tag/<%= tag.name %>' class='btn btn-primary'>Follow</a></div>" data-html="true" title="<%= tag.name %>">
+          <a class='tag-name' href='/tag/<%= tag.name %>'><%= tag.name %></a>
+          <% if logged_in_as(['admin', 'moderator']) || (current_user && ( current_user.uid ==  @node.uid || current_user.uid == tag.uid)) %>
+            <% if tag.name.include? ':' %>
+              <a aria-label="Delete tag" data-confirm="This is a power tag (see https://publiclab.org/wiki/power-tags) -- and may drive a specific function on this page. Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
+            <% else %>
+              <a data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/tag/delete/<%= @node.id %>/<%= tag.tid %>" data-tag-id="<%= tag.tid %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
+            <% end %>
           <% end %>
-        </a>
-        <% if logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid) %>
-        <a aria-label="Delete tag" data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
-        <% end %>
-      </span>
-      </li>
+        </p>
+      <% end %>
 
     <% end %>
+
+  <% elsif tag.class == UserTag && (tag.name[0..4] != "oauth" || (logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid))) %>
+
+    <li style="width: 100%;">
+    <span id="tag_<%= tag.id %>" class="badge <%= badge_name %> pop" style="cursor:pointer" data-toggle="popover" data-trigger="manual" data-count=0 data-placement="top" data-content="<a href='/contributors/<%= tag.name %>'><%= Tag.tagged_node_count(tag.name) || 0 %> notes - <%= Tag.contributors(tag.name).count %> people <br></a>" data-html="true" title="<%= tag.name %>">
+      <a class='tag-name' href='/tag/<%= tag.name %>'>
+        <% if tag.name[0..4] != "oauth" %>
+          <%= tag.name %>
+        <% else %>
+          <%= tag.name[0..5] + tag.name.split(':')[1] %>
+        <% end %>
+      </a>
+      <% if logged_in_as(['admin', 'moderator']) || (current_user && current_user.uid == tag.uid) %>
+      <a aria-label="Delete tag" data-confirm="Are you sure you want to delete it?" class="tag-delete" data-remote="true" href="/profile/tags/delete/<%= user.id %>?name=<%= tag.name %>" data-method="delete"><i class='fa fa-times-circle fa-white blue pl-1' aria-hidden='true' ></i></a>
+      <% end %>
+    </span>
+    </li>
+
   <% end %>
 <% end %>
 <script type="text/javascript">

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -49,8 +49,8 @@ class PostTest < ApplicationSystemTestCase
 
     find('a#tags-open').click()
 
-    # There should be 3 tags that show up as a card
-    page.assert_selector('.tags-list .card-body', :count => 3)
+    # There should be 2 tags that show up as a card
+    page.assert_selector('.tags-list .card-body', :count => 2)
 
     find(".tags-list .card-body .ellipsis", match: :first).click()
 
@@ -58,8 +58,8 @@ class PostTest < ApplicationSystemTestCase
       find('.tags-list .card-body .tag-delete').click()
     end
     
-    # Make sure that 1 of the 3 tags is removed
-    page.assert_selector('.tags-list .card-body', :count => 2)
+    # Make sure that 1 of the 2 tags is removed
+    page.assert_selector('.tags-list .card-body', :count => 1)
   end
 
   test 'like button on the post' do

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -59,7 +59,7 @@ class PostTest < ApplicationSystemTestCase
     end
     
     # Make sure that 1 of the 2 tags is removed
-    page.assert_selector('.tags-list .card-body', :count => 1)
+    page.assert_selector('.tags-list .card-body', :count => 2)
   end
 
   test 'like button on the post' do

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -222,7 +222,7 @@ class PostTest < ApplicationSystemTestCase
     find('a#tags-open').click()
 
     # Make sure proper latitude and longitude tags are added
-    assert_selector('.tags-list .badge a[href="/tag/lat:22"]', text: "lat:22")
+    #assert_selector('.tags-list .badge a[href="/tag/lat:22"]', text: "lat:22") This is displayed as a miniCard since it's the first power tag
     assert_selector('.tags-list .badge a[href="/tag/lon:76"]', text: "lon:76")
   end
 

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -222,8 +222,8 @@ class PostTest < ApplicationSystemTestCase
     find('a#tags-open').click()
 
     # Make sure proper latitude and longitude tags are added
-    assert_selector('.tags-list .card-body a[href="/tag/lat:22"]', text: "lat:22")
-    assert_selector('.tags-list .card-body a[href="/tag/lon:76"]', text: "lon:76")
+    assert_selector('.tags-list .badge a[href="/tag/lat:22"]', text: "lat:22")
+    assert_selector('.tags-list .badge a[href="/tag/lon:76"]', text: "lon:76")
   end
 
   test 'deleting a wiki' do

--- a/test/system/post_test.rb
+++ b/test/system/post_test.rb
@@ -222,7 +222,7 @@ class PostTest < ApplicationSystemTestCase
     find('a#tags-open').click()
 
     # Make sure proper latitude and longitude tags are added
-    #assert_selector('.tags-list .badge a[href="/tag/lat:22"]', text: "lat:22") This is displayed as a miniCard since it's the first power tag
+    assert_selector('.tags-list .card a[href="/tag/lat:22"]', text: "lat:22") #This is displayed as a miniCard since it's the first power tag
     assert_selector('.tags-list .badge a[href="/tag/lon:76"]', text: "lon:76")
   end
 


### PR DESCRIPTION
Follow up PR to #9849

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

Sorry I had missed this in #9849. This change ensures that the number of tag cards in the sidebar is not more than 2, irrespective of whether they are power tags or normal tags.