### PR TITLE
Corrected Greek YAML file langauge code 

### DIFF
--- a/config/locales/gr.yml
+++ b/config/locales/gr.yml
@@ -1,5 +1,5 @@
 ---
-it:
+el:
   activerecord:
     errors:
       messages:


### PR DESCRIPTION
Part of #9686 
To sync language files with transifex, the language code in YAML files should same as they are in https://www.transifex.com/explore/languages/ . This file has Greek translations but was labeled Italian (it) in the YAML file.
![w1](https://user-images.githubusercontent.com/38528640/124919083-6a753a00-e013-11eb-8f0f-a4beb1092272.png)
