### PR TITLE
created drafts page

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -427,6 +427,17 @@ class NotesController < ApplicationController
     end
   end
 
+  def drafts
+    @user = User.find_by(name: params[:id])
+    if current_user&.can_moderate? || current_user == @user
+      @pagy, @drafts = pagy(@user.drafts, items: 24)
+      render template: 'notes/drafts'
+    else
+      flash[:warning] = "This page is only visible to the author and moderators."
+      redirect_to '/'
+    end
+  end
+
   private
 
   def set_node

--- a/app/views/notes/_nav_tabs.html.erb
+++ b/app/views/notes/_nav_tabs.html.erb
@@ -1,4 +1,4 @@
-<div class="node-types" style="margin-bottom:8px;">
+<div class="node-types mr-3" style="margin-bottom:8px;">
   <ul class="nav nav-tabs" aria-labelledby="dropdownMenuButton">
 
     <li class="nav-item">
@@ -27,5 +27,13 @@
         <span class="d-lg-inline"><%= translation('notes.index.comments') %></span>
       </a>
     </li>
+
+    <% if current_user&.can_moderate? || current_user == @user %>
+      <li class="nav-item" style="width: 155px;">
+        <a class="nav-link" href="/drafts/author/<%= @user.name %>">
+          <i class="fa fa-pencil"></i> <span class="d-lg-inline"><%= translation('notes.index.drafts') %></span>
+        </a>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/app/views/notes/drafts.html.erb
+++ b/app/views/notes/drafts.html.erb
@@ -1,0 +1,18 @@
+<div class="col-lg-9">
+  <h3 class="mb-4">Your Drafts (<%= @drafts.count %>)</h3>
+  <div id="notes">
+    <div class="row">
+      <% @drafts.each_with_index do |node,i| %>
+        <div class="<% if @widget %>col-4 <% end %><%= node.tagnames_as_classes %> col-lg-4 col-md-6 clearfix node note node-nid-<%= node.id %> note-nid-<%= node.id %>">
+          <%= render partial: 'notes/card', locals: { node: node, i: i, tagname: false } %>
+        </div>
+        <% unless @widget %><hr class="d-md-none" /><% end %>
+      <% end %>
+    </div>
+  </div>
+  <% if @pagy %>
+    <%== pagy_bootstrap_nav @pagy %>
+  <% else %>
+    <%= will_paginate notes, renderer: WillPaginate::ActionView::BootstrapLinkRenderer unless @unpaginated || (unpaginated ||= false) %>
+  <% end %>
+</div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -266,7 +266,7 @@
       <li><h5><a href = "/tag/question:*/author/<%= params[:id] %>"><%= pluralize(Node.questions.where(status: 1, uid: @profile_user.id).length, 'question', plural:'questions') %></a></h5></li>
       <li><h5><a href = "/profile/comments/<%= params[:id] %>"><%= pluralize(Comment.where(uid: @profile_user.id).count, 'comment', plural: 'comments') %></a></h5></li>
       <% if current_user&.can_moderate? || @profile_user == current_user %>
-        <li><h5><a href='#'><%= pluralize(@profile_user.drafts.size, 'draft', plural: 'drafts' )%></a></h5></li>
+        <li><h5><a href='/drafts/author/<%= @profile_user.name %>'><%= pluralize(@profile_user.drafts.size, 'draft', plural: 'drafts' )%></a></h5></li>
       <% end %>
       <li><h5><a href = "/tag/activity:*/author/<%= params[:id] %>"><%= pluralize(@count_activities_posted, 'activity posted', plural:'activities posted') %> </a></h5></li>
       <li><h5><a href = "/tag/replication:*/author/<%= params[:id] %>"><%= pluralize(@count_activities_attempted, 'activity attempted', plural:'activities attempted')%></a> </h5></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,7 @@ en:
       research_notes: "Research Notes"
       questions: "Questions"
       comments: "Comments"
+      drafts: "Drafts"
       all_notes: "All Notes"
     _notes:
       moderate_first_time_post: "Moderate first-time post:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Plots2::Application.routes.draw do
   get 'notes/show/:id' => 'notes#show'
   get 'notes/:author/:date/:id' => 'notes#show'
   get 'notes/feeds' => 'subscription#notes'
+  get 'drafts/author/:id' => 'notes#drafts'
 
   # :id will be the node's id (like has no id)
   get 'likes' => 'like#index'

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -1069,4 +1069,26 @@ class NotesControllerTest < ActionController::TestCase
          }
     end
   end
+
+  test 'moderators can view drafts page' do
+    user = users(:moderator)
+    UserSession.create(user)
+    get :drafts, params: { id: users(:newcomer).username }
+    assert_response :success
+  end
+
+  test 'draft author can view drafts page' do
+    user = users(:jeff)
+    UserSession.create(user)
+    get :drafts, params: { id: user.username }
+    assert_response :success
+  end
+
+  test 'drafts page is not shown when user is not a draft author or moderator' do
+    user = users(:newcomer)
+    UserSession.create(user)
+    get :drafts, params: { id: users(:jeff).username }
+    assert_equal "This page is only visible to the author and moderators.", flash[:warning]
+    assert_response :redirect
+  end
 end


### PR DESCRIPTION
Fixes #9798
Part of larger planning issue in #9667

<img width="769" alt="Screenshot 2021-07-09 at 00 14 56" src="https://user-images.githubusercontent.com/63427719/125001488-b42d4700-e04a-11eb-848d-96b6dfc924fb.png">

## Responsiveness

https://user-images.githubusercontent.com/63427719/125001931-b17f2180-e04b-11eb-9f22-936c1d4f8b28.mov

When a user who is neither a moderator or the drafts author tries to visit the drafts page, a flash notice is displayed and the user is redirected to the homepage

<img width="641" alt="Screenshot 2021-07-09 at 00 23 25" src="https://user-images.githubusercontent.com/63427719/125002017-e3908380-e04b-11eb-989a-5b8276342d33.png">

