### PR TITLE
[WIP] Continued refinements to cytoscape visualization

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -387,14 +387,14 @@ class Tag < ApplicationRecord
         .limit(limit).each do |tag|
         data["tags"] << {
           "name" => tag.name,
-          "count" => tag.count,
+          "count" => tag.count
         }
       end
       data["edges"] = []
       data["tags"].each do |tag|
         Tag.related(tag["name"], 10).each do |related_tag|
-          reverse = {"from" => related_tag.name, "to" => tag["name"]}
-          unless (data["edges"].include? reverse)
+          reverse = { "from" => related_tag.name, "to" => tag["name"] }
+          unless data["edges"].include? reverse
             data["edges"] << { "from" => tag["name"], "to" => related_tag.name }
           end
         end

--- a/app/views/tag/graph.html.erb
+++ b/app/views/tag/graph.html.erb
@@ -36,13 +36,26 @@ html, body {
 
   (function() {
 
-  $.ajax({
-    url : '/tag/graph.json?limit=' + <%= params[:limit] || 250 %>,
-    type: 'GET',
-    success: function(response){
-      setup_cytoscape(response);
-    }
-  });
+  var mobile = window.matchMedia("(max-width: 400px)")
+  var desktop = window.matchMedia("(min-width: 400px)")
+
+  if (mobile.matches){
+    $.ajax({
+      url : '/tag/graph.json?limit=' + <%= params[:limit] || 100 %>,
+      type: 'GET',
+      success: function(response){
+        setup_cytoscape(response);
+      }
+    });
+  } else{
+    $.ajax({
+      url : '/tag/graph.json?limit=' + <%= params[:limit] || 250 %>,
+      type: 'GET',
+      success: function(response){
+        setup_cytoscape(response);
+      }
+    });
+  }
 
   function parse_cyto_data(data) {
     var output = {
@@ -66,7 +79,7 @@ html, body {
             id: edge.from + "_" + edge.to,
             source: edge.from,
             target: edge.to,
-            weight: Math.random()*10+3 // <= dummy value for jlouvain
+            weight: 10 //Math.random()*10+3 // <= dummy value for jlouvain
           }
         });
       }
@@ -183,15 +196,15 @@ html, body {
           style: {
             'width': 'mapData(weight, ' + min + ',' + max + ', 30, 150)',
             'height': 'mapData(weight, ' + min + ',' + max + ', 30, 150)',
-            'background-color': '#888',
-            'label': 'data(id)',
-            'font-size': 11,
+            'content': 'data(id)',
+            'font-size': '12px',
             'text-valign': 'center',
-            'color': 'white',
-            'border-width': 3,
-            'border-color': 'white',
-            'text-outline-width': 1.5,
-            'text-outline-color': '#444'
+            'text-halign': 'center',
+            'text-outline-width': '2px',
+            'color': '#fff',
+            'overlay-padding': '6px',
+            'z-index': '10'
+
           }
         },
 
@@ -199,25 +212,32 @@ html, body {
           selector: 'edge',
           style: {
             'curve-style': 'haystack',
-            'haystack-radius': 0,
+            'haystack-radius': '0.5',
+            'opacity': '0.4',
+            'line-color': '#000',
             'width': 2,
-            'opacity': 0.3,
-            'line-color': '#888'
+            'overlay-padding': '3px'
           }
         }
       ]
 
     });
 
-    cy.on('tap', 'node', function(){
-      try { // your browser may block popups
-        window.open( this.data('href') );
-      } catch(e){ // fall back on url change
-        window.location.href = this.data('href');
-      }
-    });
 
-    cy.on('tapstart', 'node', function(e){
+  if (mobile.matches) { // If media query matches
+    cy.on('taphold', 'node', function(e){
+      cy.nodes().style('opacity', 1);
+      cy.edges().style('opacity', 0.3);
+      var node = e.target;
+      node.connectedEdges()
+        .style('line-color', '#888');
+      node.connectedEdges()
+        .connectedNodes()
+        .style('border-color', 'white');
+    });
+    
+
+    cy.on('tapend', 'node', function(e){
       cy.elements().style('opacity', 0.2);
       var node = e.target;
       node.connectedEdges()
@@ -229,7 +249,40 @@ html, body {
         .style('border-color', 'magenta');
     });
 
-    cy.on('tapend', 'node', function(e){
+    cy.on('tap', 'node', function(){
+      try { // your browser may block popups
+        window.open( this.data('href') );
+      } catch(e){ // fall back on url change
+        window.location.href = this.data('href');
+      }
+    });
+  }
+
+  if (desktop.matches) { // If media query matches
+    cy.on('tap', 'node', function(){
+      try { // your browser may block popups
+        window.open( this.data('href') );
+      } catch(e){ // fall back on url change
+        window.location.href = this.data('href');
+      }
+    });
+    
+  }
+
+    
+    cy.on('mouseover', 'node', function(e){
+      cy.elements().style('opacity', 0.2);
+      var node = e.target;
+      node.connectedEdges()
+        .style('opacity', 1)
+        .style('line-color', 'magenta');
+      node.connectedEdges()
+        .connectedNodes()
+        .style('opacity', 1)
+        .style('border-color', 'magenta');
+    });
+
+    cy.on('mouseout', 'node', function(e){
       cy.nodes().style('opacity', 1);
       cy.edges().style('opacity', 0.3);
       var node = e.target;
@@ -241,9 +294,9 @@ html, body {
     });
 
     cy.on('zoom', function(e){
-      cy.nodes().style('font-size', 11/cy.zoom())
-                .style('text-outline-width', 1.5/cy.zoom())
-                .style('border-width', 3/cy.zoom())
+      //cy.nodes()//.style('font-size', 20/cy.zoom())
+                //.style('text-outline-width', 1.5/cy.zoom())
+                //.style('border-width', 3/cy.zoom())
                 // .style('width', 'mapData(weight / ' + cy.zoom() + ', ' + min + ',' + max + ', 30, 150)')
                 // .style('height', 'mapData(weight / ' + cy.zoom() + ', ' + min + ',' + max + ', 30, 150)')
     });
@@ -278,6 +331,7 @@ html, body {
       if (index > colors.length) index = colors.length - 1;
       color = colors[index];
       node.style('backgroundColor', color);
+      node.style('text-outline-color', color);
     });
 
   }


### PR DESCRIPTION
Fixes #9880
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

### Changes made till now-
- tag names on node text outline in same color as node.
- removed redundant edges because of bidirectional data at https://publiclab.org/tag/graph.json
#### Responsive
- Highlight tags/nodes on hovering instead of tapping on desktop.
- Highlight tag/nodes on taphold and go to tag page on tap.
- Display only top 100 tags on mobile devices to make it more readable and clear.

Before-(https://publiclab.org/stats/graph)
![image](https://user-images.githubusercontent.com/42088159/125268456-5a1bd280-e325-11eb-9498-74464bd9a9fe.png)

After-(https://unstable.publiclab.org/stats/graph)
![image](https://user-images.githubusercontent.com/42088159/125285409-3dd56100-e338-11eb-984f-96fecc462ace.png)

Mobile view before-
<p align="center">
    <img src="https://user-images.githubusercontent.com/42088159/125273728-dbc22f00-e32a-11eb-8356-7484b19ddf74.jpg" width = 300>
</p>


Mobile view after-
<p align="center">
    <img src="https://user-images.githubusercontent.com/42088159/125285904-cb18b580-e338-11eb-8270-967cf2d15736.jpg" width = 300>
</p>

On hover-
![image](https://user-images.githubusercontent.com/42088159/125286577-95c09780-e339-11eb-8b09-e9e0ea639af6.png)
