### PR TITLE
moved tocbot require statement to javascripts/application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -65,3 +65,4 @@
 //= require submitFormAjax.js
 //= require urlMapHash.js
 //= require spam2.js
+//= require tocbot

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,4 +20,3 @@ console.log('Hello World from Webpacker')
 var componentRequireContext = require.context("components", true);
 var ReactRailsUJS = require("react_ujs");
 ReactRailsUJS.useContext(componentRequireContext);
-const tocbot = require('tocbot');


### PR DESCRIPTION
The wiki menu is not displaying on the main site and this error is being returned.
`Uncaught ReferenceError: tocbot is not defined`

Changing the location of the require statement for the tocbot library should fix this error. I think it's also important to note that this feature works perfectly on local and stable envs.