### PR TITLE
Reduced response time in nearby People search API

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -204,9 +204,7 @@ class SearchService
     items = user_locations
 
     # selects the items whose node_tags don't have the location:blurred tag
-    
     items = items.where('user_tags.value <> "location:blurred"')
-
 
     # Here we use period["from"] and period["to"] in the query only if they have been specified,
     # so we avoid to join revision table

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -204,11 +204,9 @@ class SearchService
     items = user_locations
 
     # selects the items whose node_tags don't have the location:blurred tag
-    items.select do |item|
-      item.user_tags.none? do |user_tag|
-        user_tag.name == "location:blurred"
-      end
-    end
+    
+    items = items.where('user_tags.value <> "location:blurred"')
+
 
     # Here we use period["from"] and period["to"] in the query only if they have been specified,
     # so we avoid to join revision table


### PR DESCRIPTION
Fixes #7556 

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in a uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

### Before - 
GET: https://publiclab.org/api/srch/nearbyPeople?nwlat=10.0&selat=0.0&nwlng=0.0&selng=10.0
Time: 39.36
![image](https://user-images.githubusercontent.com/42088159/126702690-9bfbdcc4-04d8-4754-9600-c56485cf5a8a.png)
 
### After - 
GET: https://unstable.publiclab.org/api/srch/nearbyPeople?nwlat=10.0&selat=0.0&nwlng=0.0&selng=10.0
Time : 2.12s
![image](https://user-images.githubusercontent.com/42088159/126702537-84c9c910-499d-458c-bafe-b83687a7a3c5.png)
