### PR TITLE
Revert "change webpacker.yml to see public/lib"

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: ['public/lib']
+  additional_paths: []
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
Reverts publiclab/plots2#9959 as this seems to have made integration and system tests SUPER long - from 6m to 23 minutes long, and system tests from 19m to 34m long. It also didn't solve the problem with `tocbot` so it doesn't win us anything right now.