### PR TITLE
Fallback to english translation for empty strings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,9 +158,9 @@ module ApplicationHelper
     translated_string = t(key, options)
     options[:fallback] = false
     translated_string2 = t(key, options)
-    english_translation = t(key,locale: :en)
+    english_translation = t(key, locale: :en)
 
-    if html && current_user&.has_tag('translation-helper') && ( translated_string2.include?("translation missing") || translated_string === "" ) && !translated_string.include?("<")
+    if html && current_user&.has_tag('translation-helper') && ((translated_string2.include?("translation missing"))||(translated_string === "")) && !translated_string.include?("<")
       raw(%(<span>#{english_translation} <a class="translationIcon" style='display: none; padding-left: 3px;' href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
           <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate the text \" #{translated_string} \" .' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
        </span>))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,7 +160,7 @@ module ApplicationHelper
     translated_string2 = t(key, options)
     english_translation = t(key, locale: :en)
 
-    if html && current_user&.has_tag('translation-helper') && ((translated_string2.include?("translation missing"))||(translated_string === "")) && !translated_string.include?("<")
+    if html && current_user&.has_tag('translation-helper') && (translated_string2.include?("translation missing") || translated_string === "") && !translated_string.include?("<")
       raw(%(<span>#{english_translation} <a class="translationIcon" style='display: none; padding-left: 3px;' href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
           <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate the text \" #{translated_string} \" .' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
        </span>))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,9 +158,10 @@ module ApplicationHelper
     translated_string = t(key, options)
     options[:fallback] = false
     translated_string2 = t(key, options)
+    english_translation = t(key,locale: :en)
 
-    if html && current_user&.has_tag('translation-helper') && translated_string2.include?("translation missing") && !translated_string.include?("<")
-      raw(%(<span>#{translated_string} <a class="translationIcon" style='display: none; padding-left: 3px;' href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
+    if html && current_user&.has_tag('translation-helper') && ( translated_string2.include?("translation missing") || translated_string === "" ) && !translated_string.include?("<")
+      raw(%(<span>#{english_translation} <a class="translationIcon" style='display: none; padding-left: 3px;' href="https://www.transifex.com/publiclab/publiclaborg/translate/#de/$?q=text%3A#{translated_string}">
           <i data-toggle='tooltip' data-placement='top' title='Needs translation? Click to help translate the text \" #{translated_string} \" .' style='position:relative; right:2px; color:#bbb; font-size: 15px;' class='fa fa-globe'></i></a>
        </span>))
     else


### PR DESCRIPTION
Part of #9686  
![Screenshot 2021-07-30 at 18-03-59 🎈 Public Lab Dashboard](https://user-images.githubusercontent.com/38528640/127654592-c69c82c2-af70-4924-bd42-1884b591bc13.png)
I replaced the french translation of `"dashboard"` with `""`, the function replaced it with the English translation of dashboard.

