### PR TITLE
Fix to Issue #10035 Update to Translation Call

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -198,7 +198,7 @@
             $('#comment-form-edit-<%= comment.id %>').toggle()
           "
         >
-          Cancel
+          <%= translation('comments._form.cancel') %>
         </a>
       <% end %>
       <span class="form-grey" style="color: #888;"> &nbsp;


### PR DESCRIPTION
Update to [app/views/comments/_form.html.erb](https://github.com/publiclab/plots2/blob/main/app/views/comments/_form.html.erb) to change "cancel" to translation function call.

```
-201         Cancel
+201          <%= translation('comments._form.cancel') %>
```

![image](https://user-images.githubusercontent.com/62726812/129793333-6596328d-5be0-4430-aa33-a02d72852f31.png)

Fixes #10035 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
