### PR TITLE
fixing overflow issue on long powertag names

### DIFF
--- a/app/views/tag/_miniCard.html.erb
+++ b/app/views/tag/_miniCard.html.erb
@@ -1,12 +1,12 @@
 <div class="card" style="clear:left; <% if local_assigns[:grey] %>background:#eee;<% end %>">
   <div class="card-body">
 
+    <a class="ellipsis pull-right" data-toggle="dropdown" style="cursor:pointer"><i class="fa fa-ellipsis-h" style="color:#666;font-size:18px;margin-right:10px;"></i></a>
     <% if tag.name.include? ':' %>
-      <a href="https://publiclab.org/wiki/power-tags">
-        <span class="fa fa-question-circle" style="margin-left:140px;"></span>
+      <a href="https://publiclab.org/wiki/power-tags" class="pull-right" style="margin:0px 12px;">
+        <span class="fa fa-question-circle"></span>
       </a>
     <% end %>
-    <a class="ellipsis pull-right" data-toggle="dropdown" style="cursor:pointer"><i class="fa fa-ellipsis-h" style="color:#666;font-size:18px;margin-right:10px;"></i></a>
     <div class="dropdown-menu" style = "font-size:13px;">
       <div class="dropdown-item"><a href='/tag/<%= tag.name %>' style="color:black; text-decoration: underline;"><%= Tag.tagged_node_count(tag.name) || 0 %> notes</a></div>
       <div class="dropdown-item">created by <a href='/profile/<%= tag.try(:author).try(:username) %>' style="color:black; text-decoration: underline;"><%= tag.try(:author).try(:username) %></a> <%= time_ago_in_words(Time.at(tag.date)) %> ago</div>
@@ -27,11 +27,7 @@
     </div>
 
     <a href="/tag/<%= tag.name%>">
-      <% if !tag.name.include? ':' %>
-        <h5 style="text-decoration:underline;color:black;"><%= tag.name %></h5>
-      <% else %>
-        <h5 style="text-decoration:underline;color:black;margin-top:-25px;"><%= tag.name %></h5>
-      <% end %>
+      <h5 style="text-decoration:underline;color:black;"><%= tag.name %></h5>
     </a>
     <% if !tag.name.include? ':' %>
       <p style="font-size:15px;">


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
In the minicard in the sidebar, long powertag names cause an overflow issue. This fix responsively alleviates that issue. Screenshots below.

Fixes #10124  <!--(<=== Add issue number here)-->

Mobile before/after screenshot:
![mobile](https://user-images.githubusercontent.com/11414958/132372895-57bf9c36-7417-434c-b4e4-608a83a15a68.jpg)

Tablet before/after screenshot:
![tablet](https://user-images.githubusercontent.com/11414958/132372923-0bc6e63e-e053-4fc5-a187-b32a562cd20d.png)

Desktop before/after screenshot:
![desktop](https://user-images.githubusercontent.com/11414958/132372941-e1803583-7096-4ea3-8468-32ac16876c64.png)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
