### PR TITLE
Fixing 'Help wanted' link in 'first time only' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/--first-timers-only.md
+++ b/.github/ISSUE_TEMPLATE/--first-timers-only.md
@@ -14,7 +14,7 @@ If that's you, we're interested in helping you take the first step and can answe
 
 We know that the process of creating a pull request is the biggest barrier for new contributors. This issue is for you 💝
 
-If you have contributed before, **consider leaving this one for someone new**, and looking through our general [help wanted](https://github.com/publiclab/plots2/labels/help-wanted) issues. Thanks!
+If you have contributed before, **consider leaving this one for someone new** and looking through our general [help wanted](https://github.com/publiclab/plots2/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issues. Thanks!
 
 ### 🤔 What you will need to know.
 


### PR DESCRIPTION
The link 'help wanted' in the 'first-timers only issue template isn't linked correctly.

Fixes #10112 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
