### PR TITLE
Fix #10159  : Replaced the Revision String to Translation Function Call in _revisions.html.erb

### DIFF
--- a/app/views/wiki/revisions.html.erb
+++ b/app/views/wiki/revisions.html.erb
@@ -6,7 +6,7 @@
     <ul class="nav nav-tabs">
       <li class="nav-item"><a class="nav-link" href="/wiki/<%= @node.slug_from_path %>"><%= translation('wiki.revisions.view') %></a></li>
       <li class="nav-item"><a class="nav-link" href="/wiki/edit/<%= @node.slug_from_path %>"><%= translation('wiki.revisions.edit') %></a></li>
-      <li class="nav-item"><a class="nav-link active" href="/wiki/revisions/<%= @node.slug_from_path %>">Revisions (<%= @node.revisions.length %>)</a></li>
+      <li class="nav-item"><a class="nav-link active" href="/wiki/revisions/<%= @node.slug_from_path %>"><%= translation('wiki.revisions.revisions') %> (<%= @node.revisions.length %>)</a></li>
       <!--<li class="pull-right"><%= render :partial => "home/social" %></li>-->
     </ul>
 


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
I have make changes to `Revision` word such that I remove this word with the `translation('wiki.revisions.revisions')`.

Fixes #10159 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
