### PR TITLE
Change post-merge Github Actions trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
   workflow_run:
-    workflows: ["Upload coverage on PR merge"]
+    workflows: ["Upload coverage on PR merge and create Sentry release"]
     type:
       - complete
 


### PR DESCRIPTION
Not sure if the change of workflow name broke something, so testing here. 

`Upload coverage on PR merge and create Sentry release`

Could be related to https://github.com/publiclab/plots2/issues/10038