### PR TITLE
Change string to translation function call in profile template

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -179,7 +179,7 @@
               <p id="accessTokenForm" type="text" class="token form-control text-center"><%= @profile_user.token %></p>
             </div>
             <div class="modal-footer">
-             <button type="button" class="btn btn-outline-secondary" id="copy-btn"><%= translation('users.profile.copy') %></button>
+            <button type="button" class="btn btn-outline-secondary" id="copy-btn"><%= translation('users.profile.copy') %></button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
removed   <button type="button" class="btn btn-outline-secondary" id="copy-btn">Copy</button>
and added <button type="button" class="btn btn-outline-secondary" id="copy-btn"><%= translation('users.profile.copy') %></button>
from  app/views/users/profile.html.erb in the plots2 repository .

Fixes #10282  


