### PR TITLE
fix != from =! in photo_file_name comparison for blob images

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -21,8 +21,8 @@
   <% if main_image %>
     <% img_path = main_image.path(main_image.photo_file_name == "blob" ? :original : :large) # special case for "blob" images, see https://github.com/publiclab/plots2/issues/10210 %>
     <a class="main-image" style="max-width:100%;width:800px;" href="<%= main_image.path(:original) %>">
-      <%= image_tag(img_path, class:"rounded d-none d-lg-inline d-print-block", style:'max-height:600px;max-width:100%;', lazy: main_image.photo_file_name =! "blob") %>
-      <%= image_tag(img_path, class:"rounded d-lg-none d-print-none", style:'width:100%;', lazy: main_image.photo_file_name =! "blob") %>
+      <%= image_tag(img_path, class:"rounded d-none d-lg-inline d-print-block", style:'max-height:600px;max-width:100%;', lazy: main_image.photo_file_name != "blob") %>
+      <%= image_tag(img_path, class:"rounded d-lg-none d-print-none", style:'width:100%;', lazy: main_image.photo_file_name != "blob") %>
     </a>
     <!--<div class="expand"><a onClick="$('.main-image').toggleClass('compressed');"><i class="fa fa-angle-down"></i></a></div>-->
   <% end %>


### PR DESCRIPTION
<!-- Add a short description about your changes here-->

Fixes #0000 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
<div class="wrapper">
  <a href="#" class="button">Shiney!</a>
</div>
$color: #2194E0;

@keyframes sheen {
  0% {
    transform: skewY(-45deg) translateX(0);
  }
  100% {
    transform: skewY(-45deg) translateX(12.5em);
  }
}

.wrapper {
  display: block;
  position: absolute;
  top: 50%;
  left: 50%;
  transform: translate(-50%, -50%);
}
.button {
  padding: 0.75em 2em;
  text-align: center;
  text-decoration: none;
  color: $color;
  border: 2px solid $color;
  font-size: 24px;
  display: inline-block;
  border-radius: 0.3em;
  transition: all 0.2s ease-in-out;
  position: relative;
  overflow: hidden;
  &:before {
    content: "";
    background-color: rgba(255,255,255,0.5);
    height: 100%;
    width: 3em;
    display: block;
    position: absolute;
    top: 0;
    left: -4.5em;
    transform: skewX(-45deg) translateX(0);
    transition: none;
  }
  &:hover {
    background-color: $color;
    color: #fff;
    border-bottom: 4px solid darken($color, 10%);
    &:before {
      transform: skewX(-45deg) translateX(13.5em);
     transition: all 0.5s ease-in-out;
    }
  }
}