### PR TITLE
Changed: projects button content to an expression tag

### DIFF
--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -53,7 +53,7 @@
 
       <% end %>
 
-      <p><center><a class="btn btn-outline-secondary" href="/projects">More projects</a></center></p>
+      <p><center><a class="btn btn-outline-secondary" href="/projects"><%= translation('home.home.more_projects') %></a></center></p>
 
     <% end %>
   <% end %>


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
Instead of hard coding the projects content into the button, the code is changed to instead be dependent on the translation of 'home.home.more_projects'

Fixes #10370 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->

<!-- ![image_2021-10-23_015502](https://user-images.githubusercontent.com/55165929/138546131-b163b76c-d4ad-42fe-8281-cf17119cf405.png) -->

![image_2021-10-23_015649](https://user-images.githubusercontent.com/55165929/138546185-ef1bdb61-7629-46ad-bcbb-4ce88bd5d253.png)