### PR TITLE
Improved the Styling of Woofmark Buttons on pl.org/post

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -360,6 +360,67 @@ a .fa-white,
 
 /* Styles for specific areas of the site */
 /* Remove blue background on Chrome autocomplete */
+@media(max-width: 768px) {
+  .ple-module-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .ple-module-content .wk-wysiwyg {
+      width: 100%;
+  }
+    
+  .ple-content .wk-commands {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    max-width: 390px;
+  }
+
+  .ple-content .wk-commands .btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    min-width: 50px;
+    height: 38px;
+    background: white;
+    margin: 0px;
+    border-radius: 0 !important;
+    border: 1px solid #ddd;
+    border-left: none;
+  }
+  
+  .ple-content .wk-commands button.btn:nth-of-type(1),
+  .ple-content .wk-commands .btn:nth-of-type(8) {
+      border-left: 1px solid #ddd;
+  }
+  
+  .ple-content .wk-commands .btn:nth-of-type(8),
+  .ple-content .wk-commands .btn:nth-of-type(9),
+  .ple-content .wk-commands .btn:nth-of-type(10),
+  .ple-content .wk-commands a.btn{
+      border-top: 0;
+  }
+
+  .ple-content .wk-switchboard {
+    text-align: center;
+    float: none;
+  }
+}
+
+@media(max-width: 480px) {
+    .ple-content .wk-commands {
+        max-width: 325px;
+    }
+    .ple-content .wk-commands .btn {
+        min-width: 30px;
+        max-width: 43px;
+        width: 100%;
+    }
+}
+
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
I have improved the styling of Woofmark Buttons on pl.org/post as per issue #7067

Fixes #7067 

Before->
<img width="348" alt="publiclab1" src="https://user-images.githubusercontent.com/89515816/142824039-3e97da5b-0ee7-4438-b935-46bf5cef2586.png">
After->
<img width="430" alt="publiclab2" src="https://user-images.githubusercontent.com/89515816/142824045-91f8238e-3789-4678-854c-844e9eca4374.png">

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
