### PR TITLE
try to list system-test-screenshots artifact in a PR comment

### DIFF
--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -1,10 +1,8 @@
 name: Leave comment with artifacts link 
 on:
   workflow_run:
-    workflows:
-      - tests
-    types:
-      - complete
+    workflows: ["tests"]
+    types: [completed]
 
 jobs:
   screenshots_link:

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -16,6 +16,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           script: |
+            console.log(github.event.workflow_run);
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -5,10 +5,12 @@ on:
     types: [completed]
 
 jobs:
+
   screenshots_link:
     name: Comment screenshots link
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/github-script@v5
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -1,0 +1,38 @@
+name: Leave comment with artifacts link 
+on:
+  workflow_run:
+    workflows:
+      - tests
+    types:
+      - completed
+
+jobs:
+
+  screenshots_link:
+    name: Comment screenshots link
+    needs: [system-tests, comment-system-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            })
+            const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            })
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" 
+                + workflow_run.data.check_suite_id
+                + "/artifacts/"
+                + artifacts.data.artifacts[0].id
+            })

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -9,6 +9,7 @@ jobs:
   screenshots_link:
     name: Comment screenshots link
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/github-script@v5

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: context.runId
+              run_id: github.event.workflow_run.runId
             })
             const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
               owner: context.repo.owner,

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -7,10 +7,8 @@ on:
       - completed
 
 jobs:
-
   screenshots_link:
     name: Comment screenshots link
-    needs: [system-tests, comment-system-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v5

--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -4,7 +4,7 @@ on:
     workflows:
       - tests
     types:
-      - completed
+      - complete
 
 jobs:
   screenshots_link:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,8 +206,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: artifacts.data.artifacts[0].id
-#              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + await artifacts.data.artifacts[0].id
+              body: artifacts.data.artifacts[0].id // "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + await artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,7 +198,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           script: |
-            artifacts = await octokit.rest.actions.listArtifactsForRepo({
+            const artifacts = await octokit.rest.actions.listArtifactsForRepo({
               context.repo.owner,
               context.repo.repo,
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,12 +202,11 @@ jobs:
               context.repo.owner,
               context.repo.repo,
             }).then((response) => {
-              let artifact_id = response.data.artifacts[0].id
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${ artifact_id }"
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ fromJSON(response.data.artifacts[0].id) }}"
               })
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,7 +206,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: artifacts.data.artifacts[0].id // "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + await artifacts.data.artifacts[0].id
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,7 +198,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           script: |
-            const artifacts = await octokit.rest.actions.listArtifactsForRepo({
+            const artifacts = await github.rest.actions.listArtifactsForRepo({
               context.repo.owner,
               context.repo.repo,
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,17 +191,19 @@ jobs:
 
   screenshots_link:
     name: Comment screenshots link
-    needs: system-tests
+    #needs: system-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-      - name: Comment with a link to download screenshots
-        uses: thollander/actions-comment-pull-request@v1
+      - uses: actions/github-script@v5
         if: github.event_name == 'pull_request'
         with:
-          message: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: ${{ github.run_id }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: ${{ context.run_id }}"
+            })
 
   remove-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -207,7 +207,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ artifact_id }}"
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${ artifact_id }"
               })
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,7 +191,7 @@ jobs:
 
   screenshots_link:
     name: Comment screenshots link
-    needs: system-tests
+    needs: [system-tests, comment-system-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,13 +200,14 @@ jobs:
           script: |
             const artifacts = await github.rest.actions.listArtifactsForRepo({
               context.repo.owner,
-              context.repo.repo,
+              context.repo.repo
             })
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + artifacts.data.artifacts[0].id
+              body: artifacts.data.artifacts[0].id
+#              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + await artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,16 +198,15 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           script: |
-            artifacts = octokit.rest.actions.listArtifactsForRepo({
+            artifacts = await octokit.rest.actions.listArtifactsForRepo({
               context.repo.owner,
               context.repo.repo,
-            }).then((response) => {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ fromJSON(response.data.artifacts[0].id) }}"
-              })
+            }
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ artifacts.data.artifacts[0].id }}"
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,7 +212,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" + workflow_run.data.check_suite_id + "/artifacts/" + artifacts.data.artifacts[0].id
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" + workflow_run.data.check_suite_id + "/artifacts/" + artifacts.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,7 +206,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ response.data.artifacts[0].id }}"
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + response.data.artifacts[0].id
               })
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,11 +198,18 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: ${{ github.run_id }}"
+            artifacts = octokit.rest.actions.listArtifactsForRepo({
+              context.repo.owner,
+              context.repo.repo,
+            }).then((response) => {
+              suite_check_id = github.check_suite_id
+              artifact_id = response.data.artifacts[0].id
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ check_suite_id }}/artifacts/${{ artifact_id }}"
+              })
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,36 +189,6 @@ jobs:
         name: system-test-screenshots
         path: tmp/screenshots/*
 
-  screenshots_link:
-    name: Comment screenshots link
-    needs: [system-tests, comment-system-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v5
-        if: github.event_name == 'pull_request'
-        with:
-          script: |
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            })
-            const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            })
-            console.log(artifacts)
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" 
-                + workflow_run.data.check_suite_id
-                + "/artifacts/"
-                + artifacts.data.artifacts[0].id
-            })
-
   remove-labels:
     runs-on: ubuntu-latest
     needs: [add-label, unit-tests, functional-tests, integration-tests, system-tests]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,7 @@ jobs:
             const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: github.run_id
+              run_id: github.runId
             })
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -207,6 +207,7 @@ jobs:
               repo: context.repo.repo,
               run_id: context.runId
             })
+            console.log(workflow_run)
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: ${{ context.run_id }}"
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: ${{ github.run_id }}"
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,7 +212,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" + workflow_run.check_suite_id + "/artifacts/" + artifacts.data.artifacts[0].id
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" + workflow_run.data.check_suite_id + "/artifacts/" + artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,12 +202,11 @@ jobs:
               context.repo.owner,
               context.repo.repo,
             }).then((response) => {
-              artifact_id = response.data.artifacts[0].id
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ artifact_id }}"
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ response.data.artifacts[0].id }}"
               })
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,7 +204,7 @@ jobs:
             })
             const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
               run_id: github.run_id
             })
             github.rest.issues.createComment({

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,11 +202,12 @@ jobs:
               context.repo.owner,
               context.repo.repo,
             }).then((response) => {
+              let artifact_id = response.data.artifacts[0].id
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + response.data.artifacts[0].id
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ artifact_id }}"
               })
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,13 +202,12 @@ jobs:
               context.repo.owner,
               context.repo.repo,
             }).then((response) => {
-              check_suite_id = github.check_suite_id
               artifact_id = response.data.artifacts[0].id
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ check_suite_id }}/artifacts/${{ artifact_id }}"
+                body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ artifact_id }}"
               })
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,11 +202,16 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             })
+            const workflow_run = await octokit.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+              run_id: github.run_id
+            })
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + artifacts.data.artifacts[0].id
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" + workflow_run.check_suite_id + "/artifacts/" + artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,20 @@ jobs:
         name: system-test-screenshots
         path: tmp/screenshots/*
 
+  screenshots_link:
+    name: Comment screenshots link
+    needs: system-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+      - name: Comment with a link to download screenshots
+        uses: thollander/actions-comment-pull-request@v1
+        if: github.event_name == 'pull_request'
+        with:
+          message: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: ${{ github.run_id }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   remove-labels:
     runs-on: ubuntu-latest
     needs: [add-label, unit-tests, functional-tests, integration-tests, system-tests]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,23 +191,23 @@ jobs:
 
   screenshots_link:
     name: Comment screenshots link
-    #needs: system-tests
+    needs: system-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v5
         if: github.event_name == 'pull_request'
         with:
           script: |
-            const artifacts = await github.rest.actions.listArtifactsForRepo({
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
+              run_id: context.runId
             })
             const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.runId
             })
-            console.log(workflow_run)
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,10 +194,6 @@ jobs:
     #needs: system-tests
     runs-on: ubuntu-latest
     steps:
-      - name: View context attributes
-        uses: actions/github-script@v5
-        with:
-          script: console.log(context)
       - uses: actions/github-script@v5
         if: github.event_name == 'pull_request'
         with:
@@ -209,7 +205,7 @@ jobs:
             const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: github.runId
+              run_id: context.runId
             })
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,11 +208,15 @@ jobs:
               repo: context.repo.repo,
               run_id: context.runId
             })
+            console.log(artifacts)
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" + workflow_run.data.check_suite_id + "/artifacts/" + artifacts.artifacts[0].id
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/" 
+                + workflow_run.data.check_suite_id
+                + "/artifacts/"
+                + artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,6 +194,10 @@ jobs:
     #needs: system-tests
     runs-on: ubuntu-latest
     steps:
+      - name: View context attributes
+        uses: actions/github-script@v5
+        with:
+          script: console.log(context)
       - uses: actions/github-script@v5
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,7 +206,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/${{ artifacts.data.artifacts[0].id }}"
+              body: "This pull request generated screenshots of many common pages in the running app. You should be able to download and view them here: https://github.com/publiclab/plots2/suites/${{ github.check_suite_id }}/artifacts/" + artifacts.data.artifacts[0].id
             })
 
   remove-labels:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,8 +199,8 @@ jobs:
         with:
           script: |
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              context.repo.owner,
-              context.repo.repo
+              owner: context.repo.owner,
+              repo: context.repo.repo
             })
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
               context.repo.owner,
               context.repo.repo,
             }).then((response) => {
-              suite_check_id = github.check_suite_id
+              check_suite_id = github.check_suite_id
               artifact_id = response.data.artifacts[0].id
               github.rest.issues.createComment({
                 issue_number: context.issue.number,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             })
-            const workflow_run = await octokit.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
+            const workflow_run = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
               owner: context.repo.owner,
               repo: context.repo.repo
               run_id: github.run_id

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
             const artifacts = await github.rest.actions.listArtifactsForRepo({
               context.repo.owner,
               context.repo.repo,
-            }
+            })
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
Trying to make a GitHub Actions job to post the link to the artifacts for a CI run as a comment, since it's so deeply buried. We could also customize this for other things. Just a test. 

https://api.github.com/repos/publiclab/plots2/actions/runs/1579130745/artifacts

shows:

```json
{
  "total_count": 1,
  "artifacts": [
    {
      "id": 126444304,
      "node_id": "MDg6QXJ0aWZhY3QxMjY0NDQzMDQ=",
      "name": "system-test-screenshots",
      "size_in_bytes": 4168540,
      "url": "https://api.github.com/repos/publiclab/plots2/actions/artifacts/126444304",
      "archive_download_url": "https://api.github.com/repos/publiclab/plots2/actions/artifacts/126444304/zip",
      "expired": false,
      "created_at": "2021-12-14T17:52:23Z",
      "updated_at": "2021-12-14T17:52:24Z",
      "expires_at": "2022-03-14T17:52:02Z"
    }
  ]
}
```

Possibly helpful docs:

- https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
- https://docs.github.com/en/rest/reference/actions#list-artifacts-for-a-repository
- manually comment with a GitHub Actions script: https://github.com/actions/github-script#welcome-a-first-time-contributor
- using tmate to create an interactive GH Actions console: https://mxschmitt.github.io/action-tmate/