### PR TITLE
Inactive fa fa-eye icon on login page

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -112,7 +112,7 @@
           </li>
         <% else %>
         <li class="d-md-none d-xl-inline nav-item"> <!-- signup button -->
-          <a rel="tooltip" class="nav-link signupToggle" title="<%= t('layout._header.become_part_community') %>" href="#">
+          <a rel="tooltip" class="nav-link <% unless current_page?('/signup') %> signupToggle <% end %>" title="<%= t('layout._header.become_part_community') %>" href="#">
             <%= t('layout._header.join') %>
           </a>
         </li>
@@ -192,7 +192,7 @@
               </li>
             <% else %> <!-- Login button -->
                 <li class="nav-item">
-                    <a class="nav-link loginToggle" href="#">
+                    <a class="nav-link <% unless current_page?('/login') %> loginToggle <% end %>" href="#">
                     <%= t('layout._header.login.login_title') %>
                     </a>
                 </li>

--- a/app/views/layouts/_signupLoginModal.html.erb
+++ b/app/views/layouts/_signupLoginModal.html.erb
@@ -12,12 +12,16 @@
         <div class="clearfix"> <!-- clearfix class allows the modal to expand to fit the content of this div -->
           <div id="signupContainer">
             <!-- signup partial -->
+            <% unless current_page?('/signup') %>
             <%= render partial: "users/create_form" , locals: {caller: "modal"} %>
+            <% end %>
           </div>
 
           <div id="loginContainer">
             <!-- login partial -->
+            <% unless current_page?('/login') %>
             <%= render partial: "user_sessions/form" %>
+            <% end %>
           </div>
         </div>
 


### PR DESCRIPTION
<!-- Add a short description about your changes here-->

Fixes #6511 <!--(<=== Add issue number here)-->

As discussed in the issue, I have added checks such that form is not rendered due to the login popup on the login page, also made the login link in the navbar inactive if user is on the login page. I have added similar checks for the signup page (form was also rendering twice here)

https://user-images.githubusercontent.com/85152262/147352146-06ae59bc-6bff-4365-a03a-a757ddccb588.mp4

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
