### PR TITLE
Reverse order of users in tag contributors/followers lists

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -74,6 +74,7 @@ class Tag < ApplicationRecord
     uids = uids.uniq
     User.where(id: uids)
         .where(status: [1, 4])
+        .order(created: :desc)
   end
 
   def self.contributor_count(tagname)
@@ -166,6 +167,7 @@ class Tag < ApplicationRecord
                        .collect(&:user_id)
     User.where(id: uids)
         .where(status: [1, 4])
+        .order(created: :desc)
   end
 
   def self.sort_according_to_followers(raw_tags, order)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -74,7 +74,7 @@ class Tag < ApplicationRecord
     uids = uids.uniq
     User.where(id: uids)
         .where(status: [1, 4])
-        .order(created: :desc)
+        .order(created_at: :desc)
   end
 
   def self.contributor_count(tagname)
@@ -167,7 +167,7 @@ class Tag < ApplicationRecord
                        .collect(&:user_id)
     User.where(id: uids)
         .where(status: [1, 4])
-        .order(created: :desc)
+        .order(created_at: :desc)
   end
 
   def self.sort_according_to_followers(raw_tags, order)


### PR DESCRIPTION
Simpler fix for https://github.com/publiclab/plots2/issues/10016

Let's test on unstable: https://unstable.publiclab.org/contributors/balloon-mapping

vs https://stable.publiclab.org/contributors/balloon-mapping