### PR TITLE
style: Make post page footer responsive

### DIFF
--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -76,13 +76,13 @@
     margin: auto 5px;
   }
 
-  @media (min-width: 769px) {
+  @media (min-width: 651px) {
     .short-text {
       display: none;
     }
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 650px) {
     .short-text {
       display: inline-block;
     }

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -75,6 +75,24 @@
   .post-footer-text {
     margin: auto 5px;
   }
+
+  @media (max-width: 768px) {
+    .btn-responsive {
+      padding:2px 4px;
+      font-size:80%;
+      line-height: 1;
+      border-radius:3px;
+    }
+
+    .text-responsive{
+      font-size: 2vw;
+    }
+
+    .checkbox-responsive{
+      width: 2vw;
+      height: 2vw;
+    }
+  }
 </style>
 
 <div class="pl-editor">
@@ -336,15 +354,15 @@
     </div>
 
     <div class="post-footer">
-      <button class="btn btn-lg btn-outline-secondary btn-more"><i class="fa fa-clock-o"></i></button>
-      <span class="post-footer-text"> By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a> so that others may use it.</span>
-      <div class="post-footer-buttons">
-        <button class="publish-space ple-publish btn btn-lg btn-primary float-right disabled"><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
-        <button class="btn btn-outline-secondary btn-lg float-right" onclick="preview()">Preview</button>
+      <button class="btn btn-lg btn-outline-secondary btn-responsive btn-more"><i class="fa fa-clock-o"></i></button>
+      <span class="post-footer-text text-responsive"> By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a> so that others may use it.</span>
+      <div class="post-footer-buttons"> 
+        <button class="btn btn-lg btn-primary disabled btn-responsive float-right publish-space ple-publish "><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
+        <button class="btn btn-lg btn-outline-secondary btn-responsive float-right" onclick="preview()">Preview</button>
       </div>
     </div>
-
-    <span class="ple-help float-right">
+    
+    <span class="ple-help text-responsive float-right">
       <% if controller.action_name != "edit" && !current_user.first_time_poster %>
         <span id="newOpts" style="display: inline-block;">
         <span id="text" style="display: none; color:red;">
@@ -352,7 +370,7 @@
           (<a href="https://publiclab.org/draft-feature" target="_blank">?</a>) &nbsp; &nbsp;</span>
           <span class="checkbox">
             <label>
-              <input type="checkbox" id="myCheck" onclick="draftCheck()" />
+              <input type="checkbox" class="checkbox-responsive" id="myCheck" onclick="draftCheck()" />
               Save as draft
             </label> |
           </span>
@@ -360,8 +378,7 @@
           <span class="d-none d-md-inline"> steps left</span>
         </span>
       <% end %>
-    </span>
-
+    </span> 
   </div>
 </div>
 <script>

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -58,7 +58,7 @@
   }
 
   .publish-space {
-    margin-right: 10px;
+    margin-right: 1vw;
   }
 
   .post-footer {
@@ -76,21 +76,19 @@
     margin: auto 5px;
   }
 
+  @media (min-width: 769px) {
+    .short-text {
+      display: none;
+    }
+  }
+
   @media (max-width: 768px) {
-    .btn-responsive {
-      padding:2px 4px;
-      font-size:80%;
-      line-height: 1;
-      border-radius:3px;
+    .short-text {
+      display: inline-block;
     }
 
-    .text-responsive{
-      font-size: 2vw;
-    }
-
-    .checkbox-responsive{
-      width: 2vw;
-      height: 2vw;
+    .long-text {
+      display: none;
     }
   }
 </style>
@@ -354,15 +352,20 @@
     </div>
 
     <div class="post-footer">
-      <button class="btn btn-lg btn-outline-secondary btn-responsive btn-more"><i class="fa fa-clock-o"></i></button>
-      <span class="post-footer-text text-responsive"> By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a> so that others may use it.</span>
-      <div class="post-footer-buttons"> 
-        <button class="btn btn-lg btn-primary disabled btn-responsive float-right publish-space ple-publish "><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
-        <button class="btn btn-lg btn-outline-secondary btn-responsive float-right" onclick="preview()">Preview</button>
+      <button class="btn btn-outline-secondary btn-more"><i class="fa fa-clock-o"></i></button>
+      <span class="post-footer-text text-responsive long-text">By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a> so that others may use it.</span>
+      <span class="post-footer-text short-text">
+        <a href="#" data-toggle="popover" data-placement="top" title="" data-content="By publishing, you agree to <a href='https://publiclab.org/licenses'>open source your work">
+           About Posting
+        </a>
+      </span>
+      <div class="post-footer-buttons">
+        <button class="btn btn-primary disabled float-right publish-space ple-publish "><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
+        <button class="btn btn-outline-secondary float-right" onclick="preview()">Preview</button>
       </div>
     </div>
     
-    <span class="ple-help text-responsive float-right">
+    <span class="ple-help float-right">
       <% if controller.action_name != "edit" && !current_user.first_time_poster %>
         <span id="newOpts" style="display: inline-block;">
         <span id="text" style="display: none; color:red;">
@@ -370,7 +373,7 @@
           (<a href="https://publiclab.org/draft-feature" target="_blank">?</a>) &nbsp; &nbsp;</span>
           <span class="checkbox">
             <label>
-              <input type="checkbox" class="checkbox-responsive" id="myCheck" onclick="draftCheck()" />
+              <input type="checkbox" id="myCheck" onclick="draftCheck()" />
               Save as draft
             </label> |
           </span>
@@ -506,6 +509,23 @@
       $('#coord_input').toggle();
     });
     $("#coord_input").hide();
+
+    // tooltip
+    $('[data-toggle="popover"]').popover({ trigger: "manual" , html: true, animation:false})
+        .on("mouseenter", function () {
+            var _this = this;
+            $(this).popover("show");
+            $(".popover").on("mouseleave", function () {
+                $(_this).popover('hide');
+            });
+        }).on("mouseleave", function () {
+            var _this = this;
+            setTimeout(function () {
+                if (!$(".popover:hover").length) {
+                    $(_this).popover("hide");
+                }
+            }, 300);
+    });
 
     $(function() {
       var target = document.querySelector('#map_content');

--- a/app/views/editor/rich.html.erb
+++ b/app/views/editor/rich.html.erb
@@ -60,6 +60,21 @@
   .publish-space {
     margin-right: 10px;
   }
+
+  .post-footer {
+    display: flex; 
+    justify-content: flex-end; 
+    justify-self: flex-start;
+  }
+
+  .post-footer-buttons {
+    margin-left: auto; 
+    display: flex;
+  }
+
+  .post-footer-text {
+    margin: auto 5px;
+  }
 </style>
 
 <div class="pl-editor">
@@ -320,11 +335,15 @@
       -->
     </div>
 
-    <button class="btn btn-lg btn-outline-secondary btn-more"><i class="fa fa-clock-o"></i></button>
+    <div class="post-footer">
+      <button class="btn btn-lg btn-outline-secondary btn-more"><i class="fa fa-clock-o"></i></button>
+      <span class="post-footer-text"> By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a> so that others may use it.</span>
+      <div class="post-footer-buttons">
+        <button class="publish-space ple-publish btn btn-lg btn-primary float-right disabled"><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
+        <button class="btn btn-outline-secondary btn-lg float-right" onclick="preview()">Preview</button>
+      </div>
+    </div>
 
-    <span> &nbsp; By publishing, you agree to <a href="https://publiclab.org/licenses">open source your work</a><span class="d-none d-md-inline"> so that others may use it.</span></span>
-    <button class="btn btn-outline-secondary btn-lg float-right" onclick="preview()">Preview</button>
-    <button class="publish-space ple-publish btn btn-lg btn-primary float-right disabled"><% if controller.action_name == "edit" && @node.status == 3 %>Save<% else %>Publish<% end %></button>
     <span class="ple-help float-right">
       <% if controller.action_name != "edit" && !current_user.first_time_poster %>
         <span id="newOpts" style="display: inline-block;">


### PR DESCRIPTION
The footer at the bottom of the /post page was not
responsive. As a result, the buttons were getting
misaligned with different screen sizes.
This PR makes the footer responsive.

https://user-images.githubusercontent.com/76661350/148774733-971e839c-6a17-45b8-86fe-9104178a9182.mp4



<!-- Add a short description about your changes here-->

Fixes #10308 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
