### PR TITLE
Fix profile photo preview in header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -126,7 +126,7 @@
                   <% if current_user.profile_image == "https://www.gravatar.com/avatar/eb721d116a28f4a4da4ea67340c8ce75" %>
                     <i class="fa fa-user-circle fa-lg" style="color:white;"></i>
                   <% else %>
-                    <%= image_tag(current_user.profile_image, class:'rounded-circle', style:'width:20px; height:20px; margin-right:8px;', alt:'profile-photo', id:'profile-photo') %>
+                    <img src="<%= current_user.profile_image %>" class="rounded-circle" style="width:20px; height:20px; margin-right:8px;" alt="profile-photo" id="profile-photo" />
                   <% end %>
                 </div>
               </a>


### PR DESCRIPTION
Fixes #9450

Before - 
![photo-before](https://user-images.githubusercontent.com/85152262/149176526-7289890a-8b11-4fa4-a95a-6d523c5db5c8.png)

After -
![photo-after](https://user-images.githubusercontent.com/85152262/149176585-930bb53e-b579-4fd4-b35c-7c8876633e30.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below