### PR TITLE
Fix popover styling of subscription page

### DIFF
--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -73,21 +73,21 @@
           <script> input_<%= subscription.tid %> = '#share-<%= subscription.tid %>'</script>
           <a class="btn btn-outline-secondary btn-sm text-body" rel="popover"  data-toggle="popover" data-placement="left" title="<%= translation('home.subscriptions.share_subscription_link',{},false) %>" data-html="true" data-content="<div style='margin-top:10px;'><a style='padding-left:3px;' href='https://twitter.com/intent/tweet?text=🎈 Public Lab: Subscriptions&url=https://publiclab.org/subscriptions/tag/<%= subscription.tagname %>' class='twitter-share-button'>Tweet</a></div>
           <script>
-          window.twttr = (function(d, s, id){ 
-          var js, fjs = d.getElementsByTagName(s)[0],
-          t = window.twttr || {};
-          js = d.createElement(s);
-          js.id = id;
-          js.src = 'https://platform.twitter.com/widgets.js';
-          fjs.parentNode.insertBefore(js, fjs);
+            window.twttr = (function(d, s, id){ 
+              var js, fjs = d.getElementsByTagName(s)[0],
+              t = window.twttr || {};
+              js = d.createElement(s);
+              js.id = id;
+              js.src = 'https://platform.twitter.com/widgets.js';
+              fjs.parentNode.insertBefore(js, fjs);
 
-          t._e = [];
-          t.ready = function(f) {
-            t._e.push(f);
-          };
+              t._e = [];
+              t.ready = function(f) {
+                t._e.push(f);
+              };
 
-          return t;
-          }(document, 'script', 'twitter-wjs'));
+              return t;
+            }(document, 'script', 'twitter-wjs'));
           </script> 
           ">
           <i class="fa fa-share"></i> <%= translation('home.subscriptions.share') %></a>

--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -71,7 +71,26 @@
           <a rel="tooltip" title="Once per day" class="btn btn-default btn-xs" href="javascript:void(0)"><i class="fa fa-list"></i> Digest</a>
           -->
           <script> input_<%= subscription.tid %> = '#share-<%= subscription.tid %>'</script>
-          <a class="btn btn-outline-secondary btn-sm text-body" rel="popover"  data-toggle="popover" data-placement="left" title="<%= translation('home.subscriptions.share_subscription_link',{},false) %>" data-html="true" data-content="<div style='margin-top:10px;'><a style='padding-left:3px;' href='https://twitter.com/intent/tweet?text=🎈 Public Lab: Subscriptions&url=https://publiclab.org/subscriptions/tag/<%= subscription.tagname %>' class='twitter-share-button'>Tweet</a></div> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}(document,'script','twitter-wjs');</script>">
+          <a class="btn btn-outline-secondary btn-sm text-body" rel="popover"  data-toggle="popover" data-placement="left" title="<%= translation('home.subscriptions.share_subscription_link',{},false) %>" data-html="true" data-content="<div style='margin-top:10px;'><a style='padding-left:3px;' href='https://twitter.com/intent/tweet?text=🎈 Public Lab: Subscriptions&url=https://publiclab.org/subscriptions/tag/<%= subscription.tagname %>' class='twitter-share-button'>Tweet</a></div>
+          <script>
+          window.twttr = (function(d, s, id) 
+          { var js, fjs = d.getElementsByTagName(s)[0],
+            t = window.twttr || {};
+            console.log(t);
+            js = d.createElement(s);
+            js.id = id;
+            js.src = 'https://platform.twitter.com/widgets.js';
+            fjs.parentNode.insertBefore(js, fjs);
+
+            t._e = [];
+            t.ready = function(f) {
+              t._e.push(f);
+            };
+
+            return t;
+          }(document, 'script', 'twitter-wjs'));
+          </script> 
+          ">
           <i class="fa fa-share"></i> <%= translation('home.subscriptions.share') %></a>
           <a class="btn btn-outline-secondary btn-sm" href="/unsubscribe/tag/<%= subscription.tagname %>" data-method="delete"><i class="fa fa-remove"></i> <%= translation('home.subscriptions.unsubscribe') %></a>
         </div>

--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -73,21 +73,20 @@
           <script> input_<%= subscription.tid %> = '#share-<%= subscription.tid %>'</script>
           <a class="btn btn-outline-secondary btn-sm text-body" rel="popover"  data-toggle="popover" data-placement="left" title="<%= translation('home.subscriptions.share_subscription_link',{},false) %>" data-html="true" data-content="<div style='margin-top:10px;'><a style='padding-left:3px;' href='https://twitter.com/intent/tweet?text=🎈 Public Lab: Subscriptions&url=https://publiclab.org/subscriptions/tag/<%= subscription.tagname %>' class='twitter-share-button'>Tweet</a></div>
           <script>
-          window.twttr = (function(d, s, id) 
-          { var js, fjs = d.getElementsByTagName(s)[0],
-            t = window.twttr || {};
-            console.log(t);
-            js = d.createElement(s);
-            js.id = id;
-            js.src = 'https://platform.twitter.com/widgets.js';
-            fjs.parentNode.insertBefore(js, fjs);
+          window.twttr = (function(d, s, id){ 
+          var js, fjs = d.getElementsByTagName(s)[0],
+          t = window.twttr || {};
+          js = d.createElement(s);
+          js.id = id;
+          js.src = 'https://platform.twitter.com/widgets.js';
+          fjs.parentNode.insertBefore(js, fjs);
 
-            t._e = [];
-            t.ready = function(f) {
-              t._e.push(f);
-            };
+          t._e = [];
+          t.ready = function(f) {
+            t._e.push(f);
+          };
 
-            return t;
+          return t;
           }(document, 'script', 'twitter-wjs'));
           </script> 
           ">

--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -71,7 +71,7 @@
           <a rel="tooltip" title="Once per day" class="btn btn-default btn-xs" href="javascript:void(0)"><i class="fa fa-list"></i> Digest</a>
           -->
           <script> input_<%= subscription.tid %> = '#share-<%= subscription.tid %>'</script>
-          <a class="btn btn-outline-secondary btn-sm text-body" rel="popover"  data-toggle="popover" data-placement="left" title="<%= translation('home.subscriptions.share_subscription_link',{},false) %>" data-html="true" data-content="<div style='margin-top:10px;'><a style='padding-left:3px;' href='https://twitter.com/intent/tweet?text=🎈 Public Lab: Subscriptions&url=https://publiclab.org/subscriptions/tag/<%= subscription.tagname %>' class='twitter-share-button'>Tweet</a></div> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document,'script','twitter-wjs');</script>
+          <a class="btn btn-outline-secondary btn-sm text-body" rel="popover"  data-toggle="popover" data-placement="left" title="<%= translation('home.subscriptions.share_subscription_link',{},false) %>" data-html="true" data-content="<div style='margin-top:10px;'><a style='padding-left:3px;' href='https://twitter.com/intent/tweet?text=🎈 Public Lab: Subscriptions&url=https://publiclab.org/subscriptions/tag/<%= subscription.tagname %>' class='twitter-share-button'>Tweet</a></div> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}(document,'script','twitter-wjs');</script>">
           <i class="fa fa-share"></i> <%= translation('home.subscriptions.share') %></a>
           <a class="btn btn-outline-secondary btn-sm" href="/unsubscribe/tag/<%= subscription.tagname %>" data-method="delete"><i class="fa fa-remove"></i> <%= translation('home.subscriptions.unsubscribe') %></a>
         </div>
@@ -82,3 +82,9 @@
   <% end %>
 
 </div>
+
+<style>
+  .popover{ 
+    z-index: 1000;
+  }
+</style>


### PR DESCRIPTION
Fixes #7509 with following changes -

- tweet button design consistent for all popovers
- popover doesn't overlap header
- share icon visible

https://user-images.githubusercontent.com/85152262/150579083-4fc82ecd-2b3a-477a-8910-fdbb2717fe67.mp4

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

