### PR TITLE
Correcting alignment of social icons

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -97,7 +97,7 @@
 
   <div id="social-links">
 
-    <div class="profile_icons" style="text-align: center;">
+    <div class="profile_icons d-flex justify-content-center" style="gap: 8px">
       <% if @twitter.nil? == false %>
         <a href="<%= @twitter %>" >
           <i class="fa fa-twitter fa-3x" aria-hidden="true"></i>


### PR DESCRIPTION
Fixed the alignment of social icons by adding d-flex and justify-content-center CSS classes.

Fixes #10726  

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [X] ask `@publiclab/reviewers` for help, in a comment below
