### PR TITLE
Move _wiki to old table look, common template for email and settings digest only

### DIFF
--- a/app/views/subscription_mailer/send_digest.html.erb
+++ b/app/views/subscription_mailer/send_digest.html.erb
@@ -7,8 +7,5 @@
 <div style="width:95%;margin: 0 auto;margin-top: 54px;color: black;">
   <p style="font-size: 1.2em; font-family: sans-serif;margin-bottom: 0;color: lightgray;"><%= translation('subscriptions.digest.based_on_follow')%></p>
 
-  <%= render partial: "wiki/wikis"%>
-
-  <p><%= translation('subscriptions.digest.discover_more') %> <a href="<%= @base_url %>/subscriptions"><%= translation('subscriptions.digest.topics_to_follow') %></a></p>
-  <p><a href="<%= @base_url %>/settings"><%= translation('subscriptions.digest.manage_subscriptions') %></a></p>
+  <%= render partial: "subscriptions/digest"%>
 </div>

--- a/app/views/subscriptions/_digest.html.erb
+++ b/app/views/subscriptions/_digest.html.erb
@@ -1,0 +1,42 @@
+<hr id="first" style="border: none;height: 1px;background-color: #e2e2e2;margin-bottom: 32px;">
+<div style="font-family: sans-serif; max-width: 756px;">
+  <% @wikis.each do |wiki| %>
+    <div class="d-flex flex-column flex-md-row justify-content-between">
+      <div>
+        <div style="margin-bottom: 10px">
+          <h4 style="font-weight:500;margin:0;">
+            <a href="<%= @base_url%><%= wiki.path %>"><%= wiki.latest.title %></a>
+          </h3>
+        </div>
+        <div style="float:left;">
+          <% if wiki.latest.author.photo? %>
+            <img style="width:20px;margin-right:8px;border-radius:50%;"src="<%= @base_url %><%= wiki.latest.author.photo_path(:thumb) %>" />
+          <% else %>
+            <img style="width:20px;margin-right:8px;border-radius:50%;"src="https://www.gravatar.com/avatar/1aedb8d9dc4751e229a335e371db8058" />
+          <% end %>
+        </div>
+        <div style="margin-bottom: 20px;">
+          <b style="font-weight: 500;"><%= wiki.latest.author.username.capitalize %></b>
+          <p style="margin: 0;color: #999;font-weight: 500;"><span><%= translation('wiki._wikis.published') %></span> <%= wiki.latest.created_at.strftime("%B %-d %Y") %></p>
+        </div>
+      </div>
+      <div>
+        <% if wiki.main_image.present? && wiki.main_image.is_image? %>
+          <div style="padding-bottom: 30px;" class="pl-md-5 pl-lg-5">
+            <img src="<%= @base_url %><%= wiki.main_image.path(:default) %>" style="width:120px;border-radius:5px;">
+          </div>
+        <% elsif wiki.scraped_image %>
+          <div style="padding-bottom:30px;padding-top:10px;">
+            <img src="<%= @base_url %><%= wiki.scraped_image %>" style="width:120px;border-radius:5px;">
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div style="padding-bottom: 32px;">
+      <hr style="border: none;height: 1px;background-color: #e2e2e2;width: 140px;">
+    </div>
+  <% end %>
+
+  <p><%= translation('subscriptions.digest.discover_more') %> <a href="<%= @base_url %>/subscriptions"><%= translation('subscriptions.digest.topics_to_follow') %></a></p>
+  <p><a href="<%= @base_url %>/settings"><%= translation('subscriptions.digest.manage_subscriptions') %></a></p>
+</div>

--- a/app/views/subscriptions/digest.html.erb
+++ b/app/views/subscriptions/digest.html.erb
@@ -7,10 +7,8 @@
   <div style="width:85%;margin: 0 auto;margin-top: 5px;color: black;">
     <p style="font-size: 1.2em; font-family: sans-serif;margin-bottom: 0;color: lightgray;"><%= translation('subscriptions.digest.based_on_follow')%></p>
     
-    <%= render partial: "wiki/wikis"%>
+    <%= render partial: "subscriptions/digest"%>
 
-    <p><%= translation('subscriptions.digest.discover_more') %> <a href="<%= @base_url %>/subscriptions"><%= translation('subscriptions.digest.topics_to_follow') %></a></p>
-    <p><a href="<%= @base_url %>/settings"><%= translation('subscriptions.digest.manage_subscriptions') %></a></p>
   </div>
 <% end %>
 <% if @pagy %>

--- a/app/views/wiki/_wikis.html.erb
+++ b/app/views/wiki/_wikis.html.erb
@@ -1,39 +1,43 @@
-<hr id="first" style="border: none;height: 1px;background-color: #e2e2e2;margin-bottom: 32px;">
-<div style="font-family: sans-serif; max-width: 756px;">
-  <% @wikis.each do |wiki| %>
-    <div class="d-flex flex-column flex-md-row justify-content-between">
-      <div>
-        <div style="margin-bottom: 10px">
-          <h4 style="font-weight:500;margin:0;">
-            <a href="<%= @base_url%><%= wiki.path %>"><%= wiki.latest.title %></a>
-          </h3>
-        </div>
-        <div style="float:left;">
-          <% if wiki.latest.author.photo? %>
-            <img style="width:20px;margin-right:8px;border-radius:50%;"src="<%= @base_url %><%= wiki.latest.author.photo_path(:thumb) %>" />
-          <% else %>
-            <img style="width:20px;margin-right:8px;border-radius:50%;"src="https://www.gravatar.com/avatar/1aedb8d9dc4751e229a335e371db8058" />
+<% wikis ||= @wikis #accept local if present, default to instance %>
+<% if local_assigns[:digest] and wikis.size == 0 %>
+  <div class="alert alert-warning" role="alert">
+    You haven't subscribed to any topic yet. Visit <a href="https://publiclab.org/subscriptions">https://publiclab.org/subscriptions</a> to subscribe to more topics.
+  </div>
+<% else %>
+  <table class="table">
+    <tr>
+      <th><a href = "?sort=title"> <%= translation('wiki._wikis.title') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+      <th>Image</th>
+      <th><a href = "?sort=last_edited"> <%= translation('wiki._wikis.last_edited') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+      <th><a href = "?sort=edits"> <%= translation('wiki._wikis.edits') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+      <th><a href = "?sort=page_views"> <%= translation('wiki._wikis.page_views') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+      <th><a href = "?sort=likes"> <%= translation('wiki._wikis.likes') %></a> <i class="fa fa-sort" aria-hidden="true"></i></th>
+    </tr>
+    <% wikis.each do |wiki| %>
+      <tr>
+        <td style="width:50%"><i class="fa fa-file"></i> <a href="<%= wiki.path %>"><%= wiki.latest.title %></a></td>
+        <td>
+          <% if wiki.main_image.present? && wiki.main_image.is_image? %>
+            <div style="padding-bottom: 30px;" class="pl-md-5 pl-lg-5">
+              <img src="<%= wiki.main_image.path(:default) %>" style="width:120px;border-radius:5px;">
+            </div>
+          <% elsif wiki.scraped_image %>
+            <div style="padding-bottom:30px;padding-top:10px;">
+              <img src="<%= wiki.scraped_image %>" style="width:120px;border-radius:5px;">
+            </div>
           <% end %>
-        </div>
-        <div style="margin-bottom: 20px;">
-          <b style="font-weight: 500;"><%= wiki.latest.author.username.capitalize %></b>
-          <p style="margin: 0;color: #999;font-weight: 500;"><span><%= translation('wiki._wikis.published') %></span> <%= wiki.latest.created_at.strftime("%B %-d %Y") %></p>
-        </div>
-      </div>
-      <div>
-        <% if wiki.main_image.present? && wiki.main_image.is_image? %>
-          <div style="padding-bottom: 30px;" class="pl-md-5 pl-lg-5">
-            <img src="<%= @base_url %><%= wiki.main_image.path(:default) %>" style="width:120px;border-radius:5px;">
-          </div>
-        <% elsif wiki.scraped_image %>
-          <div style="padding-bottom:30px;padding-top:10px;">
-            <img src="<%= @base_url %><%= wiki.scraped_image %>" style="width:120px;border-radius:5px;">
-          </div>
-        <% end %>
-      </div>
-    </div>
-    <div style="padding-bottom: 32px;">
-      <hr style="border: none;height: 1px;background-color: #e2e2e2;width: 140px;">
-    </div>
-  <% end %>
-</div>
+        </td>
+        <td><%= distance_of_time_in_words(Time.at(wiki.latest.created_at), Time.current, { include_seconds: false, scope: 'datetime.time_ago_in_words' }) %> <%= raw translation('wiki._wikis.by') %>
+        <a href="/profile/<%= wiki.latest.author&.name %>"><%= wiki.latest.author&.name %></a></td>
+        <td><%= wiki.revisions.size %></td>
+        <td><%= number_with_delimiter(wiki.views) %></td>
+        <td><%= number_with_delimiter(wiki.cached_likes) %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>
+<% if @pagy %>
+  <%== pagy_bootstrap_nav @pagy %>
+<% else %>
+  <%= will_paginate wikis, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer if @paginated %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -622,6 +622,12 @@ en:
       more_research: "More research on \"%{tag}\""
       more_tag_research: "More \"%{tag}\" research"
     _wikis:
+      title: "Title"
+      last_edited: "Last edited"
+      edits: "Edits"
+      page_views: "Page Views"
+      likes: "Likes"
+      by: "by"
       published: "Published"
     revisions:
       revisions_for: "Revisions for <i>%{wiki}</i>"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -427,6 +427,12 @@ fr:
       more_research: "Plus de recherches sur \"%{tag}\""
       more_tag_research: "Plus de recherche sur \"%{tag}\""
     _wikis:
+      title: "Titre"
+      last_edited: "Dernière modification"
+      edits: "Modifications"
+      page_views: "Vues de pages"
+      likes: "Likes"
+      by: "par"
       published: "Publié"
     revisions:
       revisions_for: "Révisions pour <i>%{wiki}</i>"

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -272,8 +272,8 @@ class TagControllerTest < ActionController::TestCase
     assert :wikis
     assert assigns(:wikis).length > 0
 
-    selector = css_select '#wikis h4'
-    assert_equal selector.size, 1
+    selector = css_select '#wikis table tr'
+    assert_equal selector.size, 2
     assert_select '#note-graph', 0
   end
 

--- a/test/integration/I18n_test.rb
+++ b/test/integration/I18n_test.rb
@@ -183,7 +183,7 @@ class I18nTest < ActionDispatch::IntegrationTest
       follow_redirect!
 
       get '/wiki'
-      assert_select 'span', I18n.t('wiki._wikis.published')
+      assert_select 'th', I18n.t('wiki._wikis.likes')
       assert_select 'small', I18n.t('wiki.index.collaborative_documentation')
     end
   end


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
A common template was made for settings digest and email digest via #10681 - following the UI of the mailer which led to the removal of the table design followed earlier. However, since the same template was also being used in other pages like `/wiki` and `/search/wiki/query`, the sorting features no longer remained for these. 

This PR adds the table with the sorting feature look back to these pages _(via _wikis.html.erb)_ along with replacing the redundant URL column with an _Image_ column. It also maintains a common template only for settings digest and email digest _(via _digest.html.erb)._

Adds to #5908<!--(<=== Add issue number here)-->

_wiki look
<img width="946" alt="image" src="https://user-images.githubusercontent.com/76661350/154730905-f965e35a-55a9-48c8-815e-1eba2c155615.png">

_digest look
<img width="960" alt="image" src="https://user-images.githubusercontent.com/76661350/154731204-c7910521-ebc7-4ddf-b8d9-dc106c792fe5.png">

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
