### PR TITLE
Fixed Center lead images on wiki pages (#10740)

### DIFF
--- a/app/views/wiki/_header.html.erb
+++ b/app/views/wiki/_header.html.erb
@@ -5,7 +5,7 @@
 <% if @node.main_image && !@presentation %>
   <% img_path = @node.main_image.path(@node.main_image.photo_file_name == "blob" ? :original : :large) # special case for "blob" images, see https://github.com/publiclab/plots2/issues/10210 %>
   <a style="margin-bottom:10px;" href="<%= @node.main_image.path(:original) %>">
-    <%= image_tag(img_path, class:"rounded", style:'max-width:100%;max-height:600px;margin-bottom:10px;', lazy: @node.main_image.photo_file_name == "blob") %>
+    <%= image_tag(img_path, class:"rounded", style:'max-width:100%;max-height:600px;display:block;margin:0 auto 10px;', lazy: @node.main_image.photo_file_name == "blob") %>
   </a>
 <% end %>
 


### PR DESCRIPTION
[Fixed Center lead images on wiki pages](https://github.com/publiclab/plots2/issues/10740)

Fixes #10740 

 <a style="margin-bottom:10px;" href="<%= @node.main_image.path(:original) %>">
-    <%= image_tag(img_path, class:"rounded", style:'max-width:100%;max-height:600px;margin-bottom:10px;', lazy: @node.main_image.photo_file_name == "blob") %>
+    <%= image_tag(img_path, class:"rounded", style:'max-width:100%;max-height:600px;display:block;margin:0 auto 10px;', lazy: @node.main_image.photo_file_name == "blob") %>
   </a>

Please review my PR.

Thanks!
