### PR TITLE
changed wiki.css to resolve anchor hiding behind header

### DIFF
--- a/app/assets/stylesheets/wiki.css
+++ b/app/assets/stylesheets/wiki.css
@@ -69,8 +69,9 @@
 a.navbar-offset {
     display: block;
     position: relative;
-    top: -100px;
     visibility: hidden;
+    padding-top: 150px;
+    margin-top: -150px;
 }
 
 #toc-menu:hover, .toc-active {


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
Made changes in the wiki.css file to resolve the issue of the target element hiding behind the fixed header.
I changed the css code of the hidden anchor(which was the main target of the link icon), by setting the values of padding-top and margin-top  css properties, to offset it according to the height of the header.

Fixes #10744 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->


https://user-images.githubusercontent.com/84193017/158222268-8932e3f2-8c2e-4351-825e-842418c52907.mp4



