### PR TITLE
add_unflag_tooltip_to_clarify_btn

### DIFF
--- a/app/views/spam2/_flags.html.erb
+++ b/app/views/spam2/_flags.html.erb
@@ -103,7 +103,7 @@ $(document).ready(function () {
              <td style="height:35px !important;">
                <a class="btn btn-xs border-curve font-weight-bold btn<% if flag.status != 1 %>-success<% else %>-secondary disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= flag.id %>" ><i class="fa fa-check-circle fa-white"></i> Publish post</a>
                <a class="btn btn-xs border-curve font-weight-bold btn<% if flag.status != 0 %>-danger<% else %>-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= flag.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a> 
-               <a class="btn btn-xs border-curve font-weight-bold btn-warning unflag" data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
+              <a data-toggle="tooltip" data-placement="top" title="Remove all flags" class="btn btn-xs border-curve font-weight-bold btn-warning unflag" data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
                <%= link_to "/notes/delete/#{flag.id}", data: { confirm: "Are you sure you want to delete #{flag.path}?" }, :remote => true, :class => "btn border-curve btn-sm font-weight-bold btn-light delete" do %>
                 <i class="fa fa-trash text-dark"></i>
                <% end %>


### PR DESCRIPTION
edit complete, "unflag" tooltip added to button

<!-- Add a short description about your changes here-->

Fixes #10820 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [X] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

As designed, this was a simple first-time contribution. I want to ensure that I initiated the PR from the correct branch. I believe it is typically initiated from the changed-branch rather than the main, which seems to be the case here. Any clarity would be greatly appreciated. Thanks in advance.

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
