### PR TITLE
Fix Button to Display Dropdown on small screens only

### DIFF
--- a/app/views/sidebar/_question.html.erb
+++ b/app/views/sidebar/_question.html.erb
@@ -2,7 +2,8 @@
 
 <%= render :partial => "like/like", :locals => {:node => @node, :tagnames => @tagnames } %>
   <div class="accordion">
-  <button style="margin-top:-16px;margin-bottom:0;" aria-expanded="false" class="btn btn-sm btn-block btn-link" href="javascript:void()" onclick="toggle_sidebar()"><i class="pt-3 pb-3 fa fa-chevron-down fa-2x"></i></button>
+  <button style="margin-top:-16px;margin-bottom:0;" aria-expanded="false" class="btn btn-sm btn-block btn-link d-lg-none" href="javascript:void()" onclick="toggle_sidebar()"><i class="pt-3 pb-3 fa fa-chevron-down fa-2x"></i></button>
+ 
 
   <div id="sidebar" class="d-lg-inline accordion-content">
 


### PR DESCRIPTION
<!-- Changed the drop down buttons to display only on smaller screens -->

Fixes #10845 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [✔️  ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ✔️ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [✔️ #10845 [](url) ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ✔️] screenshots/GIFs are attached 📎 in case of UI updation
* [✔️ ] ask `@publiclab/reviewers` for help, in a comment below

please i'll need a review on this, Thanks @publiclab/reviewers 

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to lea
![Screenshot (90)](https://user-images.githubusercontent.com/77807331/160294228-bff50a2c-fa0d-405e-87c5-8cfe7991c085.png)
rn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
