### PR TITLE
Change translation key for distance_of_time_on_words

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -61,7 +61,7 @@ pt-BR:
     - :month
     - :year
   datetime:
-    distance_in_words:
+    time_ago_in_words:
       about_x_hours:
         one: aproximadamente 1 hora
         other: aproximadamente %{count} horas


### PR DESCRIPTION
* changed line 64 to time_ago_in_words

Old line 64: distance_in_words:
New line 64 : time_ago_in_words:

<!-- Add a short description about your changes here-->

Part of #10850 <!--(<=== Add issue number here)-->


