### PR TITLE
added unflag-tooltip to claify button

### DIFF
--- a/app/views/spam2/_flags.html.erb
+++ b/app/views/spam2/_flags.html.erb
@@ -43,6 +43,7 @@ $(document).ready(function () {
 	$('#reset').on('click', function () { // all filter
 		search_table("all", "/spam2/flags/filter/");
 	});
+  $('#unflag-node').tooltip({ boundary: 'window' });
 });
 </script>
 <div class="card" id="table-card">
@@ -110,7 +111,7 @@ $(document).ready(function () {
              <td style="height:35px !important;">
                <a class="btn btn-xs border-curve font-weight-bold btn<% if flag.status != 1 %>-success<% else %>-secondary disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= flag.id %>" ><i class="fa fa-check-circle fa-white"></i> Publish post</a>
                <a class="btn btn-xs border-curve font-weight-bold btn<% if flag.status != 0 %>-danger<% else %>-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= flag.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a> 
-               <a data-toggle="tooltip" data-placement="top" title="Remove all flags" class="btn btn-xs border-curve font-weight-bold btn-warning unflag" data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
+               <a id="unflag-node" data-toggle="tooltip" data-placement="top" title="Remove all flags" class="btn btn-xs border-curve font-weight-bold btn-warning unflag" data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
                <%= link_to "/notes/delete/#{flag.id}", data: { confirm: "Are you sure you want to delete #{flag.path}?" }, :remote => true, :class => "btn border-curve btn-sm font-weight-bold btn-light delete" do %>
                 <i class="fa fa-trash text-dark"></i>
                <% end %>

--- a/app/views/spam2/_flags.html.erb
+++ b/app/views/spam2/_flags.html.erb
@@ -110,7 +110,7 @@ $(document).ready(function () {
              <td style="height:35px !important;">
                <a class="btn btn-xs border-curve font-weight-bold btn<% if flag.status != 1 %>-success<% else %>-secondary disabled<% end %> publish" data-remote="true" href="/moderate/publish/<%= flag.id %>" ><i class="fa fa-check-circle fa-white"></i> Publish post</a>
                <a class="btn btn-xs border-curve font-weight-bold btn<% if flag.status != 0 %>-danger<% else %>-secondary disabled<% end %> spam" data-remote="true" href="/moderate/spam/<%= flag.id %>"><i class="fa fa-ban fa-white"></i> Spam post</a> 
-               <a class="btn btn-xs border-curve font-weight-bold btn-warning unflag" data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
+               <a data-toggle="tooltip" data-placement="top" title="Remove all flags" class="btn btn-xs border-curve font-weight-bold btn-warning unflag" data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
                <%= link_to "/notes/delete/#{flag.id}", data: { confirm: "Are you sure you want to delete #{flag.path}?" }, :remote => true, :class => "btn border-curve btn-sm font-weight-bold btn-light delete" do %>
                 <i class="fa fa-trash text-dark"></i>
                <% end %>


### PR DESCRIPTION
<!-- Add a short description about your changes here-->

Fixes #10839 (the PR fix for the original issue) and #10820 (the original issue) <!--(<=== Add issue number here)-->

added `data-toggle="tooltip" data-placement="top" title="Remove all flags"`
to the existing "unflag" button:
```
<a class="btn btn-xs border-curve font-weight-bold btn-warning unflag"
  data-remote="true"href="/moderate/remove_flag_node/<%= flag.id %>">Unflag</a>
```
The changes will be applied to the following:

![Screen Shot 2022-03-30 at 2 49 41 PM](https://user-images.githubusercontent.com/81270711/160918459-50a6728d-2c12-4981-b410-a5a1d085b60c.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts 📁
* [X] screenshots/GIFs are attached 📎 in case of UI updation
* [X] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

This PR was created in reference for the original PR, #10839, as the branch (and corresponding repo) has been deleted and is unrecoverable.

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->


