### PR TITLE
added a catch to check for search term before results are loaded

### DIFF
--- a/app/views/search/profiles.html.erb
+++ b/app/views/search/profiles.html.erb
@@ -11,7 +11,9 @@
 
       <div class="row">
         <div class="col-lg-7">
-        <% if @profiles.present? %>
+        <% if params[:query].blank?%>
+          <p>Please enter a search term.</p>
+        <% elsif @profiles.present? %>
 
           <h4>Results for "<b><%= params[:query] %></b>":</h4>
           <p>Searched profiles by <i>username</i> and <i>bio</i></p>
@@ -44,7 +46,9 @@
         <% end %>
     </div>
     <div class="col-lg-4 col-lg-offset-1" >
-      <% if @tag_profiles.present?%>
+      <% if params[:query].blank? %>
+        <p>&nbsp;</p>
+      <% elsif @tag_profiles.present?%>
         <h4>Results for "<b><%= params[:query] %></b>":</h4>
         <p>Searched profiles by <i>profile tags</i></p>
         <% @tag_profiles.each do |profile| %>

--- a/app/views/search/questions.html.erb
+++ b/app/views/search/questions.html.erb
@@ -9,7 +9,10 @@
 
     <%= render partial: "search/form", locals: { searchType: "questions/" } %>
 
-    <% if @questions.present? %>
+    <% if params[:query].blank?%>
+      <p>Please enter a search term.</p>
+      
+    <% elsif @questions.present? %>
       <h4>Results for "<b><%= params[:query] %></b>":</h4>
 
       <div class="related-tags-container">


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
Added a check to the profiles and question html file to return a message asking for the user to enter a search term if non is provided
Fixes #10882 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
