### PR TITLE
10890 display confirm modal before deleting spam posts

### DIFF
--- a/app/assets/javascripts/spam2.js
+++ b/app/assets/javascripts/spam2.js
@@ -55,6 +55,10 @@ function search_table(filter, url) {
 }
 
 function batch_nav(bulk) {
+	if((bulk == "batch_delete" || bulk == "batch_comment/delete") && !confirm("Are you sure you want to delete the selected nodes?")) {
+	return false;
+}
+
 	vals = []
 	$('.selectedId').each(function (i, a) { // batch nav
 		if (a.checked) vals.push(a.value);

--- a/test/system/spam2_test.rb
+++ b/test/system/spam2_test.rb
@@ -108,7 +108,9 @@ class SpamTest < ApplicationSystemTestCase
     within "#n#{page2.id}" do
       find(".selectedId").click()
     end
-    find("#delete-batch").click()
+    accept_confirm do
+      find("#delete-batch").click()
+    end
     assert_selector('div.alert', text: '2 nodes deleted')
   end
 


### PR DESCRIPTION
Display confirm modal before deleting spam posts.

Fixes #10890 

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
