### PR TITLE
Update on "Make Insights Table More Descriptive in Spam 2 #10959" issue

### DIFF
--- a/app/views/spam2/_insights.html.erb
+++ b/app/views/spam2/_insights.html.erb
@@ -1,28 +1,28 @@
 <div class="card-deck w-100 mb-3" id="stats_spam">
   <div class="card">
     <div class="card-body">
-    <a class="card-title  text-secondary h5 font-weight-bold" href="/spam2/filter/unmoderated/30"> <i class="fa fa-circle text-primary"></i>  Unmoderated</a>
+      <a class="card-title text-secondary h5 font-weight-bold" href="/spam2/filter/unmoderated/30"> <i class="fa fa-circle text-primary"></i>  Unmoderated</a>
       <ul class="list-group list-group-flush text-secondary  mt-3">
-        <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Unmoderated Nodes"><%= Node.where(status: 4).size%></span></li>
-        <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Unmoderated Comments"><%= Comment.where(status: 4).size %></span></li>
+        <li class="list-group-item"><span title="Unmoderated Nodes"><%= Node.where(status: 4).size%> nodes</span></li>
+        <li class="list-group-item"><span title="Unmoderated Comments"><%= Comment.where(status: 4).size %> comments</span></li>
       </ul>
     </div>
   </div>
   <div class="card">
    <div class="card-body">
-       <a class="card-title h5 text-secondary font-weight-bold" href="/spam2/filter/spammed/30"> <i class="fa fa-ban text-danger"></i>  Spammed</a>
+      <a class="card-title h5 text-secondary font-weight-bold" href="/spam2/filter/spammed/30"> <i class="fa fa-ban text-danger"></i>  Spammed</a>
       <ul class="list-group list-group-flush text-secondary mt-3">
-        <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Spammed Nodes"><%= Node.where(status: 0).size%></span></li>
-        <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Spammed Comments"><%= Comment.where(status: 0).size %></span></li>
+	<li class="list-group-item"><span title="Spammed Nodes"><%= Node.where(status: 0).size%> nodes</span></li>
+   	<li class="list-group-item"><span title="Spammed Comments"><%= Comment.where(status: 0).size %> comments</span></li>      
       </ul>
     </div>
   </div>
   <div class="card">
     <div class="card-body">
-        <a class="card-title h5 text-secondary font-weight-bold" href="/spam2/flags/filter/all/30"> <i class="fa fa-flag text-warning"></i>  Flagged</a>
+      <a class="card-title h5 text-secondary font-weight-bold" href="/spam2/flags/filter/all/30"> <i class="fa fa-flag text-warning"></i>  Flagged</a>
       <ul class="list-group list-group-flush text-secondary mt-3">
-        <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Flagged Nodes"><%= Node.where('flag > ?', 0).size%></span></li>
-        <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Spammed Comments"><%= Comment.where('flag > ?', 0).size %></span></li>
+        <li class="list-group-item"><span title="Flagged Nodes"><%= Node.where('flag > ?', 0).size%> nodes</span></li>
+        <li class="list-group-item"><span title="Flagged Comments"><%= Comment.where('flag > ?', 0).size %> comments</span></li>
       </ul>
     </div>
   </div>
@@ -30,8 +30,8 @@
     <div class="card-body">
         <a class="card-title h5 text-secondary font-weight-bold" href="/spam2/filter/published/30"> <i class="fa fa-check text-success"></i>  Published</a>
         <ul class="list-group list-group-flush text-secondary mt-3">
-            <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Published Nodes"><%= Node.where(status: 1).size%></span></li>
-            <li class="list-group-item"><span data-toggle="tooltip" data-placement="top" title="Published Comments"><%= Comment.published.count %></span></li>
+          <li class="list-group-item"><span title="Published Nodes"><%= Node.where(status: 1).size%> nodes</span></li>
+          <li class="list-group-item"><span title="Published Comments"><%= Comment.published.count %> comments</span></li>
         </ul>
     </div>
   </div>


### PR DESCRIPTION
The "Make Insights Table More Descriptive in Spam 2 #10959" has been updated accordingly as was required.

I have been able to change the anchor (<a></a>)  tags of Unmoderated,Spammed,Flagged sectons and their corresponding list (<li> </li>) tags (with the inclusion of the Published section).  

The issue number was #10959

Thanks!
