### PR TITLE
add meta tag to warn bots not to index revision pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,10 @@
         <%= javascript_include_tag "cable" %>
     <% end %>
 
+    <% if @is_revision %>
+        <meta name="robots" content="noindex">
+    <% end %>
+
     <% if @node && @node.body %>
       <meta property="og:title" content="<%= @title %>" />
       <meta property="og:site_name" content="Public Lab" />


### PR DESCRIPTION
add meta tag to warn bots not to index revision pages

Fixes #10946

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
