### PR TITLE
Second git+https protocol fix

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10726,7 +10726,7 @@ publiclab-editor@^2.0.0:
     moment "~2.27.0"
     resig-class "~1.0.0"
     typeahead.js-browserify "~1.0.7"
-    woofmark "git://github.com/jywarren/woofmark.git#plots2"
+    woofmark "https://github.com/jywarren/woofmark.git#plots2"
     xhr "~2.5.0"
 
 publiclab-editor@^3.1.0:
@@ -13604,9 +13604,9 @@ window-size@0.1.0:
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
   integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
 
-"woofmark@git://github.com/jywarren/woofmark.git#plots2":
+"woofmark@git+https://github.com/jywarren/woofmark.git#plots2":
   version "4.0.3"
-  resolved "git://github.com/jywarren/woofmark.git#78821fad8687757a4201fbef3be4b85418e785ef"
+  resolved "git+https://github.com/jywarren/woofmark.git#78821fad8687757a4201fbef3be4b85418e785ef"
   dependencies:
     bullseye "1.4.6"
     bureaucracy "1.0.7"


### PR DESCRIPTION
Follow-up to #11045:

```

warning Pattern ["woofmark@https://github.com/jywarren/woofmark.git#plots2"] is trying to unpack in the same destination "/usr/local/share/.cache/yarn/v6/npm-woofmark-4.0.3-78821fad8687757a4201fbef3be4b85418e785ef/node_modules/woofmark" as pattern ["woofmark@git://github.com/jywarren/woofmark.git#plots2"]. This could result in non-deterministic behavior, skipping.
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/jywarren/woofmark.git
Directory: /app
Output:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```