### PR TITLE
Issue Resolved: Fix Breaking-link Punctuation at end of URL in Comments #10947

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 PublicLab.org
 ======
-I forked and cloned this repo.
 
 [![Code of Conduct](https://img.shields.io/badge/code-of%20conduct-green.svg)](https://publiclab.org/conduct)
 [![Build Status](https://github.com/publiclab/plots2/workflows/tests/badge.svg?branch=main)](https://github.com/publiclab/plots2/actions)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 PublicLab.org
 ======
+I forked and cloned this repo.
 
 [![Code of Conduct](https://img.shields.io/badge/code-of%20conduct-green.svg)](https://publiclab.org/conduct)
 [![Build Status](https://github.com/publiclab/plots2/workflows/tests/badge.svg?branch=main)](https://github.com/publiclab/plots2/actions)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,7 +21,7 @@ class Comment < ApplicationRecord
   def self.inheritance_column
     'rails_type'
   end
-
+  
   def self.search(query)
     Comment.where('MATCH(comment) AGAINST(?)', query)
       .where(status: 1)
@@ -503,10 +503,7 @@ class Comment < ApplicationRecord
   end
 
   def render_body
-    body = RDiscount.new(
-      title_suggestion(self),
-      :autolink
-    ).to_html
+    body = RDiscount.new(title_suggestion(self)).to_html
     # if it has quoted email text that wasn't caught by the yahoo and gmail filters,
     # manually insert the comment filter delimeter:
     parsed = parse_quoted_text

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -145,7 +145,7 @@
 
     <% comment_body = comment.render_body %>
     <div class="comment-body" id="comment-body-<%= comment.cid %>">
-      <%= raw insert_extras(filtered_comment_body(comment_body)) %>
+      <%= raw auto_link(insert_extras(filtered_comment_body(comment_body)), :sanitize => false) %>
     </div>
 
     <% if contain_trimmed_body?(comment_body) %>


### PR DESCRIPTION
The commits made on 9th April, about updating two files are the required changes.