### PR TITLE
Disable Comment Form While Guest Browsing

### DIFF
--- a/app/javascript/components/CommentsContainer.js
+++ b/app/javascript/components/CommentsContainer.js
@@ -174,7 +174,7 @@ const CommentsContainer = ({
                 textAreaValue={state.textAreaValues["main"]} 
               /> :
               <p>
-                <a href="https://publiclab.org/login">Login</a> to comment.
+                <a href="/login">Login</a> to comment.
               </p>
             }
           </div>

--- a/app/javascript/components/CommentsContainer.js
+++ b/app/javascript/components/CommentsContainer.js
@@ -174,7 +174,7 @@ const CommentsContainer = ({
                 textAreaValue={state.textAreaValues["main"]} 
               /> :
               <p>
-                <a href="#">Login</a> to comment.
+                <a href="https://publiclab.org/login">Login</a> to comment.
               </p>
             }
           </div>

--- a/app/javascript/components/CommentsContainer.js
+++ b/app/javascript/components/CommentsContainer.js
@@ -161,17 +161,22 @@ const CommentsContainer = ({
               handleDeleteComment={handleDeleteComment}
               handleTextAreaChange={handleTextAreaChange}
               handleUpdateComment={handleUpdateComment}
-              // setTextAreaValues={setTextAreaValues}
               textAreaValues={state.textAreaValues}
             />
             {/* main comment form */}
-            <CommentForm 
-              commentFormType="main" 
-              formId="main"
-              handleFormSubmit={handleCreateComment}
-              handleTextAreaChange={handleTextAreaChange}
-              textAreaValue={state.textAreaValues["main"]}
-            />
+            {
+              currentUser ?
+              <CommentForm 
+                commentFormType="main" 
+                formId="main"
+                handleFormSubmit={handleCreateComment}
+                handleTextAreaChange={handleTextAreaChange}
+                textAreaValue={state.textAreaValues["main"]} 
+              /> :
+              <p>
+                <a href="#">Login</a> to comment.
+              </p>
+            }
           </div>
         </div>
       )}


### PR DESCRIPTION
This PR makes changes in the React rewrite of the commenting system.

It disables the login form at the bottom of notes while guest browsing (user isn't logged in):

Before the change:
<img width="551" alt="Screen Shot 2022-04-18 at 1 48 07 PM" src="https://user-images.githubusercontent.com/4361605/163877302-035d870c-1796-42ad-ba24-05070c471684.png">

After the change:
<img width="485" alt="Screen Shot 2022-04-18 at 1 46 49 PM" src="https://user-images.githubusercontent.com/4361605/163877371-019de9f2-9bc7-4017-99ea-04a77ad58569.png">

---
(This issue is part of the larger Comment Editor Overhaul Project with Outreachy. Refer to Planning Issues #9069 and #9365 for more context)