### PR TITLE
Fix reverse chronological sorting on inline grids

### DIFF
--- a/app/models/concerns/node_shared.rb
+++ b/app/models/concerns/node_shared.rb
@@ -398,7 +398,7 @@ module NodeShared
                    .where('node.type = ? OR node.type = ?', type1, type2)
                    .joins(:revision,:tag)
                    .where('term_data.name = ?', tagname)
-                   .order('node.vid')
+                   .order('node.vid DESC')
                    .limit(limit)
                    .where.not(nid: pinned.collect(&:nid)) # don't include pinned items twice
     else


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
Inline grids that included both wikis and notes had content sorted in reverse chronological order. 
This PR adds a `DESC` clause in the SQL query to sort them in chronological order.

Before

<img width="603" alt="image" src="https://user-images.githubusercontent.com/76661350/166504944-dc90d7c0-6d34-45a7-9db3-fc98c5ed08a6.png">


After

<img width="605" alt="image" src="https://user-images.githubusercontent.com/76661350/166504576-8f25a59d-ccc4-4d93-969b-b47e8b4c9b0b.png">

Fixes #11103 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [-\x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
