### PR TITLE
Remove direct woofmark dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "tocbot": "^4.18.2",
     "typeahead.js": "^0.11.1",
     "typeahead.js-browserify": "Javier-Rotelli/typeahead.js-browserify#~1.0.7",
-    "urlhash": "^0.1.3",
-    "woofmark": "~4.2.0"
+    "urlhash": "^0.1.3"
   },
   "devDependencies": {
     "webpack-dev-server": "^4.9.1"


### PR DESCRIPTION
It was added in https://github.com/publiclab/plots2/commit/5c58a2e2ef7ac9affa683a4c9a596b44cf930413 and since it's compiled into https://github.com/publiclab/PublicLab.Editor/, I don't think its necessary!
