### PR TITLE
Fixes #11203: Refined Information hierarchy on profile page

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -93,11 +93,18 @@ class Tag < ApplicationRecord
   end
 
   # finds recent nodes - should drop "limit" and allow use of chainable .limit()
-  def self.find_nodes_by_type(tagnames, type = 'note', limit = 10)
-    nodes = Node.where(status: 1, type: type)
-                .includes(:tag)
-                .references(:term_data)
-                .where('term_data.name IN (?)', tagnames)
+  def self.find_nodes_by_type(tagnames, type = 'note', limit = 10, author_id = -1)
+    if author_id != -1
+      nodes = Node.where(status: 1, type: type, uid: author_id)
+                  .includes(:tag)
+                  .references(:term_data)
+                  .where('term_data.name IN (?)', tagnames)
+    else 
+      nodes = Node.where(status: 1, type: type)
+                  .includes(:tag)
+                  .references(:term_data)
+                  .where('term_data.name IN (?)', tagnames)
+    end
     # .select(%i[node.nid node.status node.type community_tags.nid community_tags.tid term_data.name term_data.tid])
     # above select could be added later for further optimization
     order = 'node_revisions.timestamp DESC'

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -94,7 +94,7 @@ class Tag < ApplicationRecord
 
   # finds recent nodes - should drop "limit" and allow use of chainable .limit()
   def self.find_nodes_by_type(tagnames, type = 'note', limit = 10, author_id = nil)
-    query = {status: 1, type: type}
+    query = { status: 1, type: type }
     query['uid'] = author_id unless author_id.blank? 
     nodes = Node.where(query)
               .includes(:tag)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -94,17 +94,17 @@ class Tag < ApplicationRecord
 
   # finds recent nodes - should drop "limit" and allow use of chainable .limit()
   def self.find_nodes_by_type(tagnames, type = 'note', limit = 10, author_id = -1)
-    if author_id != -1
-      nodes = Node.where(status: 1, type: type, uid: author_id)
-                  .includes(:tag)
-                  .references(:term_data)
-                  .where('term_data.name IN (?)', tagnames)
-    else 
-      nodes = Node.where(status: 1, type: type)
-                  .includes(:tag)
-                  .references(:term_data)
-                  .where('term_data.name IN (?)', tagnames)
-    end
+    nodes = if author_id != -1
+              Node.where(status: 1, type: type, uid: author_id)
+              .includes(:tag)
+              .references(:term_data)
+              .where('term_data.name IN (?)', tagnames)
+            else
+              Node.where(status: 1, type: type)
+              .includes(:tag)
+              .references(:term_data)
+              .where('term_data.name IN (?)', tagnames)
+            end
     # .select(%i[node.nid node.status node.type community_tags.nid community_tags.tid term_data.name term_data.tid])
     # above select could be added later for further optimization
     order = 'node_revisions.timestamp DESC'

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -94,7 +94,9 @@ class Tag < ApplicationRecord
 
   # finds recent nodes - should drop "limit" and allow use of chainable .limit()
   def self.find_nodes_by_type(tagnames, type = 'note', limit = 10, author_id = nil)
-    nodes = Node.where(status: 1, type: type, uid: author_id)
+    query = {status: 1, type: type}
+    query['uid'] = author_id unless author_id.blank? 
+    nodes = Node.where(query)
               .includes(:tag)
               .references(:term_data)
               .where('term_data.name IN (?)', tagnames)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -93,18 +93,11 @@ class Tag < ApplicationRecord
   end
 
   # finds recent nodes - should drop "limit" and allow use of chainable .limit()
-  def self.find_nodes_by_type(tagnames, type = 'note', limit = 10, author_id = -1)
-    nodes = if author_id != -1
-              Node.where(status: 1, type: type, uid: author_id)
+  def self.find_nodes_by_type(tagnames, type = 'note', limit = 10, author_id = nil)
+    nodes = Node.where(status: 1, type: type, uid: author_id)
               .includes(:tag)
               .references(:term_data)
               .where('term_data.name IN (?)', tagnames)
-            else
-              Node.where(status: 1, type: type)
-              .includes(:tag)
-              .references(:term_data)
-              .where('term_data.name IN (?)', tagnames)
-            end
     # .select(%i[node.nid node.status node.type community_tags.nid community_tags.tid term_data.name term_data.tid])
     # above select could be added later for further optimization
     order = 'node_revisions.timestamp DESC'

--- a/app/views/tag/_profileCard.html.erb
+++ b/app/views/tag/_profileCard.html.erb
@@ -7,7 +7,7 @@
       <p class="posted-by-links"><a href="/tag/<%= tag.name %>"><%= pluralize(Tag.follower_count(tag.name), 'person') %> discussing</a></p>
     </div>
     <div class="card-body">
-      <% Tag.find_nodes_by_type(tag.name, type = 'note', limit = 3).each do |node|  %>
+      <% Tag.find_nodes_by_type(tag.name, type = 'note', limit = 3, author_id = @profile_user.id).each do |node|  %>
         <div class="posted-by-links">
           <% if node.main_image %>
             <img class="rounded-circle" id="profile-photo" style="width:20px; height:20px; margin-right:8px; display: inline-block;" src="<%= node.main_image.path(:default) %>" />
@@ -17,7 +17,6 @@
             <div class="circle"></div>
           <% end %>
           <a class="post-title" <% if @widget %>target="_blank"<% end %> href="<%= node.path %>"><%= (node.type == 'note') ? node.title : node.latest.title %></a>
-          by <a href="/profile/<%= node.author.name %>" class="text-decoration-none">@<%= node.author.name %></a>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Fetched posts on the profile page only by the user, rather than dispalying activity of the user on a particular post.

Fixes #11203 <!--(<=== Add issue number here)-->

### Screenshots

Before:

![Screenshot (246)](https://user-images.githubusercontent.com/78212650/175018985-e395cfd6-6d8d-46bd-bb89-29f820a833a9.png)

After:

![Screenshot (247)](https://user-images.githubusercontent.com/78212650/175019048-8215df85-c811-4a00-b78e-3c6ea34ecd7f.png)

![image](https://user-images.githubusercontent.com/78212650/175021336-9c72b583-715c-4e25-9f9c-b9261754bfe5.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
