### PR TITLE
Convert map nodes to note nodes

### DIFF
--- a/db/migrate/20220625142729_convert_map_to_note_nodes.rb
+++ b/db/migrate/20220625142729_convert_map_to_note_nodes.rb
@@ -2,14 +2,14 @@ class ConvertMapToNoteNodes < ActiveRecord::Migration[5.2]
   def change
     Node.where(type: 'map').each do |node|
       revision = node.latest
-      iframe_link = "<iframe style='width:100%;border:none;background:#ddd;margin-bottom:8px;' height='375' src='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=#{node.map.min_zoom+1}'></iframe>"
+      iframe_link = "<iframe style='width:100%;border:none;background:#ddd;margin-bottom:8px;' height='375' src='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map&.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=#{node.map&.min_zoom+1}'></iframe>"
       conversion_buttons =
         "<div class='btn-toolbar'>"\
           "<div class='btn-group'>"\
-            "<a class='btn btn-sm btn-danger' rel='tooltip' title='View the map in a full-screen web viewer' href='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=17'>Web viewer</a>"\
-            "<a class='btn btn-sm btn-success' rel='tooltip' title='' href='#{node.map.field_jpg_url_value}'>JPG (#{node.map.field_jpg_filesize_value.to_i} MB)</a>"\
-            "<a class='btn btn-sm btn-info' rel='tooltip' title='' href='#{node.map.field_geotiff_url_value}'>GeoTiff (#{node.map.field_geotiff_filesize_value.to_i} MB)</a>"\
-            "<a class='btn btn-sm btn-warning' rel='tooltip' title='Tiled Map Service (for developers)' href='#{node.map.field_tms_url_value}'>TMS</a>"\
+            "<a class='btn btn-sm btn-danger' rel='tooltip' title='View the map in a full-screen web viewer' href='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map&.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=17'>Web viewer</a>"\
+            "<a class='btn btn-sm btn-success' rel='tooltip' title='' href='#{node.map&.field_jpg_url_value}'>JPG (#{node.map&.field_jpg_filesize_value.to_i} MB)</a>"\
+            "<a class='btn btn-sm btn-info' rel='tooltip' title='' href='#{node.map&.field_geotiff_url_value}'>GeoTiff (#{node.map&.field_geotiff_filesize_value.to_i} MB)</a>"\
+            "<a class='btn btn-sm btn-warning' rel='tooltip' title='Tiled Map Service (for developers)' href='#{node.map&.field_tms_url_value}'>TMS</a>"\
           "</div>"\
         "</div>"
 
@@ -17,7 +17,7 @@ class ConvertMapToNoteNodes < ActiveRecord::Migration[5.2]
       "<div class='map-details'>"\
         "<small>"
 
-      if node.map.authorship
+      if node.map&.authorship
         map_details += "<p><b>By</b> #{node.map.authorship}</p>"
       else
         map_details +=
@@ -29,31 +29,31 @@ class ConvertMapToNoteNodes < ActiveRecord::Migration[5.2]
         "<p><a href='https://maps.google.com/maps?t=h&ll=#{node.lat},#{node.lon}'>#{node.lat} N, #{node.lon} E</a></p>"\
         "<p>#{node.views} views</p>"
 
-      map_details += "<p><b>Ground resolution: </b>#{node.map.field_ground_resolution_value} cm/px</p>" if node.map.field_ground_resolution_value
+      map_details += "<p><b>Ground resolution: </b>#{node.map&.field_ground_resolution_value} cm/px</p>" if node.map&.field_ground_resolution_value
 
       map_details +=
-            "<p><b>Capture date:</b> #{node.map.captured_on.to_s}</p>"\
-            "<p><b>Publication date:</b> #{node.map.published_on.to_s}</p>"\
-            "<p><b>License:</b> #{node.map.license.html_safe}</p>"\
+            "<p><b>Capture date:</b> #{node.map&.captured_on.to_s}</p>"\
+            "<p><b>Publication date:</b> #{node.map&.published_on.to_s}</p>"\
+            "<p><b>License:</b> #{node.map&.license.html_safe}</p>"\
           "</small>"\
         "</div><hr />"\
         "<style>.map-details p { margin:4px 0; }</style>"
 
       notes = "<hr \>"
 
-      unless node.map.notes.nil?
+      unless node.map&.notes.nil?
         notes =
         "<h3>Notes</h3>"\
-        "<p>#{node.map.notes.html_safe}</p>"\
+        "<p>#{node.map&.notes.html_safe}</p>"\
         "<hr />"
       end
 
       cartographer_notes = ""
 
-      unless node.map.cartographer_notes.nil?
+      unless node.map&.cartographer_notes.nil?
         cartographer_notes =
         "<h3>Cartographer notes</h3>"\
-        "<p>#{node.map.cartographer_notes.html_safe}</p>"\
+        "<p>#{node.map&.cartographer_notes.html_safe}</p>"\
         "<hr />"
       end
 

--- a/db/migrate/20220625142729_convert_map_to_note_nodes.rb
+++ b/db/migrate/20220625142729_convert_map_to_note_nodes.rb
@@ -2,13 +2,13 @@ class ConvertMapToNoteNodes < ActiveRecord::Migration[5.2]
   def change
     Node.where(type: 'map').each do |node|
       revision = node.latest
-      iframe_link = "<iframe style='width:100%;border:none;background:#ddd;margin-bottom:8px;' height='375' src='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map&.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=#{node.map&.min_zoom+1}'></iframe>"
+      iframe_link = "<iframe style='width:100%;border:none;background:#ddd;margin-bottom:8px;' height='375' src='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map&.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=#{node.map&.min_zoom.to_i+1}'></iframe>"
       conversion_buttons =
         "<div class='btn-toolbar'>"\
           "<div class='btn-group'>"\
             "<a class='btn btn-sm btn-danger' rel='tooltip' title='View the map in a full-screen web viewer' href='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map&.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=17'>Web viewer</a>"\
-            "<a class='btn btn-sm btn-success' rel='tooltip' title='' href='#{node.map&.field_jpg_url_value}'>JPG (#{node.map&.field_jpg_filesize_value.to_i} MB)</a>"\
-            "<a class='btn btn-sm btn-info' rel='tooltip' title='' href='#{node.map&.field_geotiff_url_value}'>GeoTiff (#{node.map&.field_geotiff_filesize_value.to_i} MB)</a>"\
+            "<a class='btn btn-sm btn-success #{ "disabled" if node.map&.field_jpg_filesize_value.nil? }' rel='tooltip' title='' href='#{node.map&.field_jpg_url_value}'>JPG (#{node.map&.field_jpg_filesize_value.to_i} MB)</a>"\
+            "<a class='btn btn-sm btn-info #{ "disabled" if node.map&.field_geotiff_filesize_value.nil? }' rel='tooltip' title='' href='#{node.map&.field_geotiff_url_value}'>GeoTiff (#{node.map&.field_geotiff_filesize_value.to_i} MB)</a>"\
             "<a class='btn btn-sm btn-warning' rel='tooltip' title='Tiled Map Service (for developers)' href='#{node.map&.field_tms_url_value}'>TMS</a>"\
           "</div>"\
         "</div>"
@@ -34,7 +34,7 @@ class ConvertMapToNoteNodes < ActiveRecord::Migration[5.2]
       map_details +=
             "<p><b>Capture date:</b> #{node.map&.captured_on.to_s}</p>"\
             "<p><b>Publication date:</b> #{node.map&.published_on.to_s}</p>"\
-            "<p><b>License:</b> #{node.map&.license.html_safe}</p>"\
+            "<p><b>License:</b> #{node.map&.license&.html_safe}</p>"\
           "</small>"\
         "</div><hr />"\
         "<style>.map-details p { margin:4px 0; }</style>"

--- a/db/migrate/20220625142729_convert_map_to_note_nodes.rb
+++ b/db/migrate/20220625142729_convert_map_to_note_nodes.rb
@@ -1,0 +1,76 @@
+class ConvertMapToNoteNodes < ActiveRecord::Migration[5.2]
+  def change
+    Node.where(type: 'map').each do |node|
+      revision = node.latest
+      iframe_link = "<iframe style='width:100%;border:none;background:#ddd;margin-bottom:8px;' height='375' src='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=#{node.map.min_zoom+1}'></iframe>"
+      conversion_buttons =
+        "<div class='btn-toolbar'>"\
+          "<div class='btn-group'>"\
+            "<a class='btn btn-sm btn-danger' rel='tooltip' title='View the map in a full-screen web viewer' href='https://publiclab.github.io/plots-leaflet-viewer/?tms=#{node.map.tms}&lon=#{node.lon}&lat=#{node.lat}&zoom=17'>Web viewer</a>"\
+            "<a class='btn btn-sm btn-success' rel='tooltip' title='' href='#{node.map.field_jpg_url_value}'>JPG (#{node.map.field_jpg_filesize_value.to_i} MB)</a>"\
+            "<a class='btn btn-sm btn-info' rel='tooltip' title='' href='#{node.map.field_geotiff_url_value}'>GeoTiff (#{node.map.field_geotiff_filesize_value.to_i} MB)</a>"\
+            "<a class='btn btn-sm btn-warning' rel='tooltip' title='Tiled Map Service (for developers)' href='#{node.map.field_tms_url_value}'>TMS</a>"\
+          "</div>"\
+        "</div>"
+
+      map_details =
+      "<div class='map-details'>"\
+        "<small>"
+
+      if node.map.authorship
+        map_details += "<p><b>By</b> #{node.map.authorship}</p>"
+      else
+        map_details +=
+          "<p><b>Mapped by</b> #{node.drupal_content_field_mappers.collect(&:field_mappers_value).uniq.join(', ') }</p>"\
+          "<p><b>Cartographer:</b> #{node.drupal_content_field_map_editor.collect(&:field_map_editor_value).uniq.join(', ') }</p>"\
+          "<p><b>Published by</b> <a href='/profile/#{node.author.name}'>#{node.author.name}</a></p>"
+      end
+      map_details +=
+        "<p><a href='https://maps.google.com/maps?t=h&ll=#{node.lat},#{node.lon}'>#{node.lat} N, #{node.lon} E</a></p>"\
+        "<p>#{node.views} views</p>"
+
+      map_details += "<p><b>Ground resolution: </b>#{node.map.field_ground_resolution_value} cm/px</p>" if node.map.field_ground_resolution_value
+
+      map_details +=
+            "<p><b>Capture date:</b> #{node.map.captured_on.to_s}</p>"\
+            "<p><b>Publication date:</b> #{node.map.published_on.to_s}</p>"\
+            "<p><b>License:</b> #{node.map.license.html_safe}</p>"\
+          "</small>"\
+        "</div><hr />"\
+        "<style>.map-details p { margin:4px 0; }</style>"
+
+      notes = "<hr \>"
+
+      unless node.map.notes.nil?
+        notes =
+        "<h3>Notes</h3>"\
+        "<p>#{node.map.notes.html_safe}</p>"\
+        "<hr />"
+      end
+
+      cartographer_notes = ""
+
+      unless node.map.cartographer_notes.nil?
+        cartographer_notes =
+        "<h3>Cartographer notes</h3>"\
+        "<p>#{node.map.cartographer_notes.html_safe}</p>"\
+        "<hr />"
+      end
+
+      old_body = revision.body
+
+      revision.body = iframe_link
+      revision.body += conversion_buttons
+      revision.body += map_details
+      revision.body += old_body
+      revision.body += notes
+      revision.body += cartographer_notes
+
+      node.type = 'note'
+      new_path = node.generate_path
+      node.path = new_path
+      revision.save
+      node.save
+    end
+  end
+end


### PR DESCRIPTION
<!-- Add a short description about your changes here-->

Fixes #4072 <!--(<=== Add issue number here)-->

This MR aims to convert all map nodes into note nodes. It consists of a db migration, which can be run using `rails db:migrate` to be run. The script does the following:

1. Get the necessary values and data and add it to the revision body in the form of HTML
2. Update the type of node to `note`
3. Create a new path for the node to reflect its new type, using `generate_path`

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->

## Screenshots

This is the console output before running the migration.

![Screenshot from 2022-06-25 20-09-06](https://user-images.githubusercontent.com/76864239/175778794-f00c6abb-c3eb-456d-9485-1c11f31fd41e.png)

We can see that before the migration, it is being rendered as a map. We can see that from the URL as well.

![Screenshot from 2022-06-25 20-11-08](https://user-images.githubusercontent.com/76864239/175778841-3b8c8ba5-4c9e-4100-9377-31e4137d5d5e.png)

After running the migration, we note that all the maps have been converted to notes:

![Screenshot from 2022-06-25 20-12-46](https://user-images.githubusercontent.com/76864239/175778865-42ce968c-210f-4e9d-9b72-9b4fa055c346.png)

It is also reflected when we go to the notes page:

![Screenshot from 2022-06-25 20-13-10](https://user-images.githubusercontent.com/76864239/175778879-0e6e95b2-4d0a-487c-8ec1-be53bac02a1c.png)

Individually, we can see the map in the note template.

![Screenshot from 2022-06-25 20-13-37](https://user-images.githubusercontent.com/76864239/175778909-371b6405-dec1-4d38-bed4-77924e0bdf66.png)

