### PR TITLE
Fixes #11248: Added tooltip on 'first-time-poster' tag

### DIFF
--- a/app/views/tag/_miniCard.html.erb
+++ b/app/views/tag/_miniCard.html.erb
@@ -26,9 +26,15 @@
       <% end %>
     </div>
 
+    <% if tag.name == "first-time-poster" %>
+    <a href="/tag/<%= tag.name%>" rel="tooltip" title="This tag has been added by default.">
+      <h5 style="text-decoration:underline;color:black;"><%= tag.name %></h5>
+    </a>
+    <% else %>
     <a href="/tag/<%= tag.name%>">
       <h5 style="text-decoration:underline;color:black;"><%= tag.name %></h5>
     </a>
+    <% end %>
     <% if !tag.name.include? ':' %>
       <p style="font-size:15px;">
         <a style="color:#808080;" href="/tag/<%= tag.name %>"><%= Tag.follower_count(tag.name) %> following</a>


### PR DESCRIPTION
Added tooltip on `first-time-poster` tag to highlight that it is added by default when a note is posted.

Fixes #11248 <!--(<=== Add issue number here)-->

### Screenshot:

![image](https://user-images.githubusercontent.com/78212650/177380939-7d6c64a6-934c-482f-a7a5-7b19a71b531b.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
