### PR TITLE
Remove grey color from links in wiki edit page

### DIFF
--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -13,12 +13,12 @@
 
   <%= raw translation('wiki.edit.whats_a_wiki_page') %>
   <hr />
-  <div class="navbar d-md-none d-lg-block">
-    <ul class="navbar-nav">
-      <li class="nav-item navbar-brand"><%= translation('wiki.edit.more') %></li>
+  <div class="d-md-none d-lg-block">
+     <h5><%= translation('wiki.edit.more') %></h5>
+     <ul class="pl-3">
       <% if @node.path %><li><a href="/wiki/revisions/<%= @node.slug_from_path %>"><%= translation('wiki.edit.revisions_for_this_page') %></a></li><% end %>
-      <li class="nav-item"><a href="/wiki/posting-research"><%= translation('wiki.edit.about_posting_research') %></a></li>
-      <li class="nav-item"><a href="/wiki/authoring-help#Advanced+formatting"><%= translation('wiki.edit.advanced_formatting') %></a></li>
+      <li class=""><a href="/wiki/posting-research"><%= translation('wiki.edit.about_posting_research') %></a></li>
+      <li class=""><a href="/wiki/authoring-help#Advanced+formatting"><%= translation('wiki.edit.advanced_formatting') %></a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
I changed the color of the link from grey to blue.

<!-- Add a short description about your changes here-->

Fixes #0000 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
