### PR TITLE
interpolate redirect path- search-controller 

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,7 +9,7 @@ class SearchController < ApplicationController
 
   # a route to convert /search/_____ to /search?q=______ style search queries
   def google_redirect
-    redirect_to '/search?q=' + params[:query]
+    redirect_to "/search?q=#{params[:query]}"
   end
 
   def notes


### PR DESCRIPTION
Removed (redirect_to '/search?q=' + params[:query])  and replaced it with (redirect_to "/search?q=#{params[:query]}") on line 12

Note: Brackets ( ) not included

<!-- Edited line 12 on search_controller.rb-->

Fixes #0000 <!--(<===#11500-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
