### PR TITLE
Update and rename comment_test.rb to comment_system_test.rb to solve class name mismatch error

### DIFF
--- a/test/comment_system_tests/comment_system_test.rb
+++ b/test/comment_system_tests/comment_system_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require "application_system_test_case"
 # https://guides.rubyonrails.org/testing.html#implementing-a-system-test
 
-class CommentTest < ApplicationSystemTestCase
+class CommentSystemTest < ApplicationSystemTestCase
   Capybara.default_max_wait_time = 60
 
   def setup


### PR DESCRIPTION
<!-- Add a short description about your changes here-->
Renamed the file comment_test.rb as comment_system_test.rb and change the classname by writing the code class CommentSystemTest < ApplicationSystemTestCase.

Fixes #11620 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
