### PR TITLE
Update prop types for comment for improved structure

### DIFF
--- a/app/javascript/components/Comment.js
+++ b/app/javascript/components/Comment.js
@@ -92,7 +92,16 @@ Comment.propTypes = {
     PropTypes.array,
     PropTypes.element
   ]),
-  comment: PropTypes.object.isRequired,
+  comment: PropTypes.shape({
+  authorId: PropTypes.number.isRequired,
+  authorPicUrl: PropTypes.string,
+  authorPicFilename: PropTypes.string,
+  authorUsername: PropTypes.string.isRequired,
+  commentId: PropTypes.number.isRequired,
+  commentName: PropTypes.string,
+  htmlCommentText: PropTypes.string.isRequired,
+  timeCreatedString: PropTypes.string.isRequired
+}).isRequired,
   deleteButton: PropTypes.element.isRequired,
   editCommentForm: PropTypes.element.isRequired,
   isEditFormVisible: PropTypes.bool.isRequired,


### PR DESCRIPTION
Enhanced the comment prop validation with PropTypes.shape instead of PropTypes.object for improved, clearer structure. Provides a more explicit structure for the expected shape of the object, improving code readability and maintainability.

<!-- Add a short description about your changes here-->

Fixes #0000 <!--(<=== Add issue number here)-->

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

<!--We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!-->

<!--If tests do fail, click on the red `X` to learn why by reading the logs.-->

<!--Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software -->

<!--Thanks!-->
