### PR TITLE
Add "Random Post" Button on Homepage

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -501,4 +501,9 @@ class NotesController < ApplicationController
         .where('node.status = 1')
         .where.not(nid: hidden_nids)
   end
+  def random
+    post = Post.order("RANDOM()").first
+    redirect_to post_path(post)
+  end
+  
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -121,12 +121,17 @@
     <%= render :partial => 'layouts/header' %>
     <div id="top_map"> </div>
     <div class="container">
-      <div class="row">
-
-        <%= yield %>
-
-      </div><!--/row-->
-    </div><!--/container-->
+    <div class="row">
+  
+      <div class="col-md-12 mb-2">
+        <%= link_to '🎲 Random Post', random_path, class: 'btn btn-secondary' %>
+      </div>
+  
+      <%= yield %>
+  
+    </div><!--/row-->
+  </div><!--/container-->
+  
 
     <%= render :partial => "layouts/footer" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Plots2::Application.routes.draw do
 
   # Manually written API functions
   post 'comment/create/token/:id.:format', to: 'comment#create_by_token'
+  get '/random', to: 'posts#random'
+
 
   post '/node/update/title' => 'notes#update_title'
 


### PR DESCRIPTION
**Description:**
This PR adds a "🎲 Random Post" button to the homepage of the Public Lab website. The button is designed to enhance user engagement by letting visitors discover a random post with a single click. It's a fun and interactive way to explore content on the site.

**Changes made:**

Added a button labeled "🎲 Random Post".

The button links to the route /random, which loads a randomly selected post.
**Related Issue:**
Fixes #11187
**Screenshot**
![screenshotOfRandomPostButton](https://github.com/user-attachments/assets/d8436422-8151-49e5-a9db-96ced57c706f)
