### PR TITLE
Fix map floating over footer while scrolling

### DIFF
--- a/app/assets/stylesheets/map.css
+++ b/app/assets/stylesheets/map.css
@@ -51,3 +51,13 @@
 .leaflet-container .add-content-button {
   margin-right: 10px;
 }
+
+.leaflet-pane {
+  position: initial !important;
+}
+
+.leaflet-bar,
+.leaflet-top {
+  position: initial !important;
+}
+


### PR DESCRIPTION
Fixes #10306

This PR updates Leaflet map styles to prevent the map
from overlapping the footer while scrolling.
