### PR TITLE
Fix N+1 query in Node#tagnames_as_classes

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -526,15 +526,14 @@ class Node < ActiveRecord::Base
     tags.collect(&:name)
   end
 
-  # Here we re-query to fetch /all/ tagnames; this is used in
-  # /views/notes/_notes.html.erb in a way that would otherwise only
-  # return a single tag due to a join, yet select() keeps this efficient
+  # Fetch all tagnames for this node directly, bypassing the `tag`
+  # association which may be filtered by a join in the calling context.
   def tagnames_as_classes
-    Node.select([:nid])
-        .find(id)
-        .tagnames
-        .map { |t| 'tag-' + t.tr(':', '-') }
-        .join(' ')
+    Tag.joins(:node_tag)
+       .where('community_tags.nid = ?', nid)
+       .pluck(:name)
+       .map { |t| 'tag-' + t.tr(':', '-') }
+       .join(' ')
   end
 
   def edit_path


### PR DESCRIPTION
## Summary
- Eliminates N+1 query in `Node#tagnames_as_classes` by replacing `Node.select([:nid]).find(id).tagnames` with a direct `Tag.joins(:node_tag).pluck(:name)` call
- Reduces **two queries per node** (Node.find + tag association load) to a **single efficient pluck query**
- No change in behavior — returns the same tag class strings used in note listing views

## Details
The previous implementation re-fetched the node via `Node.find(id)` to bypass a potentially filtered `tag` association (caused by joins in the calling context). This created an N+1 problem when rendering lists of notes.

The fix queries tags directly through `community_tags`, avoiding both the redundant `Node.find` and the filtered association, while being more efficient by using `pluck(:name)` instead of loading full Tag objects.

## Test plan
- [ ] Existing test `test/unit/node_test.rb` line 291 validates output: `'tag-test tag-awesome tag-spectrometer tag-activity-spectrometer tag-sub-tag'`
- [ ] Verify note listing pages (`/notes`, `/dashboard`) render tag CSS classes correctly

Closes #11853