### PR TITLE
Fix map overlapping footer issue (#10306)

### DIFF
--- a/app/assets/stylesheets/map.css
+++ b/app/assets/stylesheets/map.css
@@ -51,3 +51,9 @@
 .leaflet-container .add-content-button {
   margin-right: 10px;
 }
+.leaflet-pane{
+  position: initial !important;
+}
+.leaflet-bar, .leaflet-top{
+  position: initial !important;
+}


### PR DESCRIPTION
Fixes #10306

This PR fixes the UI bug where the map overlaps the footer while scrolling by adjusting CSS positioning in map.css.

### Changes made:
- Added CSS to reset position of leaflet elements
- Prevented map from overlapping footer

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

@publiclab/reviewers please review